### PR TITLE
Merge follow-up from dd-trace-java 0.40.0

### DIFF
--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentSpan.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentSpan.java
@@ -13,6 +13,8 @@ public interface AgentSpan {
 
   AgentSpan setError(boolean error);
 
+  AgentSpan setErrorMessage(String errorMessage);
+
   AgentSpan addThrowable(Throwable throwable);
 
   AgentSpan getLocalRootSpan();

--- a/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentTracer.java
+++ b/dd-java-agent/agent-bootstrap/src/main/java/datadog/trace/instrumentation/api/AgentTracer.java
@@ -168,6 +168,11 @@ public class AgentTracer {
     }
 
     @Override
+    public AgentSpan setErrorMessage(final String errorMessage) {
+      return this;
+    }
+
+    @Override
     public AgentSpan addThrowable(final Throwable throwable) {
       return this;
     }

--- a/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTracerImpl.java
+++ b/dd-java-agent/agent-tooling/src/main/java/datadog/trace/agent/tooling/AgentTracerImpl.java
@@ -171,6 +171,14 @@ public final class AgentTracerImpl implements TracerAPI {
     }
 
     @Override
+    public AgentSpan setErrorMessage(final String errorMessage) {
+      if (span instanceof DDSpan) {
+        ((DDSpan) span).setErrorMessage(errorMessage);
+      }
+      return this;
+    }
+
+    @Override
     public AgentSpan addThrowable(final Throwable throwable) {
       if (span instanceof DDSpan) {
         ((DDSpan) span).setErrorMeta(throwable);

--- a/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
+++ b/dd-java-agent/instrumentation/google-http-client/src/main/java/datadog/trace/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
@@ -121,6 +121,7 @@ public class GoogleHttpClientInstrumentation extends Instrumenter.Default {
           // for a failed request.  Thus, check the response code
           if (response != null && !response.isSuccessStatusCode()) {
             span.setError(true);
+            span.setErrorMessage(response.getStatusMessage());
           }
 
           DECORATE.beforeFinish(span);

--- a/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/dd-java-agent/instrumentation/google-http-client/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -68,6 +68,7 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest<GoogleHttpCli
             "$Tags.HTTP_URL" "${uri.resolve(uri.path)}"
             "$Tags.HTTP_METHOD" method
             "$Tags.HTTP_STATUS" 500
+            "$DDTags.ERROR_MSG" "Server Error"
           }
         }
       }

--- a/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
+++ b/dd-trace-ot/src/main/java/datadog/opentracing/DDSpan.java
@@ -120,6 +120,10 @@ public class DDSpan implements Span {
     return context().getTrace().getRootSpan();
   }
 
+  public void setErrorMessage(final String errorMessage) {
+    setTag(DDTags.ERROR_MSG, errorMessage);
+  }
+
   public void setErrorMeta(final Throwable error) {
     setError(true);
 


### PR DESCRIPTION
DataDog/dd-trace-java#1148 didn't come over in last dd-trace-java merge (#46) because I had previously deleted the code that wasn't doing anything instead of fixing it (which is what DataDog/dd-trace-java#1148 does)