### PR TITLE
Improve sporadic test failures

### DIFF
--- a/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -24,20 +24,14 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest<AkkaHttpClientDec
       .withMethod(HttpMethods.lookup(method).get())
       .addHeaders(headers.collect { RawHeader.create(it.key, it.value) })
 
-    def response
-    try {
-      response = Http.get(system)
-        .singleRequest(request, materializer)
-      //.whenComplete { result, error ->
-      // FIXME: Callback should be here instead.
-      //  callback?.call()
-      //}
-        .toCompletableFuture()
-        .get()
-    } finally {
-      // FIXME: remove this when callback above works.
-      blockUntilChildSpansFinished(1)
-    }
+    def response = Http.get(system)
+      .singleRequest(request, materializer)
+    //.whenComplete { result, error ->
+    // FIXME: Callback should be here instead.
+    //  callback?.call()
+    //}
+      .toCompletableFuture()
+      .get()
     callback?.call()
     return response.status().intValue()
   }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -47,12 +47,7 @@ class ApacheHttpAsyncClientCallbackTest extends HttpClientTest<ApacheHttpAsyncCl
       }
     })
 
-    try {
-      return responseFuture.get()
-    } finally {
-      // child span is reported asynchronously, this is needed for consistent span ordering during test verification
-      blockUntilChildSpansFinished(1)
-    }
+    return responseFuture.get()
   }
 
   @Override

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -28,12 +28,7 @@ class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest<ApacheHttpAsy
     // So to make sure request is done we start request, wait for future to finish
     // and then call callback if present.
     Future future = client.execute(request, null)
-    try {
-      future.get()
-    } finally {
-      // child span is reported asynchronously, this is needed for consistent span ordering during test verification
-      blockUntilChildSpansFinished(1)
-    }
+    future.get()
     if (callback != null) {
       callback()
     }

--- a/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/apache-httpasyncclient-4/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -47,20 +47,12 @@ class ApacheHttpAsyncClientTest extends HttpClientTest<ApacheHttpAsyncClientDeco
     }
 
     def future = client.execute(request, handler)
-    def response
-    try {
-      response = future.get()
-    } finally {
-      // child span is reported asynchronously, this is needed for consistent span ordering during test verification
-      blockUntilChildSpansFinished(1)
-    }
+    def response = future.get()
     response.entity?.content?.close() // Make sure the connection is closed.
     if (callback != null) {
       // need to wait for callback to complete in case test is expecting span from it
       latch.await()
     }
-    // child span is reported asynchronously, this is needed for consistent span ordering during test verification
-    blockUntilChildSpansFinished(1)
     response.statusLine.statusCode
   }
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -59,8 +59,6 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
       cluster.openBucket(bucketSettings.name(), bucketSettings.password()).subscribe({ bkt ->
         bkt.upsert(JsonDocument.create("helloworld", content)).subscribe({ result -> inserted.set(result) })
       })
-
-      blockUntilChildSpansFinished(2) // Improve span ordering consistency
     }
 
     then:
@@ -104,8 +102,6 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
               })
           })
       })
-
-      blockUntilChildSpansFinished(3) // Improve span ordering consistency
     }
 
     // Create a JSON document and store it with the ID "helloworld"
@@ -153,8 +149,6 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
             .single()
             .subscribe({ row -> queryResult.set(row.value()) })
       })
-
-      blockUntilChildSpansFinished(2) // Improve span ordering consistency
     }
 
     then:

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -28,7 +28,7 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
 
     then:
     assert hasBucket.get()
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 2) {
         assertCouchbaseCall(it, 0, "Cluster.openBucket", null)
         assertCouchbaseCall(it, 1, "ClusterManager.hasBucket", null, span(0))
@@ -66,12 +66,12 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     then:
     inserted.get().content().getString("hello") == "world"
 
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
 
-        assertCouchbaseCall(it, 2, "Cluster.openBucket", null, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketSettings.name(), span(2))
+        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(1))
       }
     }
 
@@ -113,13 +113,13 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     found.get() == inserted.get()
     found.get().content().getString("hello") == "world"
 
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 4) {
         basicSpan(it, 0, "someTrace")
 
-        assertCouchbaseCall(it, 3, "Cluster.openBucket", null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(3))
-        assertCouchbaseCall(it, 1, "Bucket.get", bucketSettings.name(), span(2))
+        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(1))
+        assertCouchbaseCall(it, 3, "Bucket.get", bucketSettings.name(), span(2))
       }
     }
 
@@ -160,12 +160,12 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     then:
     queryResult.get().get("row") == "value"
 
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
 
-        assertCouchbaseCall(it, 2, "Cluster.openBucket", null, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.query", bucketCouchbase.name(), span(2))
+        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.query", bucketCouchbase.name(), span(1))
       }
     }
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -52,8 +52,6 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     runUnderTrace("someTrace") {
       inserted = bkt.upsert(JsonDocument.create("helloworld", content))
       found = bkt.get("helloworld")
-
-      blockUntilChildSpansFinished(2)
     }
 
     then:

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -19,7 +19,7 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
 
     then:
     assert hasBucket
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 1) {
         assertCouchbaseCall(it, 0, "ClusterManager.hasBucket")
       }
@@ -60,14 +60,14 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     found == inserted
     found.content().getString("hello") == "world"
 
-    sortAndAssertTraces(2) {
+    assertTraces(2) {
       trace(0, 1) {
         assertCouchbaseCall(it, 0, "Cluster.openBucket")
       }
       trace(1, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(0))
-        assertCouchbaseCall(it, 1, "Bucket.get", bucketSettings.name(), span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketSettings.name(), span(0))
+        assertCouchbaseCall(it, 2, "Bucket.get", bucketSettings.name(), span(0))
       }
     }
 
@@ -101,7 +101,7 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
     result.first().value().get("row") == "value"
 
     and:
-    sortAndAssertTraces(2) {
+    assertTraces(2) {
       trace(0, 1) {
         assertCouchbaseCall(it, 0, "Cluster.openBucket")
       }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -112,8 +112,6 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     runUnderTrace("someTrace") {
       repo.save(doc)
       result = FIND(repo, "1")
-
-      blockUntilChildSpansFinished(2)
     }
 
     then: // RETRIEVE
@@ -141,8 +139,6 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
       repo.save(doc)
       doc.data = "other data"
       repo.save(doc)
-
-      blockUntilChildSpansFinished(2)
     }
 
 
@@ -171,8 +167,6 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
       repo.save(doc)
       repo.delete("1")
       result = repo.findAll().iterator().hasNext()
-
-      blockUntilChildSpansFinished(3)
     }
 
     then:

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -118,11 +118,11 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
 
     then: // RETRIEVE
     result == doc
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketCouchbase.name(), span(0))
-        assertCouchbaseCall(it, 1, "Bucket.get", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 2, "Bucket.get", bucketCouchbase.name(), span(0))
       }
     }
 
@@ -147,7 +147,7 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
 
 
     then:
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
         assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), span(0))
@@ -177,12 +177,12 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
 
     then:
     assert !result
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 4) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 3, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), span(0))
         assertCouchbaseCall(it, 2, "Bucket.remove", bucketCouchbase.name(), span(0))
-        assertCouchbaseCall(it, 1, "Bucket.query", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 3, "Bucket.query", bucketCouchbase.name(), span(0))
       }
     }
   }

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -73,11 +73,11 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     then:
     result != null
 
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", name, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.get", name, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", name, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.get", name, span(0))
       }
     }
 
@@ -100,11 +100,11 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
 
 
     then:
-    sortAndAssertTraces(1) {
+    assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 2, "Bucket.upsert", name, span(0))
-        assertCouchbaseCall(it, 1, "Bucket.remove", name, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", name, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.remove", name, span(0))
       }
     }
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -45,7 +45,6 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     runUnderTrace("getting info") {
       templates = [new CouchbaseTemplate(couchbaseManager.info(), bucketCouchbase),
                    new CouchbaseTemplate(memcacheManager.info(), bucketMemcache)]
-      blockUntilChildSpansFinished(2)
     }
   }
 
@@ -65,8 +64,6 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     runUnderTrace("someTrace") {
       template.save(doc)
       result = template.findById("1", Doc)
-
-      blockUntilChildSpansFinished(2)
     }
 
 
@@ -94,8 +91,6 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     runUnderTrace("someTrace") {
       template.save(doc)
       template.remove(doc)
-
-      blockUntilChildSpansFinished(2)
     }
 
 

--- a/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/dd-java-agent/instrumentation/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -11,15 +11,12 @@ import com.couchbase.mock.BucketConfiguration
 import com.couchbase.mock.CouchbaseMock
 import com.couchbase.mock.http.query.QueryServer
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.Config
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
 import io.opentelemetry.sdk.trace.SpanData
 import spock.lang.Shared
 
@@ -106,33 +103,6 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       .searchTimeout(timeout)
       .analyticsTimeout(timeout)
       .socketConnectTimeout(timeout.intValue())
-  }
-
-  void sortAndAssertTraces(
-    final int size,
-    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
-    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
-    final Closure spec) {
-
-    TEST_WRITER.waitForTraces(size)
-
-    TEST_WRITER.each {
-      it.sort({
-        a, b ->
-          boolean aIsCouchbaseOperation = a.name == "couchbase.call"
-          boolean bIsCouchbaseOperation = b.name == "couchbase.call"
-
-          if (aIsCouchbaseOperation && !bIsCouchbaseOperation) {
-            return 1
-          } else if (!aIsCouchbaseOperation && bIsCouchbaseOperation) {
-            return -1
-          }
-
-          return a.attributes[DDTags.RESOURCE_NAME].stringValue.compareTo(b.attributes[DDTags.RESOURCE_NAME].stringValue)
-      })
-    }
-
-    assertTraces(size, spec)
   }
 
   void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object parentSpan = null) {

--- a/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
+++ b/dd-java-agent/instrumentation/datastax-cassandra-3/src/test/groovy/CassandraClientTest.groovy
@@ -82,7 +82,6 @@ class CassandraClientTest extends AgentTestRunner {
       withConfigOverride(Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
         session.executeAsync(statement)
       }
-      blockUntilChildSpansFinished(1)
     }
 
     expect:

--- a/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/dropwizard/src/test/groovy/DropwizardAsyncTest.groovy
@@ -38,17 +38,6 @@ class DropwizardAsyncTest extends DropwizardTest {
     }
   }
 
-  @Override
-  // Return the handler span's name
-  String reorderHandlerSpan() {
-    "jax-rs.request"
-  }
-
-  @Override
-  boolean reorderControllerSpan() {
-    true
-  }
-
   @Path("/")
   static class AsyncServiceResource {
     final executor = Executors.newSingleThreadExecutor()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -163,14 +163,15 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -127,13 +127,13 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
@@ -166,10 +166,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -177,14 +177,15 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -141,13 +141,13 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
@@ -180,10 +180,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -72,10 +72,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(3) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[0][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[0]
-          TEST_WRITER[0] = TEST_WRITER[1]
-          TEST_WRITER[1] = tmp
+        if (traces[0][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[0]
+          traces[0] = traces[1]
+          traces[1] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -133,10 +133,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(7) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -132,14 +132,15 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     template.queryForList(query, Doc) == [new Doc()]
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(7) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -104,9 +104,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   def "test elasticsearch get"() {
     expect:
     template.createIndex(indexName)
-    TEST_WRITER.waitForTraces(1)
     template.getClient().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
-    TEST_WRITER.waitForTraces(2)
 
     when:
     NativeSearchQuery query = new NativeSearchQueryBuilder()
@@ -272,9 +270,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   def "test results extractor"() {
     setup:
     template.createIndex(indexName)
-    TEST_WRITER.waitForTraces(1)
     testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
-    TEST_WRITER.waitForTraces(2)
 
     template.index(IndexQueryBuilder.newInstance()
       .withObject(new Doc(id: 1, data: "doc a"))

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -163,14 +163,15 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -127,13 +127,13 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
@@ -166,10 +166,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -177,14 +177,15 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -141,13 +141,13 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
@@ -180,10 +180,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -72,10 +72,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(3) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[0][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[0]
-          TEST_WRITER[0] = TEST_WRITER[1]
-          TEST_WRITER[1] = tmp
+        if (traces[0][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[0]
+          traces[0] = traces[1]
+          traces[1] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -69,8 +69,32 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     repo.index(doc) == doc
 
     and:
-    assertTraces(2) {
+    assertTraces(3) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[0][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[0]
+          TEST_WRITER[0] = TEST_WRITER[1]
+          TEST_WRITER[1] = tmp
+        }
+      }
       trace(0, 1) {
+        span(0) {
+          operationName "elasticsearch.query"
+          tags {
+            "$DDTags.SERVICE_NAME" "elasticsearch"
+            "$DDTags.RESOURCE_NAME" "PutMappingAction"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
+            "elasticsearch.request.indices" indexName
+          }
+        }
+      }
+      trace(1, 1) {
         span(0) {
           operationName "elasticsearch.query"
           tags {
@@ -90,7 +114,7 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
       }
-      trace(1, 1) {
+      trace(2, 1) {
         span(0) {
           operationName "elasticsearch.query"
           tags {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -133,10 +133,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(7) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -132,14 +132,15 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     template.queryForList(query, Doc) == [new Doc()]
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(7) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-2/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -104,9 +104,7 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
   def "test elasticsearch get"() {
     expect:
     template.createIndex(indexName)
-    TEST_WRITER.waitForTraces(1)
     template.getClient().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
-    TEST_WRITER.waitForTraces(2)
 
     when:
     NativeSearchQuery query = new NativeSearchQueryBuilder()

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -170,14 +170,15 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -133,13 +133,13 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
@@ -173,10 +173,10 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -184,14 +184,15 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[2]
+          TEST_WRITER[2] = TEST_WRITER[3]
+          TEST_WRITER[3] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -148,13 +148,13 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()
@@ -187,10 +187,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     assertTraces(5) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[2]
-          TEST_WRITER[2] = TEST_WRITER[3]
-          TEST_WRITER[3] = tmp
+        if (traces[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[2]
+          traces[2] = traces[3]
+          traces[3] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -65,9 +65,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     !result.iterator().hasNext()
 
     and:
-    waitForTracesAndSortSpans(1)
     assertTraces(1) {
       trace(0, 2) {
+        sortSpans {
+          sort(trace)
+        }
         span(0) {
           operationName "repository.operation"
           tags {
@@ -110,9 +112,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     repo.index(doc) == doc
 
     and:
-    waitForTracesAndSortSpans(2)
     assertTraces(2) {
       trace(0, 3) {
+        sortSpans {
+          sort(trace)
+        }
         span(0) {
           operationName "repository.operation"
           tags {
@@ -183,9 +187,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     repo.findById("1").get() == doc
 
     and:
-    waitForTracesAndSortSpans(1)
     assertTraces(1) {
       trace(0, 2) {
+        sortSpans {
+          sort(trace)
+        }
         span(0) {
           operationName "repository.operation"
           tags {
@@ -225,9 +231,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     repo.findById("1").get() == doc
 
     and:
-    waitForTracesAndSortSpans(2)
     assertTraces(2) {
       trace(0, 3) {
+        sortSpans {
+          sort(trace)
+        }
         span(0) {
           operationName "repository.operation"
           tags {
@@ -277,6 +285,9 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
         }
       }
       trace(1, 2) {
+        sortSpans {
+          sort(trace)
+        }
         span(0) {
           operationName "repository.operation"
           tags {
@@ -315,9 +326,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     !repo.findAll().iterator().hasNext()
 
     and:
-    waitForTracesAndSortSpans(2)
     assertTraces(2) {
       trace(0, 3) {
+        sortSpans {
+          sort(trace)
+        }
         span(0) {
           operationName "repository.operation"
           tags {
@@ -368,6 +381,9 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       }
 
       trace(1, 2) {
+        sortSpans {
+          sort(trace)
+        }
         span(0) {
           operationName "repository.operation"
           tags {
@@ -400,16 +416,12 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     indexName = "test-index"
   }
 
-  def waitForTracesAndSortSpans(int number) {
-    TEST_WRITER.waitForTraces(number)
-    for (List<SpanData> trace : TEST_WRITER) {
-      // need to normalize span ordering since they are finished by different threads
-      if (trace.size() > 1 && trace[1].name == "repository.operation") {
-        def tmp = trace[1]
-        trace[1] = trace[0]
-        trace[0] = tmp
-      }
+  def sort(List<SpanData> spans) {
+    // need to normalize span ordering since they are finished by different threads
+    if (spans[1].name == "repository.operation") {
+      def tmp = spans[1]
+      spans[1] = spans[0]
+      spans[0] = tmp
     }
-    return true
   }
 }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -68,7 +68,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         sortSpans {
-          sort(trace)
+          sort(spans)
         }
         span(0) {
           operationName "repository.operation"
@@ -115,7 +115,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 3) {
         sortSpans {
-          sort(trace)
+          sort(spans)
         }
         span(0) {
           operationName "repository.operation"
@@ -190,7 +190,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         sortSpans {
-          sort(trace)
+          sort(spans)
         }
         span(0) {
           operationName "repository.operation"
@@ -234,7 +234,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 3) {
         sortSpans {
-          sort(trace)
+          sort(spans)
         }
         span(0) {
           operationName "repository.operation"
@@ -286,7 +286,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
       }
       trace(1, 2) {
         sortSpans {
-          sort(trace)
+          sort(spans)
         }
         span(0) {
           operationName "repository.operation"
@@ -329,7 +329,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 3) {
         sortSpans {
-          sort(trace)
+          sort(spans)
         }
         span(0) {
           operationName "repository.operation"
@@ -382,7 +382,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
 
       trace(1, 2) {
         sortSpans {
-          sort(trace)
+          sort(spans)
         }
         span(0) {
           operationName "repository.operation"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -111,29 +111,8 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
 
     and:
     waitForTracesAndSortSpans(2)
-    // need to normalize trace ordering since they are finished by different threads
-    if (TEST_WRITER[1][0].attributes[DDTags.RESOURCE_NAME].stringValue == "PutMappingAction") {
-      def tmp = TEST_WRITER[1]
-      TEST_WRITER[1] = TEST_WRITER[0]
-      TEST_WRITER[0] = tmp
-    }
     assertTraces(2) {
-      trace(0, 1) {
-        span(0) {
-          operationName "elasticsearch.query"
-          tags {
-            "$DDTags.SERVICE_NAME" "elasticsearch"
-            "$DDTags.RESOURCE_NAME" "PutMappingAction"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.DB_TYPE" "elasticsearch"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "elasticsearch.action" "PutMappingAction"
-            "elasticsearch.request" "PutMappingRequest"
-          }
-        }
-      }
-      trace(1, 3) {
+      trace(0, 3) {
         span(0) {
           operationName "repository.operation"
           tags {
@@ -179,6 +158,21 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.broadcast.failed" 0
             "elasticsearch.shard.broadcast.successful" 5
             "elasticsearch.shard.broadcast.total" 10
+          }
+        }
+      }
+      trace(1, 1) {
+        span(0) {
+          operationName "elasticsearch.query"
+          tags {
+            "$DDTags.SERVICE_NAME" "elasticsearch"
+            "$DDTags.RESOURCE_NAME" "PutMappingAction"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.DB_TYPE" "elasticsearch"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "elasticsearch.action" "PutMappingAction"
+            "elasticsearch.request" "PutMappingRequest"
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -142,27 +142,7 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-
         span(1) {
-          operationName "elasticsearch.query"
-          childOf(span(0))
-          tags {
-            "$DDTags.SERVICE_NAME" "elasticsearch"
-            "$DDTags.RESOURCE_NAME" "RefreshAction"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "RefreshAction"
-            "elasticsearch.request" "RefreshRequest"
-            "elasticsearch.request.indices" indexName
-            "elasticsearch.shard.broadcast.failed" 0
-            "elasticsearch.shard.broadcast.successful" 5
-            "elasticsearch.shard.broadcast.total" 10
-          }
-        }
-
-        span(2) {
           operationName "elasticsearch.query"
           childOf(span(0))
           tags {
@@ -181,6 +161,24 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
+          }
+        }
+        span(2) {
+          operationName "elasticsearch.query"
+          childOf(span(0))
+          tags {
+            "$DDTags.SERVICE_NAME" "elasticsearch"
+            "$DDTags.RESOURCE_NAME" "RefreshAction"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "RefreshAction"
+            "elasticsearch.request" "RefreshRequest"
+            "elasticsearch.request.indices" indexName
+            "elasticsearch.shard.broadcast.failed" 0
+            "elasticsearch.shard.broadcast.successful" 5
+            "elasticsearch.shard.broadcast.total" 10
           }
         }
       }
@@ -249,24 +247,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$DDTags.SERVICE_NAME" "elasticsearch"
-            "$DDTags.RESOURCE_NAME" "RefreshAction"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "RefreshAction"
-            "elasticsearch.request" "RefreshRequest"
-            "elasticsearch.request.indices" indexName
-            "elasticsearch.shard.broadcast.failed" 0
-            "elasticsearch.shard.broadcast.successful" 5
-            "elasticsearch.shard.broadcast.total" 10
-          }
-        }
-        span(2) {
-          operationName "elasticsearch.query"
-          childOf(span(0))
-          tags {
-            "$DDTags.SERVICE_NAME" "elasticsearch"
             "$DDTags.RESOURCE_NAME" "IndexAction"
             "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -281,6 +261,24 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
+          }
+        }
+        span(2) {
+          operationName "elasticsearch.query"
+          childOf(span(0))
+          tags {
+            "$DDTags.SERVICE_NAME" "elasticsearch"
+            "$DDTags.RESOURCE_NAME" "RefreshAction"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "RefreshAction"
+            "elasticsearch.request" "RefreshRequest"
+            "elasticsearch.request.indices" indexName
+            "elasticsearch.shard.broadcast.failed" 0
+            "elasticsearch.shard.broadcast.successful" 5
+            "elasticsearch.shard.broadcast.total" 10
           }
         }
       }
@@ -340,24 +338,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           childOf(span(0))
           tags {
             "$DDTags.SERVICE_NAME" "elasticsearch"
-            "$DDTags.RESOURCE_NAME" "RefreshAction"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
-            "$Tags.COMPONENT" "elasticsearch-java"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "elasticsearch"
-            "elasticsearch.action" "RefreshAction"
-            "elasticsearch.request" "RefreshRequest"
-            "elasticsearch.request.indices" indexName
-            "elasticsearch.shard.broadcast.failed" 0
-            "elasticsearch.shard.broadcast.successful" 5
-            "elasticsearch.shard.broadcast.total" 10
-          }
-        }
-        span(2) {
-          operationName "elasticsearch.query"
-          childOf(span(0))
-          tags {
-            "$DDTags.SERVICE_NAME" "elasticsearch"
             "$DDTags.RESOURCE_NAME" "DeleteAction"
             "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
@@ -371,6 +351,24 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
             "elasticsearch.shard.replication.failed" 0
             "elasticsearch.shard.replication.successful" 1
             "elasticsearch.shard.replication.total" 2
+          }
+        }
+        span(2) {
+          operationName "elasticsearch.query"
+          childOf(span(0))
+          tags {
+            "$DDTags.SERVICE_NAME" "elasticsearch"
+            "$DDTags.RESOURCE_NAME" "RefreshAction"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.ELASTICSEARCH
+            "$Tags.COMPONENT" "elasticsearch-java"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "elasticsearch"
+            "elasticsearch.action" "RefreshAction"
+            "elasticsearch.request" "RefreshRequest"
+            "elasticsearch.request.indices" indexName
+            "elasticsearch.shard.broadcast.failed" 0
+            "elasticsearch.shard.broadcast.successful" 5
+            "elasticsearch.shard.broadcast.total" 10
           }
         }
       }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -124,9 +124,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
   def "test elasticsearch get"() {
     expect:
     template.createIndex(indexName)
-    TEST_WRITER.waitForTraces(1)
     template.getClient().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
-    TEST_WRITER.waitForTraces(2)
 
     when:
     NativeSearchQuery query = new NativeSearchQueryBuilder()
@@ -300,9 +298,7 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
   def "test results extractor"() {
     setup:
     template.createIndex(indexName)
-    TEST_WRITER.waitForTraces(1)
     testNode.client().admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
-    TEST_WRITER.waitForTraces(2)
 
     template.index(IndexQueryBuilder.newInstance()
       .withObject(new Doc(id: 1, data: "doc a"))

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -155,15 +155,16 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
     // FIXME: it looks like proper approach is to provide TEST_WRITER with an API to filter traces as they are written
     TEST_WRITER.waitForTraces(7)
     filterIgnoredActions()
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
 
     assertTraces(7) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -157,10 +157,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
     assertTraces(7) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {
@@ -374,9 +374,11 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
   }
 
   void filterIgnoredActions() {
-    for (int i = 0; i < TEST_WRITER.size(); i++) {
-      if (IGNORED_ACTIONS.contains(TEST_WRITER[i][0].attributes[DDTags.RESOURCE_NAME].stringValue)) {
-        TEST_WRITER.remove(i)
+    TEST_WRITER.doUnderStructuralChangeLock {
+      for (int i = 0; i < TEST_WRITER.traces.size(); i++) {
+        if (IGNORED_ACTIONS.contains(TEST_WRITER.traces[i][0].attributes[DDTags.RESOURCE_NAME].stringValue)) {
+          TEST_WRITER.traces.remove(i)
+        }
       }
     }
   }

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -170,14 +170,15 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[3]
-      TEST_WRITER[3] = TEST_WRITER[4]
-      TEST_WRITER[4] = tmp
-    }
     assertTraces(6) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[3]
+          TEST_WRITER[3] = TEST_WRITER[4]
+          TEST_WRITER[4] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -133,13 +133,13 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     client.admin().cluster().prepareHealth().setWaitForYellowStatus().execute().actionGet(TIMEOUT)
@@ -173,10 +173,10 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[3]
-          TEST_WRITER[3] = TEST_WRITER[4]
-          TEST_WRITER[4] = tmp
+        if (traces[3][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[3]
+          traces[3] = traces[4]
+          traces[4] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -148,13 +148,13 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.acknowledged
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()
@@ -187,10 +187,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     assertTraces(5) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[2]
-          TEST_WRITER[2] = TEST_WRITER[3]
-          TEST_WRITER[3] = tmp
+        if (traces[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[2]
+          traces[2] = traces[3]
+          traces[3] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-5/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -184,14 +184,15 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[2]
+          TEST_WRITER[2] = TEST_WRITER[3]
+          TEST_WRITER[3] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -166,14 +166,15 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[2]
+          TEST_WRITER[2] = TEST_WRITER[3]
+          TEST_WRITER[3] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -130,13 +130,13 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.index() == indexName
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()
@@ -169,10 +169,10 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     assertTraces(5) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[2]
-          TEST_WRITER[2] = TEST_WRITER[3]
-          TEST_WRITER[3] = tmp
+        if (traces[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[2]
+          traces[2] = traces[3]
+          traces[3] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -145,13 +145,13 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
 
   def "test elasticsearch get"() {
     setup:
-    assert TEST_WRITER == []
+    assert TEST_WRITER.traces == []
     def indexResult = client.admin().indices().prepareCreate(indexName).get()
     TEST_WRITER.waitForTraces(1)
 
     expect:
     indexResult.index() == indexName
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     when:
     def emptyResult = client.prepareGet(indexName, indexType, id).get()
@@ -184,10 +184,10 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     assertTraces(5) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-          def tmp = TEST_WRITER[2]
-          TEST_WRITER[2] = TEST_WRITER[3]
-          TEST_WRITER[3] = tmp
+        if (traces[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = traces[2]
+          traces[2] = traces[3]
+          traces[3] = tmp
         }
       }
       trace(0, 1) {

--- a/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/dd-java-agent/instrumentation/elasticsearch/transport-6/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -181,14 +181,15 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     result.index == indexName
 
     and:
-    // IndexAction and PutMappingAction run in separate threads and order in which
-    // these spans are closed is not defined. So we force the order if it is wrong.
-    if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
-      def tmp = TEST_WRITER[2]
-      TEST_WRITER[2] = TEST_WRITER[3]
-      TEST_WRITER[3] = tmp
-    }
     assertTraces(5) {
+      sortTraces {
+        // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
+        if (TEST_WRITER[2][0].attributes[DDTags.RESOURCE_NAME].stringValue == "IndexAction") {
+          def tmp = TEST_WRITER[2]
+          TEST_WRITER[2] = TEST_WRITER[3]
+          TEST_WRITER[3] = tmp
+        }
+      }
       trace(0, 1) {
         span(0) {
           operationName "elasticsearch.query"

--- a/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
+++ b/dd-java-agent/instrumentation/grizzly-2/src/test/groovy/GrizzlyAsyncTest.groovy
@@ -1,13 +1,13 @@
+import org.glassfish.grizzly.http.server.HttpServer
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
+import org.glassfish.jersey.server.ResourceConfig
+
 import javax.ws.rs.GET
 import javax.ws.rs.Path
 import javax.ws.rs.QueryParam
 import javax.ws.rs.container.AsyncResponse
 import javax.ws.rs.container.Suspended
 import javax.ws.rs.core.Response
-import org.glassfish.grizzly.http.server.HttpServer
-import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
-import org.glassfish.jersey.server.ResourceConfig
-
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -25,11 +25,6 @@ class GrizzlyAsyncTest extends GrizzlyTest {
     rc.register(SimpleExceptionMapper)
     rc.register(AsyncServiceResource)
     GrizzlyHttpServerFactory.createHttpServer(new URI("http://localhost:$port"), rc)
-  }
-
-  @Override
-  boolean reorderControllerSpan() {
-    true
   }
 
   @Path("/")

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -82,23 +82,23 @@ class GrpcStreamingTest extends AgentTestRunner {
     then:
     error.get() == null
 
-    // sort for consistent ordering
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> serverMessages = new ArrayList<>()
-    for (SpanData span : TEST_WRITER[0]) {
-      if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
-        serverMessages.add(span)
-      }
-      if (span.name == "grpc.server" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
-        serverMessages.add(0, span)
-      }
-    }
-    // move the server messages to the end
-    TEST_WRITER[0].removeAll(serverMessages)
-    TEST_WRITER[0].addAll(serverMessages)
-
     assertTraces(1) {
       trace(0, clientMessageCount * serverMessageCount + 1 + clientMessageCount + 1) {
+        sortSpans {
+          // sort for consistent ordering
+          List<SpanData> serverMessages = new ArrayList<>()
+          for (SpanData span : trace) {
+            if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
+              serverMessages.add(span)
+            }
+            if (span.name == "grpc.server" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
+              serverMessages.add(0, span)
+            }
+          }
+          // move the server messages to the end
+          trace.removeAll(serverMessages)
+          trace.addAll(serverMessages)
+        }
         span(0) {
           operationName "grpc.client"
           parent()

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -87,7 +87,7 @@ class GrpcStreamingTest extends AgentTestRunner {
         sortSpans {
           // sort for consistent ordering
           List<SpanData> serverMessages = new ArrayList<>()
-          for (SpanData span : trace) {
+          for (SpanData span : spans) {
             if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
               serverMessages.add(span)
             }
@@ -96,8 +96,8 @@ class GrpcStreamingTest extends AgentTestRunner {
             }
           }
           // move the server messages to the end
-          trace.removeAll(serverMessages)
-          trace.addAll(serverMessages)
+          spans.removeAll(serverMessages)
+          spans.addAll(serverMessages)
         }
         span(0) {
           operationName "grpc.client"

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -83,6 +83,7 @@ class GrpcStreamingTest extends AgentTestRunner {
     error.get() == null
 
     // sort for consistent ordering
+    TEST_WRITER.waitForTraces(1)
     List<SpanData> serverMessages = new ArrayList<>()
     for (SpanData span : TEST_WRITER[0]) {
       if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -12,6 +12,7 @@ import io.grpc.StatusRuntimeException
 import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.stub.StreamObserver
+import io.opentelemetry.sdk.trace.SpanData
 
 import java.util.concurrent.TimeUnit
 
@@ -38,6 +39,22 @@ class GrpcTest extends AgentTestRunner {
 
     then:
     response.message == "Hello $name"
+
+    // sort for consistent ordering
+    TEST_WRITER.waitForTraces(1)
+    List<SpanData> serverMessages = new ArrayList<>()
+    for (SpanData span : TEST_WRITER[0]) {
+      if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
+        serverMessages.add(span)
+      }
+      if (span.name == "grpc.server" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
+        serverMessages.add(0, span)
+      }
+    }
+    // move the server messages to the end
+    TEST_WRITER[0].removeAll(serverMessages)
+    TEST_WRITER[0].addAll(serverMessages)
+
     assertTraces(1) {
       trace(0, 4) {
         span(0) {

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -40,23 +40,23 @@ class GrpcTest extends AgentTestRunner {
     then:
     response.message == "Hello $name"
 
-    // sort for consistent ordering
-    TEST_WRITER.waitForTraces(1)
-    List<SpanData> serverMessages = new ArrayList<>()
-    for (SpanData span : TEST_WRITER[0]) {
-      if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
-        serverMessages.add(span)
-      }
-      if (span.name == "grpc.server" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
-        serverMessages.add(0, span)
-      }
-    }
-    // move the server messages to the end
-    TEST_WRITER[0].removeAll(serverMessages)
-    TEST_WRITER[0].addAll(serverMessages)
-
     assertTraces(1) {
       trace(0, 4) {
+        sortSpans {
+          // sort for consistent ordering
+          List<SpanData> serverMessages = new ArrayList<>()
+          for (SpanData span : trace) {
+            if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
+              serverMessages.add(span)
+            }
+            if (span.name == "grpc.server" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
+              serverMessages.add(0, span)
+            }
+          }
+          // move the server messages to the end
+          trace.removeAll(serverMessages)
+          trace.addAll(serverMessages)
+        }
         span(0) {
           operationName "grpc.client"
           parent()

--- a/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/dd-java-agent/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -45,7 +45,7 @@ class GrpcTest extends AgentTestRunner {
         sortSpans {
           // sort for consistent ordering
           List<SpanData> serverMessages = new ArrayList<>()
-          for (SpanData span : trace) {
+          for (SpanData span : spans) {
             if (span.name == "grpc.message" && span.attributes[Tags.COMPONENT].stringValue == "grpc-server") {
               serverMessages.add(span)
             }
@@ -54,8 +54,8 @@ class GrpcTest extends AgentTestRunner {
             }
           }
           // move the server messages to the end
-          trace.removeAll(serverMessages)
-          trace.addAll(serverMessages)
+          spans.removeAll(serverMessages)
+          spans.addAll(serverMessages)
         }
         span(0) {
           operationName "grpc.client"

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/CriteriaTest.groovy
@@ -33,16 +33,6 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.criteria.$methodName"
           childOf span(0)
           tags {
@@ -52,8 +42,8 @@ class CriteriaTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^select /
@@ -65,6 +55,16 @@ class CriteriaTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/QueryTest.groovy
@@ -38,16 +38,6 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.$queryMethodName"
           childOf span(0)
           tags {
@@ -59,8 +49,8 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_STATEMENT" queryMethodName == "iterate" ? null : String
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" String
@@ -72,6 +62,16 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" String
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -170,16 +170,6 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.iterate"
           childOf span(0)
           tags {
@@ -190,8 +180,8 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^select /
@@ -203,6 +193,16 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }

--- a/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-3.3/src/test/groovy/SessionTest.groovy
@@ -53,16 +53,6 @@ class SessionTest extends AbstractHibernateTest {
             }
           }
           span(1) {
-            operationName "hibernate.transaction.commit"
-            childOf span(0)
-            tags {
-              "$DDTags.SERVICE_NAME" "hibernate"
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-              "$Tags.COMPONENT" "java-hibernate"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            }
-          }
-          span(2) {
             operationName "hibernate.$methodName"
             childOf span(0)
             tags {
@@ -73,8 +63,8 @@ class SessionTest extends AbstractHibernateTest {
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             }
           }
-          span(3) {
-            childOf span(2)
+          span(2) {
+            childOf span(1)
             tags {
               "$DDTags.SERVICE_NAME" "h2"
               "$DDTags.RESOURCE_NAME" String
@@ -86,6 +76,16 @@ class SessionTest extends AbstractHibernateTest {
               "$Tags.DB_USER" "sa"
               "$Tags.DB_STATEMENT" String
               "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            }
+          }
+          span(3) {
+            operationName "hibernate.transaction.commit"
+            childOf span(0)
+            tags {
+              "$DDTags.SERVICE_NAME" "hibernate"
+              "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+              "$Tags.COMPONENT" "java-hibernate"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             }
           }
         }
@@ -135,6 +135,17 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
+          operationName "hibernate.$methodName"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.RESOURCE_NAME" resource
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
+        span(2) {
           operationName "hibernate.transaction.commit"
           childOf span(0)
           tags {
@@ -144,8 +155,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(2) {
-          childOf span(1)
+        span(3) {
+          childOf span(2)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" String
@@ -157,17 +168,6 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" String
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
-          }
-        }
-        span(3) {
-          operationName "hibernate.$methodName"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.RESOURCE_NAME" resource
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -221,31 +221,6 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
-          childOf span(1)
-          tags {
-            "$DDTags.SERVICE_NAME" "h2"
-            "$DDTags.RESOURCE_NAME" String
-            "$DDTags.SPAN_TYPE" "sql"
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "h2"
-            "$Tags.DB_INSTANCE" "db1"
-            "$Tags.DB_USER" "sa"
-            "$Tags.DB_STATEMENT" String
-            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
-          }
-        }
-        span(3) {
           operationName "hibernate.$methodName"
           childOf span(0)
           tags {
@@ -256,8 +231,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(4) {
-          childOf span(3)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^select /
@@ -268,6 +243,31 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
+        span(4) {
+          childOf span(3)
+          tags {
+            "$DDTags.SERVICE_NAME" "h2"
+            "$DDTags.RESOURCE_NAME" String
+            "$DDTags.SPAN_TYPE" "sql"
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "$Tags.DB_STATEMENT" String
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
           }
         }
@@ -319,16 +319,6 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.replicate"
           childOf span(0)
           errored(true)
@@ -338,6 +328,16 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             errorTags(MappingException, "Unknown entity: java.lang.Long")
+          }
+        }
+        span(2) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -375,6 +375,17 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
+          operationName "hibernate.$methodName"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.RESOURCE_NAME" resource
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
+        span(2) {
           operationName "hibernate.transaction.commit"
           childOf span(0)
           tags {
@@ -384,8 +395,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(2) {
-          childOf span(1)
+        span(3) {
+          childOf span(2)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" String
@@ -399,18 +410,6 @@ class SessionTest extends AbstractHibernateTest {
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
           }
         }
-        span(3) {
-          operationName "hibernate.$methodName"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.RESOURCE_NAME" resource
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-
       }
     }
 
@@ -469,16 +468,6 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.query.list"
           childOf span(0)
           tags {
@@ -490,8 +479,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_STATEMENT" String
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" String
@@ -503,6 +492,16 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" String
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -559,18 +558,30 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(2) {
-          operationName "hibernate.session"
-          childOf span(0)
+          operationName "hibernate.save"
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.RESOURCE_NAME" "Value"
             "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
         span(3) {
+          operationName "hibernate.delete"
+          childOf span(1)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.RESOURCE_NAME" "Value"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
+        span(4) {
           operationName "hibernate.transaction.commit"
-          childOf span(2)
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
             "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
@@ -578,23 +589,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(4) {
-          childOf span(3)
-          tags {
-            "$DDTags.SERVICE_NAME" "h2"
-            "$DDTags.RESOURCE_NAME" ~/^delete /
-            "$DDTags.SPAN_TYPE" "sql"
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "h2"
-            "$Tags.DB_INSTANCE" "db1"
-            "$Tags.DB_USER" "sa"
-            "$Tags.DB_STATEMENT" ~/^delete /
-            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
-          }
-        }
         span(5) {
-          childOf span(3)
+          childOf span(4)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^insert /
@@ -609,6 +605,21 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(6) {
+          childOf span(4)
+          tags {
+            "$DDTags.SERVICE_NAME" "h2"
+            "$DDTags.RESOURCE_NAME" ~/^delete /
+            "$DDTags.SPAN_TYPE" "sql"
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "$Tags.DB_STATEMENT" ~/^delete /
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(7) {
           operationName "hibernate.session"
           childOf span(0)
           tags {
@@ -618,20 +629,9 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(7) {
-          operationName "hibernate.delete"
-          childOf span(2)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.RESOURCE_NAME" "Value"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
         span(8) {
-          operationName "hibernate.save"
-          childOf span(1)
+          operationName "hibernate.insert"
+          childOf span(7)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
             "$DDTags.RESOURCE_NAME" "Value"
@@ -641,11 +641,10 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(9) {
-          operationName "hibernate.insert"
-          childOf span(6)
+          operationName "hibernate.session"
+          childOf span(0)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.RESOURCE_NAME" "Value"
             "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
@@ -653,7 +652,7 @@ class SessionTest extends AbstractHibernateTest {
         }
         span(10) {
           operationName "hibernate.save"
-          childOf span(2)
+          childOf span(9)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
             "$DDTags.RESOURCE_NAME" "Value"

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/CriteriaTest.groovy
@@ -33,16 +33,6 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.criteria.$methodName"
           childOf span(0)
           tags {
@@ -52,8 +42,8 @@ class CriteriaTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^select /
@@ -65,6 +55,16 @@ class CriteriaTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/QueryTest.groovy
@@ -38,16 +38,6 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.$queryMethodName"
           childOf span(0)
           tags {
@@ -59,8 +49,8 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_STATEMENT" queryMethodName == "iterate" ? null : String
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" String
@@ -72,6 +62,16 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" String
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -170,16 +170,6 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.iterate"
           childOf span(0)
           tags {
@@ -190,8 +180,8 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^select /
@@ -203,6 +193,16 @@ class QueryTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }

--- a/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.0/src/test/groovy/SessionTest.groovy
@@ -53,16 +53,6 @@ class SessionTest extends AbstractHibernateTest {
             }
           }
           span(1) {
-            operationName "hibernate.transaction.commit"
-            childOf span(0)
-            tags {
-              "$DDTags.SERVICE_NAME" "hibernate"
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-              "$Tags.COMPONENT" "java-hibernate"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            }
-          }
-          span(2) {
             operationName "hibernate.$methodName"
             childOf span(0)
             tags {
@@ -73,8 +63,8 @@ class SessionTest extends AbstractHibernateTest {
               "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             }
           }
-          span(3) {
-            childOf span(2)
+          span(2) {
+            childOf span(1)
             tags {
               "$DDTags.SERVICE_NAME" "h2"
               "$DDTags.RESOURCE_NAME" String
@@ -86,6 +76,16 @@ class SessionTest extends AbstractHibernateTest {
               "$Tags.DB_USER" "sa"
               "$Tags.DB_STATEMENT" String
               "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+            }
+          }
+          span(3) {
+            operationName "hibernate.transaction.commit"
+            childOf span(0)
+            tags {
+              "$DDTags.SERVICE_NAME" "hibernate"
+              "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+              "$Tags.COMPONENT" "java-hibernate"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             }
           }
         }
@@ -149,31 +149,6 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
-          childOf span(1)
-          tags {
-            "$DDTags.SERVICE_NAME" "h2"
-            "$DDTags.RESOURCE_NAME" String
-            "$DDTags.SPAN_TYPE" "sql"
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "h2"
-            "$Tags.DB_INSTANCE" "db1"
-            "$Tags.DB_USER" "sa"
-            "$Tags.DB_STATEMENT" String
-            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
-          }
-        }
-        span(3) {
           operationName "hibernate.$methodName"
           childOf span(0)
           tags {
@@ -184,8 +159,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(4) {
-          childOf span(3)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^select /
@@ -196,6 +171,31 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
+        span(4) {
+          childOf span(3)
+          tags {
+            "$DDTags.SERVICE_NAME" "h2"
+            "$DDTags.RESOURCE_NAME" String
+            "$DDTags.SPAN_TYPE" "sql"
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "$Tags.DB_STATEMENT" String
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
           }
         }
@@ -247,16 +247,6 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.replicate"
           childOf span(0)
           errored(true)
@@ -266,6 +256,16 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             errorTags(MappingException, "Unknown entity: java.lang.Long")
+          }
+        }
+        span(2) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -303,6 +303,17 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
+          operationName "hibernate.$methodName"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.RESOURCE_NAME" resource
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
+        span(2) {
           operationName "hibernate.transaction.commit"
           childOf span(0)
           tags {
@@ -312,8 +323,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(2) {
-          childOf span(1)
+        span(3) {
+          childOf span(2)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" String
@@ -327,18 +338,6 @@ class SessionTest extends AbstractHibernateTest {
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
           }
         }
-        span(3) {
-          operationName "hibernate.$methodName"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.RESOURCE_NAME" resource
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-
       }
     }
 
@@ -397,16 +396,6 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.query.list"
           childOf span(0)
           tags {
@@ -418,8 +407,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_STATEMENT" String
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" String
@@ -431,6 +420,16 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" String
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -487,18 +486,30 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(2) {
-          operationName "hibernate.session"
-          childOf span(0)
+          operationName "hibernate.save"
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.RESOURCE_NAME" "Value"
             "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
         span(3) {
+          operationName "hibernate.delete"
+          childOf span(1)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.RESOURCE_NAME" "Value"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
+        span(4) {
           operationName "hibernate.transaction.commit"
-          childOf span(2)
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
             "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
@@ -506,23 +517,8 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(4) {
-          childOf span(3)
-          tags {
-            "$DDTags.SERVICE_NAME" "h2"
-            "$DDTags.RESOURCE_NAME" ~/^delete /
-            "$DDTags.SPAN_TYPE" "sql"
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "h2"
-            "$Tags.DB_INSTANCE" "db1"
-            "$Tags.DB_USER" "sa"
-            "$Tags.DB_STATEMENT" ~/^delete /
-            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
-          }
-        }
         span(5) {
-          childOf span(3)
+          childOf span(4)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^insert /
@@ -537,6 +533,21 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(6) {
+          childOf span(4)
+          tags {
+            "$DDTags.SERVICE_NAME" "h2"
+            "$DDTags.RESOURCE_NAME" ~/^delete /
+            "$DDTags.SPAN_TYPE" "sql"
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "h2"
+            "$Tags.DB_INSTANCE" "db1"
+            "$Tags.DB_USER" "sa"
+            "$Tags.DB_STATEMENT" ~/^delete /
+            "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
+          }
+        }
+        span(7) {
           operationName "hibernate.session"
           childOf span(0)
           tags {
@@ -546,20 +557,9 @@ class SessionTest extends AbstractHibernateTest {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(7) {
-          operationName "hibernate.delete"
-          childOf span(2)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.RESOURCE_NAME" "Value"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
         span(8) {
-          operationName "hibernate.save"
-          childOf span(1)
+          operationName "hibernate.insert"
+          childOf span(7)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
             "$DDTags.RESOURCE_NAME" "Value"
@@ -569,18 +569,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(9) {
-          operationName "hibernate.insert"
-          childOf span(6)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.RESOURCE_NAME" "Value"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(10) {
-          childOf span(9)
+          childOf span(8)
           tags {
             "$DDTags.SERVICE_NAME" "h2"
             "$DDTags.RESOURCE_NAME" ~/^insert /
@@ -594,9 +583,19 @@ class SessionTest extends AbstractHibernateTest {
             "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
           }
         }
+        span(10) {
+          operationName "hibernate.session"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+          }
+        }
         span(11) {
           operationName "hibernate.save"
-          childOf span(2)
+          childOf span(10)
           tags {
             "$DDTags.SERVICE_NAME" "hibernate"
             "$DDTags.RESOURCE_NAME" "Value"

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -76,16 +76,6 @@ class ProcedureCallTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.procedure.getOutputs"
           childOf span(0)
           tags {
@@ -96,8 +86,8 @@ class ProcedureCallTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(3) {
-          childOf span(2)
+        span(2) {
+          childOf span(1)
           tags {
             "$DDTags.SERVICE_NAME" "hsqldb"
             "$DDTags.RESOURCE_NAME" "{call TEST_PROC()}"
@@ -109,6 +99,16 @@ class ProcedureCallTest extends AgentTestRunner {
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" "{call TEST_PROC()}"
             "span.origin.type" "org.hsqldb.jdbc.JDBCCallableStatement"
+          }
+        }
+        span(3) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }
@@ -147,16 +147,6 @@ class ProcedureCallTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hibernate.transaction.commit"
-          childOf span(0)
-          tags {
-            "$DDTags.SERVICE_NAME" "hibernate"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
-            "$Tags.COMPONENT" "java-hibernate"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-          }
-        }
-        span(2) {
           operationName "hibernate.procedure.getOutputs"
           childOf span(0)
           errored(true)
@@ -167,6 +157,16 @@ class ProcedureCallTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
             errorTags(SQLGrammarException, "could not prepare statement")
+          }
+        }
+        span(2) {
+          operationName "hibernate.transaction.commit"
+          childOf span(0)
+          tags {
+            "$DDTags.SERVICE_NAME" "hibernate"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HIBERNATE
+            "$Tags.COMPONENT" "java-hibernate"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
       }

--- a/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/hibernate/core-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -53,7 +53,7 @@ class SpringJpaTest extends AgentTestRunner {
     then:
     customer.id != null
     // Behavior changed in new version:
-    def extraTrace = TEST_WRITER.size() == 2
+    def extraTrace = TEST_WRITER.traces.size() == 2
     assertTraces(extraTrace ? 2 : 1) {
       if (extraTrace) {
         trace(0, 1) {

--- a/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/dd-java-agent/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -78,8 +78,8 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
 
     expect:
     assertTraces(3) {
-      server.distributedRequestTrace(it, 0, TEST_WRITER[2][2])
-      server.distributedRequestTrace(it, 1, TEST_WRITER[2][1])
+      server.distributedRequestTrace(it, 0, traces[2][2])
+      server.distributedRequestTrace(it, 1, traces[2][1])
       trace(2, 3) {
         span(0) {
           operationName "someTrace"
@@ -294,7 +294,7 @@ class HttpUrlConnectionTest extends HttpClientTest<HttpUrlConnectionDecorator> {
 
     expect:
     assertTraces(2) {
-      server.distributedRequestTrace(it, 0, TEST_WRITER[1][1])
+      server.distributedRequestTrace(it, 0, traces[1][1])
       trace(1, 2) {
         span(0) {
           operationName "someTrace"

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -82,29 +82,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
         }
         span(1) {
           operationName "hystrix.cmd"
-          childOf span(3)
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "OtherGroup.HystrixObservableChainTest\$2.execute"
-            "$DDTags.SPAN_TYPE" null
-            "$Tags.COMPONENT" "hystrix"
-            "hystrix.command" "HystrixObservableChainTest\$2"
-            "hystrix.group" "OtherGroup"
-            "hystrix.circuit-open" false
-          }
-        }
-        span(2) {
-          operationName "trace.annotation"
-          childOf span(1)
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "HystrixObservableChainTest\$2.tracedMethod"
-            "$DDTags.SPAN_TYPE" null
-            "$Tags.COMPONENT" "trace"
-          }
-        }
-        span(3) {
-          operationName "hystrix.cmd"
           childOf span(0)
           errored false
           tags {
@@ -116,12 +93,35 @@ class HystrixObservableChainTest extends AgentTestRunner {
             "hystrix.circuit-open" false
           }
         }
+        span(2) {
+          operationName "trace.annotation"
+          childOf span(1)
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "HystrixObservableChainTest\$1.tracedMethod"
+            "$DDTags.SPAN_TYPE" null
+            "$Tags.COMPONENT" "trace"
+          }
+        }
+        span(3) {
+          operationName "hystrix.cmd"
+          childOf span(1)
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "OtherGroup.HystrixObservableChainTest\$2.execute"
+            "$DDTags.SPAN_TYPE" null
+            "$Tags.COMPONENT" "hystrix"
+            "hystrix.command" "HystrixObservableChainTest\$2"
+            "hystrix.group" "OtherGroup"
+            "hystrix.circuit-open" false
+          }
+        }
         span(4) {
           operationName "trace.annotation"
           childOf span(3)
           errored false
           tags {
-            "$DDTags.RESOURCE_NAME" "HystrixObservableChainTest\$1.tracedMethod"
+            "$DDTags.RESOURCE_NAME" "HystrixObservableChainTest\$2.tracedMethod"
             "$DDTags.SPAN_TYPE" null
             "$Tags.COMPONENT" "trace"
           }

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -47,7 +47,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
         new HystrixObservableCommand<String>(asKey("OtherGroup")) {
           @Trace
           private String tracedMethod() {
-            blockUntilChildSpansFinished(2)
             return "$str!"
           }
 
@@ -61,9 +60,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
         }.toObservable()
           .subscribeOn(Schedulers.trampoline())
       }.toBlocking().first()
-      // when this is running in different threads, we don't know when the other span is done
-      // adding sleep to improve ordering consistency
-      blockUntilChildSpansFinished(4)
       return val
     }
 

--- a/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/dd-java-agent/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -35,10 +35,7 @@ class HystrixTest extends AgentTestRunner {
       }
     }
     def result = runUnderTrace("parent") {
-      def res = operation(command)
-      // child spans are reported asynchronously, this is needed for consistent span ordering during test verification
-      blockUntilChildSpansFinished(2)
-      res
+      operation(command)
     }
     expect:
     TRANSFORMED_CLASSES.contains("com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler\$ThreadPoolWorker")
@@ -109,10 +106,7 @@ class HystrixTest extends AgentTestRunner {
       }
     }
     def result = runUnderTrace("parent") {
-      def res = operation(command)
-      // child spans are reported asynchronously, this is needed for consistent span ordering during test verification
-      blockUntilChildSpansFinished(2)
-      res
+      operation(command)
     }
     expect:
     TRANSFORMED_CLASSES.contains("com.netflix.hystrix.strategy.concurrency.HystrixContextScheduler\$ThreadPoolWorker")

--- a/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-2.5-testing/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -53,10 +53,10 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
     }.run()
 
     TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.get(0)
+    List<SpanData> trace = TEST_WRITER.traces[0]
 
     expect:
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
     trace.size() == 2
     trace.get(0).name == "parent"
     trace.get(1).name == "asyncChild"
@@ -124,7 +124,7 @@ class AkkaExecutorInstrumentationTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(1)
 
     expect:
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     where:
     name              | method         | poolImpl

--- a/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/scala/AkkaActors.scala
+++ b/dd-java-agent/instrumentation/java-concurrent/akka-testing/src/test/scala/AkkaActors.scala
@@ -1,7 +1,6 @@
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
-import datadog.trace.agent.test.AgentTestRunner.blockUntilChildSpansFinished
 import datadog.trace.api.Trace
 import datadog.trace.instrumentation.api.AgentTracer.activeSpan
 
@@ -36,21 +35,18 @@ class AkkaActors {
   def basicTell(): Unit = {
     howdyGreeter ! WhoToGreet("Akka")
     howdyGreeter ! Greet
-    blockUntilChildSpansFinished(1)
   }
 
   @Trace
   def basicAsk(): Unit = {
     howdyGreeter ! WhoToGreet("Akka")
     howdyGreeter ? Greet
-    blockUntilChildSpansFinished(1)
   }
 
   @Trace
   def basicForward(): Unit = {
     helloGreeter ! WhoToGreet("Akka")
     helloGreeter ? Greet
-    blockUntilChildSpansFinished(1)
   }
 }
 

--- a/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -53,10 +53,10 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
     }.run()
 
     TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.get(0)
+    List<SpanData> trace = TEST_WRITER.traces[0]
 
     expect:
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
     trace.size() == 2
     trace.get(0).name == "parent"
     trace.get(1).name == "asyncChild"
@@ -124,7 +124,7 @@ class ScalaExecutorInstrumentationTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(1)
 
     expect:
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     where:
     name              | method         | poolImpl

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
@@ -56,11 +56,11 @@ class CompletableFutureTest extends AgentTestRunner {
     TEST_WRITER.size() == 1
     trace.size() == 4
     trace.get(0).name == "parent"
-    trace.get(1).name == "function"
+    trace.get(1).name == "supplier"
     trace.get(1).parentSpanId == trace.get(0).spanId
     trace.get(2).name == "appendingSupplier"
     trace.get(2).parentSpanId == trace.get(0).spanId
-    trace.get(3).name == "supplier"
+    trace.get(3).name == "function"
     trace.get(3).parentSpanId == trace.get(0).spanId
 
     cleanup:

--- a/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
@@ -48,12 +48,12 @@ class CompletableFutureTest extends AgentTestRunner {
     }.get()
 
     TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.get(0)
+    List<SpanData> trace = TEST_WRITER.traces[0]
 
     expect:
     result == "abc"
 
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
     trace.size() == 4
     trace.get(0).name == "parent"
     trace.get(1).name == "supplier"

--- a/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -80,10 +80,10 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
     }.run()
 
     TEST_WRITER.waitForTraces(1)
-    List<SpanData> trace = TEST_WRITER.get(0)
+    List<SpanData> trace = TEST_WRITER.traces[0]
 
     expect:
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
     trace.size() == 2
     trace.get(0).name == "parent"
     trace.get(1).name == "asyncChild"
@@ -161,11 +161,11 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(2)
 
     expect:
-    TEST_WRITER.size() == 2
-    TEST_WRITER.get(0).size() == 1
-    TEST_WRITER.get(0).get(0).name == "parent"
-    TEST_WRITER.get(1).size() == 1
-    TEST_WRITER.get(1).get(0).name == "asyncChild"
+    TEST_WRITER.traces.size() == 2
+    TEST_WRITER.traces[0].size() == 1
+    TEST_WRITER.traces[0][0].name == "parent"
+    TEST_WRITER.traces[1].size() == 1
+    TEST_WRITER.traces[1][0].name == "asyncChild"
 
     cleanup:
     pool?.shutdown()
@@ -226,7 +226,7 @@ class ExecutorInstrumentationTest extends AgentTestRunner {
     TEST_WRITER.waitForTraces(1)
 
     expect:
-    TEST_WRITER.size() == 1
+    TEST_WRITER.traces.size() == 1
 
     where:
     name                | method           | poolImpl

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/JMS2Test.groovy
@@ -92,8 +92,8 @@ class JMS2Test extends AgentTestRunner {
     receivedMessage.text == messageText
     assertTraces(1) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, false, HornetQMessageConsumer, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, false, HornetQMessageConsumer, span(0))
       }
     }
 
@@ -129,8 +129,8 @@ class JMS2Test extends AgentTestRunner {
     expect:
     assertTraces(1) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, true, consumer.messageListener.class, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, true, consumer.messageListener.class, span(0))
       }
     }
     // This check needs to go after all traces have been accounted for

--- a/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
@@ -76,8 +76,8 @@ class SpringTemplateJMS2Test extends AgentTestRunner {
     receivedMessage.text == messageText
     assertTraces(1) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, false, HornetQMessageConsumer, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, false, HornetQMessageConsumer, span(0))
       }
     }
 
@@ -105,12 +105,12 @@ class SpringTemplateJMS2Test extends AgentTestRunner {
     receivedMessage.text == "responded!"
     assertTraces(2) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, false, HornetQMessageConsumer, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, false, HornetQMessageConsumer, span(0))
       }
       trace(1, 2) {
-        producerSpan(it, 1, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
-        consumerSpan(it, 0, "Temporary Queue", false, HornetQMessageConsumer, span(1))
+        producerSpan(it, 0, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
+        consumerSpan(it, 1, "Temporary Queue", false, HornetQMessageConsumer, span(0))
       }
     }
 

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/JMS1Test.groovy
@@ -55,8 +55,8 @@ class JMS1Test extends AgentTestRunner {
     receivedMessage.text == messageText
     assertTraces(1) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, false, ActiveMQMessageConsumer, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, false, ActiveMQMessageConsumer, span(0))
       }
     }
 
@@ -92,8 +92,8 @@ class JMS1Test extends AgentTestRunner {
     expect:
     assertTraces(1) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, true, consumer.messageListener.class, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, true, consumer.messageListener.class, span(0))
       }
     }
     // This check needs to go after all traces have been accounted for

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/SpringTemplateJMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/SpringTemplateJMS1Test.groovy
@@ -49,8 +49,8 @@ class SpringTemplateJMS1Test extends AgentTestRunner {
     receivedMessage.text == messageText
     assertTraces(1) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, false, ActiveMQMessageConsumer, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, false, ActiveMQMessageConsumer, span(0))
       }
     }
 
@@ -77,28 +77,17 @@ class SpringTemplateJMS1Test extends AgentTestRunner {
     }
 
     TEST_WRITER.waitForTraces(2)
-    // Manually reorder if reported in the wrong order.
-    if (TEST_WRITER[0][0].name == "jms.produce") {
-      def producerSpan = TEST_WRITER[0][0]
-      TEST_WRITER[0][0] = TEST_WRITER[0][1]
-      TEST_WRITER[0][1] = producerSpan
-    }
-    if (TEST_WRITER[1][0].name == "jms.produce") {
-      def producerSpan = TEST_WRITER[1][0]
-      TEST_WRITER[1][0] = TEST_WRITER[1][1]
-      TEST_WRITER[1][1] = producerSpan
-    }
 
     expect:
     receivedMessage.text == "responded!"
     assertTraces(2) {
       trace(0, 2) {
-        producerSpan(it, 1, jmsResourceName)
-        consumerSpan(it, 0, jmsResourceName, false, ActiveMQMessageConsumer, span(1))
+        producerSpan(it, 0, jmsResourceName)
+        consumerSpan(it, 1, jmsResourceName, false, ActiveMQMessageConsumer, span(0))
       }
       trace(1, 2) {
-        producerSpan(it, 1, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
-        consumerSpan(it, 0, "Temporary Queue", false, ActiveMQMessageConsumer, span(1))
+        producerSpan(it, 0, "Temporary Queue") // receive doesn't propagate the trace, so this is a root
+        consumerSpan(it, 1, "Temporary Queue", false, ActiveMQMessageConsumer, span(0))
       }
     }
 

--- a/dd-java-agent/instrumentation/jms/src/test/groovy/SpringTemplateJMS1Test.groovy
+++ b/dd-java-agent/instrumentation/jms/src/test/groovy/SpringTemplateJMS1Test.groovy
@@ -65,9 +65,6 @@ class SpringTemplateJMS1Test extends AgentTestRunner {
       TextMessage msg = template.receive(destination)
       assert msg.text == messageText
 
-      // Make sure that first pair of send/receive traces has landed to simplify assertions
-      TEST_WRITER.waitForTraces(1)
-
       template.send(msg.getJMSReplyTo()) {
         session -> template.getMessageConverter().toMessage("responded!", session)
       }
@@ -75,8 +72,6 @@ class SpringTemplateJMS1Test extends AgentTestRunner {
     TextMessage receivedMessage = template.sendAndReceive(destination) {
       session -> template.getMessageConverter().toMessage(messageText, session)
     }
-
-    TEST_WRITER.waitForTraces(2)
 
     expect:
     receivedMessage.text == "responded!"

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -108,18 +108,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/$jspFileName"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" jspClassName
-            "servlet.context" "/$jspWebappContext"
-            "jsp.requestURL" reqUrl
-          }
-        }
-        span(2) {
-          childOf span(0)
           operationName "jsp.compile"
           errored false
           tags {
@@ -128,6 +116,18 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
+          operationName "jsp.render"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/$jspFileName"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" jspClassName
+            "servlet.context" "/$jspWebappContext"
+            "jsp.requestURL" reqUrl
           }
         }
       }
@@ -177,18 +177,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/getQuery.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "getQuery_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.requestURL" reqUrl
-          }
-        }
-        span(2) {
-          childOf span(0)
           operationName "jsp.compile"
           errored false
           tags {
@@ -197,6 +185,18 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
+          operationName "jsp.render"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/getQuery.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "getQuery_jsp"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.requestURL" reqUrl
           }
         }
       }
@@ -243,18 +243,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/post.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "post_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.requestURL" reqUrl
-          }
-        }
-        span(2) {
-          childOf span(0)
           operationName "jsp.compile"
           errored false
           tags {
@@ -263,6 +251,18 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
+          operationName "jsp.render"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/post.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "post_jsp"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.requestURL" reqUrl
           }
         }
       }
@@ -313,6 +313,18 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/$jspFileName"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.$jspClassName"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
           operationName "jsp.render"
           errored true
           tags {
@@ -328,18 +340,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
               return errorMessageOptional || tagErrorMsg instanceof String
             }
             "error.stack" String
-          }
-        }
-        span(2) {
-          childOf span(0)
-          operationName "jsp.compile"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/$jspFileName"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.$jspClassName"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
         }
       }
@@ -388,18 +388,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/includes/includeHtml.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "includeHtml_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.requestURL" reqUrl
-          }
-        }
-        span(2) {
-          childOf span(0)
           operationName "jsp.compile"
           errored false
           tags {
@@ -408,6 +396,18 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
+          operationName "jsp.render"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/includes/includeHtml.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "includeHtml_jsp"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.requestURL" reqUrl
           }
         }
       }
@@ -450,6 +450,18 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
           operationName "jsp.render"
           errored false
           tags {
@@ -460,20 +472,8 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
             "jsp.requestURL" reqUrl
           }
         }
-        span(2) {
-          childOf span(1)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "javaLoopH2_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.requestURL" reqUrl
-          }
-        }
         span(3) {
-          childOf span(1)
+          childOf span(2)
           operationName "jsp.compile"
           errored false
           tags {
@@ -485,7 +485,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           }
         }
         span(4) {
-          childOf span(1)
+          childOf span(2)
           operationName "jsp.render"
           errored false
           tags {
@@ -497,7 +497,7 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           }
         }
         span(5) {
-          childOf span(1)
+          childOf span(2)
           operationName "jsp.compile"
           errored false
           tags {
@@ -509,15 +509,15 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           }
         }
         span(6) {
-          childOf span(0)
-          operationName "jsp.compile"
+          childOf span(2)
+          operationName "jsp.render"
           errored false
           tags {
-            "$DDTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
+            "$DDTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+            "jsp.requestURL" reqUrl
           }
         }
       }

--- a/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/dd-java-agent/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -107,6 +107,18 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/$forwardFromFileName"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
           operationName "jsp.render"
           errored false
           tags {
@@ -117,21 +129,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "jsp.requestURL" reqUrl
           }
         }
-        span(2) {
-          childOf span(1)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/$forwardDestFileName"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" jspForwardDestClassName
-            "servlet.context" "/$jspWebappContext"
-            "jsp.forwardOrigin" "/$forwardFromFileName"
-            "jsp.requestURL" baseUrl + "/$forwardDestFileName"
-          }
-        }
         span(3) {
-          childOf span(1)
+          childOf span(2)
           operationName "jsp.compile"
           errored false
           tags {
@@ -143,15 +142,16 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           }
         }
         span(4) {
-          childOf span(0)
-          operationName "jsp.compile"
+          childOf span(2)
+          operationName "jsp.render"
           errored false
           tags {
-            "$DDTags.RESOURCE_NAME" "/$forwardFromFileName"
+            "$DDTags.RESOURCE_NAME" "/$forwardDestFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+            "jsp.forwardOrigin" "/$forwardFromFileName"
+            "jsp.requestURL" baseUrl + "/$forwardDestFileName"
           }
         }
       }
@@ -199,18 +199,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/forwards/forwardToHtml.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "forwardToHtml_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.requestURL" reqUrl
-          }
-        }
-        span(2) {
-          childOf span(0)
           operationName "jsp.compile"
           errored false
           tags {
@@ -219,6 +207,18 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
+          operationName "jsp.render"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/forwards/forwardToHtml.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "forwardToHtml_jsp"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.requestURL" reqUrl
           }
         }
       }
@@ -261,6 +261,18 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/forwards/forwardToIncludeMulti.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
           operationName "jsp.render"
           errored false
           tags {
@@ -271,8 +283,20 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "jsp.requestURL" reqUrl
           }
         }
-        span(2) {
-          childOf span(1)
+        span(3) {
+          childOf span(2)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(4) {
+          childOf span(2)
           operationName "jsp.render"
           errored false
           tags {
@@ -284,21 +308,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
           }
         }
-        span(3) {
-          childOf span(2)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "javaLoopH2_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
-            "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
-          }
-        }
-        span(4) {
-          childOf span(2)
+        span(5) {
+          childOf span(4)
           operationName "jsp.compile"
           errored false
           tags {
@@ -307,23 +318,23 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
-          }
-        }
-        span(5) {
-          childOf span(2)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "javaLoopH2_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
-            "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
           }
         }
         span(6) {
-          childOf span(2)
+          childOf span(4)
+          operationName "jsp.render"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "javaLoopH2_jsp"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
+            "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
+          }
+        }
+        span(7) {
+          childOf span(4)
           operationName "jsp.compile"
           errored false
           tags {
@@ -331,31 +342,20 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
-          }
-        }
-        span(7) {
-          childOf span(1)
-          operationName "jsp.compile"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
         }
         span(8) {
-          childOf span(0)
-          operationName "jsp.compile"
+          childOf span(4)
+          operationName "jsp.render"
           errored false
           tags {
-            "$DDTags.RESOURCE_NAME" "/forwards/forwardToIncludeMulti.jsp"
+            "$DDTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+            "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
+            "jsp.requestURL" baseUrl + "/includes/includeMulti.jsp"
           }
         }
       }
@@ -398,6 +398,18 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/forwards/forwardToJspForward.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
           operationName "jsp.render"
           errored false
           tags {
@@ -408,8 +420,20 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "jsp.requestURL" reqUrl
           }
         }
-        span(2) {
-          childOf span(1)
+        span(3) {
+          childOf span(2)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/forwards/forwardToSimpleJava.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(4) {
+          childOf span(2)
           operationName "jsp.render"
           errored false
           tags {
@@ -421,21 +445,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "jsp.requestURL" baseUrl + "/forwards/forwardToSimpleJava.jsp"
           }
         }
-        span(3) {
-          childOf span(2)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/common/loop.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "loop_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
-            "jsp.requestURL" baseUrl + "/common/loop.jsp"
-          }
-        }
-        span(4) {
-          childOf span(2)
+        span(5) {
+          childOf span(4)
           operationName "jsp.compile"
           errored false
           tags {
@@ -446,28 +457,17 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
         }
-        span(5) {
-          childOf span(1)
-          operationName "jsp.compile"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/forwards/forwardToSimpleJava.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
-          }
-        }
         span(6) {
-          childOf span(0)
-          operationName "jsp.compile"
+          childOf span(4)
+          operationName "jsp.render"
           errored false
           tags {
-            "$DDTags.RESOURCE_NAME" "/forwards/forwardToJspForward.jsp"
+            "$DDTags.RESOURCE_NAME" "/common/loop.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+            "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
+            "jsp.requestURL" baseUrl + "/common/loop.jsp"
           }
         }
       }
@@ -511,6 +511,18 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
+          operationName "jsp.compile"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/forwards/forwardToCompileError.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
+            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
           operationName "jsp.render"
           errored true
           tags {
@@ -522,8 +534,8 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             errorTags(JasperException, String)
           }
         }
-        span(2) {
-          childOf span(1)
+        span(3) {
+          childOf span(2)
           operationName "jsp.compile"
           errored true
           tags {
@@ -533,18 +545,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
             errorTags(JasperException, String)
-          }
-        }
-        span(3) {
-          childOf span(0)
-          operationName "jsp.compile"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/forwards/forwardToCompileError.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
-            "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
           }
         }
       }
@@ -587,18 +587,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.render"
-          errored false
-          tags {
-            "$DDTags.RESOURCE_NAME" "/forwards/forwardToNonExistent.jsp"
-            "$Tags.COMPONENT" "jsp-http-servlet"
-            "span.origin.type" "forwardToNonExistent_jsp"
-            "servlet.context" "/$jspWebappContext"
-            "jsp.requestURL" reqUrl
-          }
-        }
-        span(2) {
-          childOf span(0)
           operationName "jsp.compile"
           errored false
           tags {
@@ -607,6 +595,18 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
+          }
+        }
+        span(2) {
+          childOf span(0)
+          operationName "jsp.render"
+          errored false
+          tags {
+            "$DDTags.RESOURCE_NAME" "/forwards/forwardToNonExistent.jsp"
+            "$Tags.COMPONENT" "jsp-http-servlet"
+            "span.origin.type" "forwardToNonExistent_jsp"
+            "servlet.context" "/$jspWebappContext"
+            "jsp.requestURL" reqUrl
           }
         }
       }

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -81,8 +81,7 @@ class KafkaClientTest extends AgentTestRunner {
 
     assertTraces(1) {
       trace(0, 2) {
-        // PRODUCER span 1
-        span(1) {
+        span(0) {
           operationName "kafka.produce"
           errored false
           parent()
@@ -94,11 +93,10 @@ class KafkaClientTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_PRODUCER
           }
         }
-        // CONSUMER span 0
-        span(0) {
+        span(1) {
           operationName "kafka.consume"
           errored false
-          childOf span(1)
+          childOf span(0)
           tags {
             "$DDTags.SERVICE_NAME" "kafka"
             "$DDTags.RESOURCE_NAME" "Consume Topic $SHARED_TOPIC"
@@ -154,8 +152,7 @@ class KafkaClientTest extends AgentTestRunner {
 
     assertTraces(1) {
       trace(0, 2) {
-        // PRODUCER span 1
-        span(1) {
+        span(0) {
           operationName "kafka.produce"
           errored false
           parent()
@@ -168,11 +165,10 @@ class KafkaClientTest extends AgentTestRunner {
             "kafka.partition" { it >= 0 }
           }
         }
-        // CONSUMER span 0
-        span(0) {
+        span(1) {
           operationName "kafka.consume"
           errored false
-          childOf span(1)
+          childOf span(0)
           tags {
             "$DDTags.SERVICE_NAME" "kafka"
             "$DDTags.RESOURCE_NAME" "Consume Topic $SHARED_TOPIC"

--- a/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/dd-java-agent/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -57,7 +57,6 @@ class KafkaClientTest extends AgentTestRunner {
     container.setupMessageListener(new MessageListener<String, String>() {
       @Override
       void onMessage(ConsumerRecord<String, String> record) {
-        TEST_WRITER.waitForTraces(1) // ensure consistent ordering of traces
         records.add(record)
       }
     })

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -334,7 +334,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     hmsetFuture.thenApplyAsync(new Function<String, Object>() {
       @Override
       Object apply(String setResult) {
-        TEST_WRITER.waitForTraces(1) // Wait for 'hmset' trace to get written
         conds.evaluate {
           assert setResult == "OK"
         }

--- a/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/dd-java-agent/instrumentation/lettuce-5/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -263,7 +263,7 @@ class LettuceReactiveClientTest extends AgentTestRunner {
 
     then:
     res != null
-    TEST_WRITER.size() == 0
+    TEST_WRITER.traces.size() == 0
   }
 
   def "debug segfault command (returns mono void) with no argument should produce span"() {

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -36,7 +36,6 @@ class Netty40ClientTest extends HttpClientTest<NettyHttpClientDecorator> {
         return response
       }
     }).get()
-    blockUntilChildSpansFinished(1)
     return response.statusCode
   }
 

--- a/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -74,7 +74,7 @@ class Netty40ClientTest extends HttpClientTest<NettyHttpClientDecorator> {
 
     and:
     assertTraces(1) {
-      def size = TEST_WRITER.get(0).size()
+      def size = traces[0].size()
       trace(0, size) {
         basicSpan(it, 0, "parent", null, null, thrownException)
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -83,7 +83,7 @@ class Netty41ClientTest extends HttpClientTest<NettyHttpClientDecorator> {
 
     and:
     assertTraces(1) {
-      def size = TEST_WRITER.get(0).size()
+      def size = traces[0].size()
       trace(0, size) {
         basicSpan(it, 0, "parent", null, null, thrownException)
 

--- a/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/dd-java-agent/instrumentation/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -44,7 +44,6 @@ class Netty41ClientTest extends HttpClientTest<NettyHttpClientDecorator> {
         return response
       }
     }).get()
-    blockUntilChildSpansFinished(1)
     return response.statusCode
   }
 

--- a/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -74,12 +74,6 @@ class PlayServerTest extends HttpServerTest<Server, NettyHttpServerDecorator> {
     true
   }
 
-  @Override
-  // Return the handler span's name
-  String reorderHandlerSpan() {
-    "play.request"
-  }
-
   boolean testExceptionBody() {
     // I can't figure out how to set a proper exception handler to customize the response body.
     false

--- a/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/dd-java-agent/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -76,12 +76,6 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
     true
   }
 
-  @Override
-  // Return the handler span's name
-  String reorderHandlerSpan() {
-    "play.request"
-  }
-
   boolean testExceptionBody() {
     // I can't figure out how to set a proper exception handler to customize the response body.
     false

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -7,6 +7,7 @@ import com.rabbitmq.client.Consumer
 import com.rabbitmq.client.DefaultConsumer
 import com.rabbitmq.client.Envelope
 import com.rabbitmq.client.GetResponse
+import com.rabbitmq.client.ShutdownSignalException
 import datadog.trace.agent.test.AgentTestRunner
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
@@ -79,7 +80,7 @@ class RabbitMQTest extends AgentTestRunner {
     try {
       channel.close()
       conn.close()
-    } catch (AlreadyClosedException e) {
+    } catch (AlreadyClosedException | ShutdownSignalException e) {
       // Ignore
     }
   }

--- a/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/dd-java-agent/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -108,12 +108,11 @@ class RabbitMQTest extends AgentTestRunner {
           tags {
           }
         }
-        rabbitSpan(it, 1, "basic.get <generated>", true, span(2))
-        // reverse order
-        rabbitSpan(it, 2, "basic.publish $exchangeName -> $routingKey", false, span(0))
+        rabbitSpan(it, 1, "exchange.declare", false, span(0))
+        rabbitSpan(it, 2, "queue.declare", false, span(0))
         rabbitSpan(it, 3, "queue.bind", false, span(0))
-        rabbitSpan(it, 4, "queue.declare", false, span(0))
-        rabbitSpan(it, 5, "exchange.declare", false, span(0))
+        rabbitSpan(it, 4, "basic.publish $exchangeName -> $routingKey", false, span(0))
+        rabbitSpan(it, 5, "basic.get <generated>", true, span(4))
       }
     }
 
@@ -139,8 +138,8 @@ class RabbitMQTest extends AgentTestRunner {
         rabbitSpan(it, 0, "queue.declare")
       }
       trace(1, 2) {
-        rabbitSpan(it, 0, "basic.get <generated>", true, span(1))
-        rabbitSpan(it, 1, "basic.publish <default> -> <generated>")
+        rabbitSpan(it, 0, "basic.publish <default> -> <generated>")
+        rabbitSpan(it, 1, "basic.get <generated>", true, span(0))
       }
     }
   }
@@ -191,8 +190,8 @@ class RabbitMQTest extends AgentTestRunner {
       }
       (1..messageCount).each {
         trace(3 + it, 2) {
-          rabbitSpan(it, 0, resource, true, span(1))
-          rabbitSpan(it, 1, "basic.publish $exchangeName -> <all>")
+          rabbitSpan(it, 0, "basic.publish $exchangeName -> <all>")
+          rabbitSpan(it, 1, resource, true, span(0))
         }
       }
     }
@@ -246,8 +245,8 @@ class RabbitMQTest extends AgentTestRunner {
         rabbitSpan(it, "basic.consume")
       }
       trace(4, 2) {
-        rabbitSpan(it, 0, "basic.deliver <generated>", true, span(1), error, error.message)
-        rabbitSpan(it, 1, "basic.publish $exchangeName -> <all>")
+        rabbitSpan(it, 0, "basic.publish $exchangeName -> <all>")
+        rabbitSpan(it, 1, "basic.deliver <generated>", true, span(0), error, error.message)
       }
     }
 
@@ -302,8 +301,8 @@ class RabbitMQTest extends AgentTestRunner {
         rabbitSpan(it, "queue.declare")
       }
       trace(1, 2) {
-        rabbitSpan(it, 0, "basic.get $queue.name", true, span(1))
-        rabbitSpan(it, 1, "basic.publish <default> -> some-routing-queue")
+        rabbitSpan(it, 0, "basic.publish <default> -> some-routing-queue")
+        rabbitSpan(it, 1, "basic.get $queue.name", true, span(0))
       }
     }
   }

--- a/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -102,11 +102,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp, NettyHttpServerD
   }
 
   @Override
-  boolean reorderControllerSpan() {
-    true
-  }
-
-  @Override
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
       operationName "ratpack.handler"

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -238,11 +238,6 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
     assertTraces(size) {
       (1..size).each {
         trace(it - 1, 3) {
-          if (trace[1].attributes["servlet.dispatch"]) {
-            def tmp = trace[1]
-            trace[1] = trace[0]
-            trace[0] = tmp
-          }
           def endpoint = lastRequest
           span(0) {
             operationName expectedOperationName()

--- a/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/dd-java-agent/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -1,9 +1,8 @@
-import datadog.trace.agent.test.asserts.ListWriterAssert
+import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
+import io.opentelemetry.sdk.trace.SpanData
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.ErrorHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -11,14 +10,12 @@ import org.eclipse.jetty.servlet.ServletContextHandler
 import javax.servlet.Servlet
 import javax.servlet.http.HttpServletRequest
 
-import static datadog.trace.agent.test.asserts.TraceAssert.assertTrace
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.AUTH_REQUIRED
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.QUERY_PARAM
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.REDIRECT
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.SUCCESS
-import static datadog.trace.agent.test.utils.TraceUtils.basicSpan
 
 abstract class JettyServlet3Test extends AbstractServlet3Test<Server, ServletContextHandler> {
 
@@ -214,101 +211,38 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
     return new URI("http://localhost:$port/$context/dispatch/")
   }
 
+  boolean hasDispatchSpan(ServerEndpoint endpoint) {
+    true
+  }
+
   @Override
-  void cleanAndAssertTraces(
-    final int size,
-    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
-    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
-    final Closure spec) {
-
-    // If this is failing, make sure HttpServerTestAdvice is applied correctly.
-    TEST_WRITER.waitForTraces(size * 2)
-    // TEST_WRITER is a CopyOnWriteArrayList, which doesn't support remove()
-    def toRemove = TEST_WRITER.findAll {
-      it.size() == 1 && it.get(0).name == "TEST_SPAN"
-    }
-    assert toRemove.size() == size
-    toRemove.each {
-      assertTrace(it, 1) {
-        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
-      }
-    }
-    TEST_WRITER.removeAll(toRemove)
-
-    assertTraces(size) {
-      (1..size).each {
-        trace(it - 1, 3) {
-          def endpoint = lastRequest
-          span(0) {
-            operationName expectedOperationName()
-            errored endpoint.errored
-            // we can't reliably assert parent or child relationship here since both are tested.
-            tags {
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
-              "$Tags.COMPONENT" serverDecorator.component()
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-              "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
-              "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-              "$Tags.PEER_PORT" Long
-              "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
-              "$Tags.HTTP_METHOD" "GET"
-              "$Tags.HTTP_STATUS" endpoint.status
-              "servlet.context" "/$context"
-              "servlet.path" endpoint.status == 404 ? endpoint.path : "/dispatch$endpoint.path"
-              "servlet.dispatch" endpoint.path
-              "span.origin.type" {
-                it == TestServlet3.DispatchImmediate.name || it == TestServlet3.DispatchAsync.name
-              }
-              if (endpoint.errored) {
-                "error.msg" { it == null || it == EXCEPTION.body }
-                "error.type" { it == null || it == Exception.name }
-                "error.stack" { it == null || it instanceof String }
-              }
-              if (endpoint.query) {
-                "$DDTags.HTTP_QUERY" endpoint.query
-              }
-            }
-          }
-          span(1) {
-            operationName expectedOperationName()
-            childOf span(0)
-            errored endpoint.errored
-            tags {
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
-              "$Tags.COMPONENT" serverDecorator.component()
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-              "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
-              "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
-              "$Tags.PEER_PORT" Long
-              "$Tags.HTTP_URL" "${endpoint.resolve(address).toString().replace("/dispatch", "")}"
-              "$Tags.HTTP_METHOD" "GET"
-              "$Tags.HTTP_STATUS" endpoint.status
-              "servlet.context" "/$context"
-              "servlet.path" endpoint.path
-              "span.origin.type" {
-                it == TestServlet3.DispatchImmediate.name || it == TestServlet3.DispatchAsync.name || it == TestServlet3.Sync.name || it == TestServlet3.Async.name
-              }
-              if (endpoint.errored) {
-                "error.msg" { it == null || it == EXCEPTION.body }
-                "error.type" { it == null || it == Exception.name }
-                "error.stack" { it == null || it instanceof String }
-              }
-              if (endpoint.query) {
-                "$DDTags.HTTP_QUERY" endpoint.query
-              }
-            }
-          }
-          span(2) {
-            operationName "controller"
-            errored endpoint.path == "/exception"
-            tags {
-              if (endpoint.errored) {
-                "error.msg" { it == null || it == EXCEPTION.body }
-                "error.type" { it == null || it == Exception.name }
-                "error.stack" { it == null || it instanceof String }
-              }
-            }
-          }
+  void dispatchSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    trace.span(index) {
+      operationName expectedOperationName()
+      childOf((SpanData) parent)
+      errored endpoint.errored
+      tags {
+        "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
+        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+        "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
+        "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
+        "$Tags.PEER_PORT" Long
+        "$Tags.HTTP_URL" "${endpoint.resolve(address).toString().replace("/dispatch", "")}"
+        "$Tags.HTTP_METHOD" "GET"
+        "$Tags.HTTP_STATUS" endpoint.status
+        "servlet.context" "/$context"
+        "servlet.path" endpoint.path
+        "span.origin.type" {
+          it == TestServlet3.DispatchImmediate.name || it == TestServlet3.DispatchAsync.name || it == TestServlet3.Sync.name || it == TestServlet3.Async.name
+        }
+        if (endpoint.errored) {
+          "error.msg" { it == null || it == EXCEPTION.body }
+          "error.type" { it == null || it == Exception.name }
+          "error.stack" { it == null || it instanceof String }
+        }
+        if (endpoint.query) {
+          "$DDTags.HTTP_QUERY" endpoint.query
         }
       }
     }

--- a/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/dd-java-agent/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -134,22 +134,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(1) { // update
-          childOf(span(0))
-          tags {
-            "$DDTags.SERVICE_NAME" "hsqldb"
-            "$DDTags.RESOURCE_NAME" ~/^update /
-            "$DDTags.SPAN_TYPE" "sql"
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "hsqldb"
-            "$Tags.DB_INSTANCE" "test"
-            "$Tags.DB_USER" "sa"
-            "$Tags.DB_STATEMENT" ~/^update /
-            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
-          }
-        }
-        span(2) { // select
+        span(1) { // select
           childOf(span(0))
           tags {
             "$DDTags.SERVICE_NAME" "hsqldb"
@@ -161,6 +146,21 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+          }
+        }
+        span(2) { // update
+          childOf(span(0))
+          tags {
+            "$DDTags.SERVICE_NAME" "hsqldb"
+            "$DDTags.RESOURCE_NAME" ~/^update /
+            "$DDTags.SPAN_TYPE" "sql"
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "$Tags.DB_STATEMENT" ~/^update /
             "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
           }
         }
@@ -217,22 +217,7 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           }
         }
-        span(1) { // delete
-          childOf(span(0))
-          tags {
-            "$DDTags.SERVICE_NAME" "hsqldb"
-            "$DDTags.RESOURCE_NAME" ~/^delete /
-            "$DDTags.SPAN_TYPE" "sql"
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
-            "$Tags.DB_TYPE" "hsqldb"
-            "$Tags.DB_INSTANCE" "test"
-            "$Tags.DB_USER" "sa"
-            "$Tags.DB_STATEMENT" ~/^delete /
-            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
-          }
-        }
-        span(2) { // select
+        span(1) { // select
           childOf(span(0))
           tags {
             "$DDTags.SERVICE_NAME" "hsqldb"
@@ -244,6 +229,21 @@ class SpringJpaTest extends AgentTestRunner {
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
             "$Tags.DB_STATEMENT" ~/^select /
+            "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
+          }
+        }
+        span(2) { // delete
+          childOf(span(0))
+          tags {
+            "$DDTags.SERVICE_NAME" "hsqldb"
+            "$DDTags.RESOURCE_NAME" ~/^delete /
+            "$DDTags.SPAN_TYPE" "sql"
+            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
+            "$Tags.DB_TYPE" "hsqldb"
+            "$Tags.DB_INSTANCE" "test"
+            "$Tags.DB_USER" "sa"
+            "$Tags.DB_STATEMENT" ~/^delete /
             "span.origin.type" "org.hsqldb.jdbc.JDBCPreparedStatement"
           }
         }

--- a/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
+++ b/dd-java-agent/instrumentation/spring-webflux-5/src/test/groovy/SpringWebfluxTest.groovy
@@ -50,6 +50,22 @@ class SpringWebfluxTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
+          operationName "netty.request"
+          parent()
+          tags {
+            "$DDTags.RESOURCE_NAME" "GET $urlPathWithVariables"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
+            "$Tags.COMPONENT" "netty"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Long
+            "$Tags.HTTP_URL" url
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
+          }
+        }
+        span(1) {
           if (annotatedMethod == null) {
             // Functional API
             operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
@@ -57,7 +73,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             // Annotation API
             operationName TestController.getSimpleName() + "." + annotatedMethod
           }
-          childOf(span(1))
+          childOf(span(0))
           tags {
             "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "spring-webflux-controller"
@@ -72,22 +88,6 @@ class SpringWebfluxTest extends AgentTestRunner {
               // Annotation API
               "handler.type" TestController.getName()
             }
-          }
-        }
-        span(1) {
-          operationName "netty.request"
-          parent()
-          tags {
-            "$DDTags.RESOURCE_NAME" "GET $urlPathWithVariables"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
-            "$Tags.COMPONENT" "netty"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Long
-            "$Tags.HTTP_URL" url
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
           }
         }
       }
@@ -120,6 +120,22 @@ class SpringWebfluxTest extends AgentTestRunner {
       println TEST_WRITER
       trace(0, 3) {
         span(0) {
+          operationName "netty.request"
+          parent()
+          tags {
+            "$DDTags.RESOURCE_NAME" "GET $urlPathWithVariables"
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
+            "$Tags.COMPONENT" "netty"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "$Tags.PEER_HOSTNAME" "localhost"
+            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+            "$Tags.PEER_PORT" Long
+            "$Tags.HTTP_URL" url
+            "$Tags.HTTP_METHOD" "GET"
+            "$Tags.HTTP_STATUS" 200
+          }
+        }
+        span(1) {
           if (annotatedMethod == null) {
             // Functional API
             operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
@@ -127,7 +143,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             // Annotation API
             operationName TestController.getSimpleName() + "." + annotatedMethod
           }
-          childOf(span(1))
+          childOf(span(0))
           tags {
             "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "spring-webflux-controller"
@@ -144,22 +160,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             }
           }
         }
-        span(1) {
-          operationName "netty.request"
-          parent()
-          tags {
-            "$DDTags.RESOURCE_NAME" "GET $urlPathWithVariables"
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
-            "$Tags.COMPONENT" "netty"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.PEER_HOSTNAME" "localhost"
-            "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-            "$Tags.PEER_PORT" Long
-            "$Tags.HTTP_URL" url
-            "$Tags.HTTP_METHOD" "GET"
-            "$Tags.HTTP_STATUS" 200
-          }
-        }
         span(2) {
           if (annotatedMethod == null) {
             // Functional API
@@ -168,7 +168,7 @@ class SpringWebfluxTest extends AgentTestRunner {
             // Annotation API
             operationName "trace.annotation"
           }
-          childOf(span(0))
+          childOf(span(1))
           errored false
           tags {
             "$DDTags.RESOURCE_NAME" annotatedMethod == null ? "SpringWebFluxTestApplication.tracedMethod" : "TestController.tracedMethod"
@@ -249,19 +249,6 @@ class SpringWebfluxTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          operationName EchoHandlerFunction.getSimpleName() + ".handle"
-          childOf(span(1))
-          tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
-            "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "request.predicate" "(POST && /echo)"
-            "handler.type" { String tagVal ->
-              return tagVal.contains(EchoHandlerFunction.getName())
-            }
-          }
-        }
-        span(1) {
           operationName "netty.request"
           parent()
           tags {
@@ -277,9 +264,22 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_STATUS" 202
           }
         }
+        span(1) {
+          operationName EchoHandlerFunction.getSimpleName() + ".handle"
+          childOf(span(0))
+          tags {
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
+            "$Tags.COMPONENT" "spring-webflux-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "request.predicate" "(POST && /echo)"
+            "handler.type" { String tagVal ->
+              return tagVal.contains(EchoHandlerFunction.getName())
+            }
+          }
+        }
         span(2) {
           operationName "echo"
-          childOf(span(0))
+          childOf(span(1))
           tags {
             "$DDTags.RESOURCE_NAME" "echo"
             "$Tags.COMPONENT" "trace"
@@ -404,19 +404,6 @@ class SpringWebfluxTest extends AgentTestRunner {
       }
       trace(1, 2) {
         span(0) {
-          operationNameContains(SpringWebFluxTestApplication.getSimpleName() + "\$", ".handle")
-          childOf(span(1))
-          tags {
-            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
-            "$Tags.COMPONENT" "spring-webflux-controller"
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "request.predicate" "(GET && /double-greet)"
-            "handler.type" { String tagVal ->
-              return tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
-            }
-          }
-        }
-        span(1) {
           operationName "netty.request"
           parent()
           tags {
@@ -430,6 +417,19 @@ class SpringWebfluxTest extends AgentTestRunner {
             "$Tags.HTTP_URL" finalUrl
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200
+          }
+        }
+        span(1) {
+          operationNameContains(SpringWebFluxTestApplication.getSimpleName() + "\$", ".handle")
+          childOf(span(0))
+          tags {
+            "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
+            "$Tags.COMPONENT" "spring-webflux-controller"
+            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+            "request.predicate" "(GET && /double-greet)"
+            "handler.type" { String tagVal ->
+              return tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
+            }
           }
         }
       }
@@ -451,6 +451,22 @@ class SpringWebfluxTest extends AgentTestRunner {
       responses.eachWithIndex { def response, int i ->
         trace(i, 2) {
           span(0) {
+            operationName "netty.request"
+            parent()
+            tags {
+              "$DDTags.RESOURCE_NAME" "GET $urlPathWithVariables"
+              "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
+              "$Tags.COMPONENT" "netty"
+              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
+              "$Tags.PEER_HOSTNAME" "localhost"
+              "$Tags.PEER_HOST_IPV4" "127.0.0.1"
+              "$Tags.PEER_PORT" Long
+              "$Tags.HTTP_URL" url
+              "$Tags.HTTP_METHOD" "GET"
+              "$Tags.HTTP_STATUS" 200
+            }
+          }
+          span(1) {
             if (annotatedMethod == null) {
               // Functional API
               operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
@@ -458,7 +474,7 @@ class SpringWebfluxTest extends AgentTestRunner {
               // Annotation API
               operationName TestController.getSimpleName() + "." + annotatedMethod
             }
-            childOf(span(1))
+            childOf(span(0))
             tags {
               "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
               "$Tags.COMPONENT" "spring-webflux-controller"
@@ -473,22 +489,6 @@ class SpringWebfluxTest extends AgentTestRunner {
                 // Annotation API
                 "handler.type" TestController.getName()
               }
-            }
-          }
-          span(1) {
-            operationName "netty.request"
-            parent()
-            tags {
-              "$DDTags.RESOURCE_NAME" "GET $urlPathWithVariables"
-              "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_SERVER
-              "$Tags.COMPONENT" "netty"
-              "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-              "$Tags.PEER_HOSTNAME" "localhost"
-              "$Tags.PEER_HOST_IPV4" "127.0.0.1"
-              "$Tags.PEER_PORT" Long
-              "$Tags.HTTP_URL" url
-              "$Tags.HTTP_METHOD" "GET"
-              "$Tags.HTTP_STATUS" 200
             }
           }
         }

--- a/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
+++ b/dd-java-agent/instrumentation/spymemcached-2.12/src/test/groovy/datadog/trace/instrumentation/spymemcached/SpymemcachedTest.groovy
@@ -274,8 +274,8 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "get", null, "hit")
-        getSpan(it, 2, "add")
+        getSpan(it, 1, "add")
+        getSpan(it, 2, "get", null, "hit")
       }
     }
   }
@@ -308,8 +308,8 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "get", null, "miss")
-        getSpan(it, 2, "delete")
+        getSpan(it, 1, "delete")
+        getSpan(it, 2, "get", null, "miss")
       }
     }
   }
@@ -340,8 +340,8 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "get", null, "hit")
-        getSpan(it, 2, "replace")
+        getSpan(it, 1, "replace")
+        getSpan(it, 2, "get", null, "hit")
       }
     }
   }
@@ -373,9 +373,9 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 4) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "get", null, "hit")
+        getSpan(it, 1, "gets")
         getSpan(it, 2, "append")
-        getSpan(it, 3, "gets")
+        getSpan(it, 3, "get", null, "hit")
       }
     }
   }
@@ -392,9 +392,9 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 4) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "get", null, "hit")
+        getSpan(it, 1, "gets")
         getSpan(it, 2, "prepend")
-        getSpan(it, 3, "gets")
+        getSpan(it, 3, "get", null, "hit")
       }
     }
   }
@@ -410,8 +410,8 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "cas")
-        getSpan(it, 2, "gets")
+        getSpan(it, 1, "gets")
+        getSpan(it, 2, "cas")
       }
     }
   }
@@ -506,8 +506,8 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "get", null, "hit")
-        getSpan(it, 2, "decr")
+        getSpan(it, 1, "decr")
+        getSpan(it, 2, "get", null, "hit")
       }
     }
   }
@@ -555,8 +555,8 @@ class SpymemcachedTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         getParentSpan(it, 0)
-        getSpan(it, 1, "get", null, "hit")
-        getSpan(it, 2, "incr")
+        getSpan(it, 1, "incr")
+        getSpan(it, 2, "get", null, "hit")
       }
     }
   }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -26,7 +26,7 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
     SayTracedHello.fromCallableWhenDisabled()
 
     expect:
-    TEST_WRITER == []
+    TEST_WRITER.traces == []
   }
 
   def "test custom annotation based trace"() {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -33,10 +33,7 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
     expect:
     new AnnotationTracedCallable().call() == "Hello!"
 
-    when:
-    TEST_WRITER.waitForTraces(1)
-
-    then:
+    and:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -124,6 +124,16 @@ class TraceAnnotationsTest extends AgentTestRunner {
           }
         }
         span(1) {
+          operationName "trace.annotation"
+          childOf span(0)
+          errored false
+          tags {
+            "$DDTags.SERVICE_NAME" "test"
+            "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHello"
+            "$Tags.COMPONENT" "trace"
+          }
+        }
+        span(2) {
           operationName "SAY_HA"
           childOf span(0)
           errored false
@@ -131,16 +141,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
             "$DDTags.SERVICE_NAME" "test"
             "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHA"
             "$DDTags.SPAN_TYPE" "DB"
-            "$Tags.COMPONENT" "trace"
-          }
-        }
-        span(2) {
-          operationName "trace.annotation"
-          childOf span(0)
-          errored false
-          tags {
-            "$DDTags.SERVICE_NAME" "test"
-            "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHello"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -167,6 +167,16 @@ class TraceAnnotationsTest extends AgentTestRunner {
           }
         }
         span(1) {
+          operationName "trace.annotation"
+          childOf span(0)
+          errored false
+          tags {
+            "$DDTags.SERVICE_NAME" "test"
+            "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHello"
+            "$Tags.COMPONENT" "trace"
+          }
+        }
+        span(2) {
           operationName "SAY_HA"
           childOf span(0)
           errored false
@@ -174,16 +184,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
             "$DDTags.SERVICE_NAME" "test"
             "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHA"
             "$DDTags.SPAN_TYPE" "DB"
-            "$Tags.COMPONENT" "trace"
-          }
-        }
-        span(2) {
-          operationName "trace.annotation"
-          childOf span(0)
-          errored false
-          tags {
-            "$DDTags.SERVICE_NAME" "test"
-            "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHello"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -210,6 +210,16 @@ class TraceAnnotationsTest extends AgentTestRunner {
           }
         }
         span(1) {
+          operationName "trace.annotation"
+          childOf span(0)
+          errored false
+          tags {
+            "$DDTags.SERVICE_NAME" "test"
+            "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHello"
+            "$Tags.COMPONENT" "trace"
+          }
+        }
+        span(2) {
           operationName "SAY_HA"
           childOf span(0)
           errored false
@@ -217,16 +227,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
             "$DDTags.SERVICE_NAME" "test"
             "$DDTags.RESOURCE_NAME" "EARTH"
             "$DDTags.SPAN_TYPE" "DB"
-            "$Tags.COMPONENT" "trace"
-          }
-        }
-        span(2) {
-          operationName "trace.annotation"
-          childOf span(0)
-          errored false
-          tags {
-            "$DDTags.SERVICE_NAME" "test"
-            "$DDTags.RESOURCE_NAME" "SayTracedHello.sayHello"
             "$Tags.COMPONENT" "trace"
           }
         }

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -313,7 +313,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
         return "Howdy!"
       }
     }.call()
-    TEST_WRITER.waitForTraces(2)
 
     then:
     assertTraces(2) {

--- a/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/dd-java-agent/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -31,10 +31,7 @@ class TraceConfigTest extends AgentTestRunner {
     expect:
     new ConfigTracedCallable().call() == "Hello!"
 
-    when:
-    TEST_WRITER.waitForTraces(1)
-
-    then:
+    and:
     assertTraces(1) {
       trace(0, 1) {
         span(0) {

--- a/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
+++ b/dd-java-agent/instrumentation/twilio/src/test/groovy/test/TwilioClientTest.groovy
@@ -376,7 +376,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(2) {
           operationName "http.request"
-          errored false
+          errored true
           tags {
             "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "apache-httpclient"
@@ -389,7 +389,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(3) {
           operationName "http.request"
-          errored true
+          errored false
           tags {
             "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "apache-httpclient"
@@ -510,11 +510,9 @@ class TwilioClientTest extends AgentTestRunner {
             "twilio.status" "sent"
           }
         }
-        // Spans are reported in reverse order of completion,
-        // so the error span is last even though it happened first.
         span(3) {
           operationName "http.request"
-          errored false
+          errored true
           tags {
             "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "apache-httpclient"
@@ -527,7 +525,7 @@ class TwilioClientTest extends AgentTestRunner {
         }
         span(4) {
           operationName "http.request"
-          errored true
+          errored false
           tags {
             "$DDTags.SPAN_TYPE" DDSpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "apache-httpclient"

--- a/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxHttpServerTest.groovy
+++ b/dd-java-agent/instrumentation/vertx/src/test/groovy/server/VertxHttpServerTest.groovy
@@ -67,11 +67,6 @@ class VertxHttpServerTest extends HttpServerTest<Vertx, NettyHttpServerDecorator
     false
   }
 
-  @Override
-  boolean reorderControllerSpan() {
-    true
-  }
-
   static class VertxWebTestServer extends AbstractVerticle {
 
     @Override

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/AgentTestRunner.java
@@ -16,7 +16,6 @@ import groovy.transform.stc.SimpleType;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.SimpleSpansProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.TraceId;
 import io.opentelemetry.trace.Tracer;
@@ -85,8 +84,7 @@ public abstract class AgentTestRunner extends DDSpecification {
     ((Logger) LoggerFactory.getLogger("datadog")).setLevel(Level.DEBUG);
 
     TEST_WRITER = new ListWriter();
-    OpenTelemetrySdk.getTracerFactory()
-        .addSpanProcessor(SimpleSpansProcessor.newBuilder(TEST_WRITER).build());
+    OpenTelemetrySdk.getTracerFactory().addSpanProcessor(TEST_WRITER);
     TEST_TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
     AgentTracer.registerIfAbsent(new AgentTracerImpl(TEST_TRACER));

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/ListWriter.java
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/ListWriter.java
@@ -1,38 +1,58 @@
 package datadog.trace.agent.test;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.TreeTraverser;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.trace.SpanId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class ListWriter extends CopyOnWriteArrayList<List<SpanData>> implements SpanExporter {
+public class ListWriter extends CopyOnWriteArrayList<List<SpanData>> implements SpanProcessor {
 
+  // not using span startEpochNanos since that is not strictly increasing so can lead to ties
+  private final Map<SpanId, Integer> spanOrders = new ConcurrentHashMap<>();
+  private final AtomicInteger nextSpanOrder = new AtomicInteger();
   private final Object lock = new Object();
 
   @Override
-  public ResultCode export(final List<SpanData> spans) {
+  public void onStart(final ReadableSpan readableSpan) {
+    spanOrders.put(readableSpan.getSpanContext().getSpanId(), nextSpanOrder.getAndIncrement());
+  }
+
+  @Override
+  public void onEnd(final ReadableSpan readableSpan) {
+    final SpanData span = readableSpan.toSpanData();
     synchronized (lock) {
-      for (final SpanData span : spans) {
-        boolean found = false;
-        for (final List<SpanData> trace : this) {
-          if (trace.get(0).getTraceId().equals(span.getTraceId())) {
-            trace.add(0, span);
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          final List<SpanData> trace = new CopyOnWriteArrayList<>();
+      boolean found = false;
+      for (final List<SpanData> trace : this) {
+        if (trace.get(0).getTraceId().equals(span.getTraceId())) {
           trace.add(span);
-          add(trace);
+          found = true;
+          break;
         }
       }
+      if (!found) {
+        final List<SpanData> trace = new CopyOnWriteArrayList<>();
+        trace.add(span);
+        add(trace);
+      }
+      sort();
       lock.notifyAll();
     }
-    return ResultCode.SUCCESS;
   }
 
   public void waitForTraces(final int number) throws InterruptedException, TimeoutException {
@@ -55,6 +75,12 @@ public class ListWriter extends CopyOnWriteArrayList<List<SpanData>> implements 
                 + " total trace(s)");
       }
     }
+  }
+
+  @Override
+  public void clear() {
+    super.clear();
+    spanOrders.clear();
   }
 
   @Override
@@ -82,5 +108,112 @@ public class ListWriter extends CopyOnWriteArrayList<List<SpanData>> implements 
       }
     }
     return false;
+  }
+
+  private void sort() {
+    sortTraces();
+    for (final List<SpanData> trace : this) {
+      sort(trace);
+    }
+  }
+
+  private void sortTraces() {
+    // cannot sort CopyOnWriteArrayList in Java 7 (leads to UnsupportedOperationException)
+    final List<List<SpanData>> copy = new ArrayList<>(this);
+    Collections.sort(
+        copy,
+        new Comparator<List<SpanData>>() {
+          @Override
+          public int compare(final List<SpanData> trace1, final List<SpanData> trace2) {
+            return Longs.compare(getMinSpanOrder(trace1), getMinSpanOrder(trace2));
+          }
+        });
+    super.clear(); // explicitly calling super in order to bypass clearing spanOrders
+    addAll(copy);
+  }
+
+  private long getMinSpanOrder(final List<SpanData> spans) {
+    long min = Long.MAX_VALUE;
+    for (final SpanData span : spans) {
+      min = Math.min(min, getSpanOrder(span));
+    }
+    return min;
+  }
+
+  private void sort(final List<SpanData> trace) {
+
+    final Map<SpanId, Node> lookup = new HashMap<>();
+    for (final SpanData span : trace) {
+      lookup.put(span.getSpanId(), new Node(span));
+    }
+
+    for (final Node node : lookup.values()) {
+      if (node.span.getParentSpanId().isValid()) {
+        final Node parentNode = lookup.get(node.span.getParentSpanId());
+        if (parentNode != null) {
+          parentNode.childNodes.add(node);
+          node.root = false;
+        }
+      }
+    }
+
+    final List<Node> rootNodes = new ArrayList<>();
+    for (final Node node : lookup.values()) {
+      sortOneLevel(node.childNodes);
+      if (node.root) {
+        rootNodes.add(node);
+      }
+    }
+    sortOneLevel(rootNodes);
+
+    final TreeTraverser<Node> traverser =
+        new TreeTraverser<Node>() {
+          @Override
+          public Iterable<Node> children(final Node node) {
+            return node.childNodes;
+          }
+        };
+
+    final List<Node> orderedNodes = new ArrayList<>();
+    for (final Node rootNode : rootNodes) {
+      Iterables.addAll(orderedNodes, traverser.preOrderTraversal(rootNode));
+    }
+
+    final List<SpanData> orderedSpans = new ArrayList<>();
+    for (final Node node : orderedNodes) {
+      orderedSpans.add(node.span);
+    }
+    trace.clear();
+    trace.addAll(orderedSpans);
+  }
+
+  private void sortOneLevel(final List<Node> nodes) {
+    Collections.sort(
+        nodes,
+        new Comparator<Node>() {
+          @Override
+          public int compare(final Node node1, final Node node2) {
+            return Ints.compare(getSpanOrder(node1.span), getSpanOrder(node2.span));
+          }
+        });
+  }
+
+  private int getSpanOrder(final SpanData span) {
+    final Integer order = spanOrders.get(span.getSpanId());
+    if (order == null) {
+      throw new IllegalStateException("order not found for span: " + span);
+    }
+    return order;
+  }
+
+  private static class Node {
+
+    private final SpanData span;
+    private final List<Node> childNodes = new ArrayList<>();
+    private boolean root = true;
+
+    private Node(final SpanData span) {
+      this.span = span;
+    }
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
@@ -12,13 +12,14 @@ import org.spockframework.runtime.model.TextPosition
 import static TraceAssert.assertTrace
 
 class ListWriterAssert {
+  private final List<List<SpanData>> traces
   private final ListWriter writer
-  private final int size
+
   private final Set<Integer> assertedIndexes = new HashSet<>()
 
-  private ListWriterAssert(ListWriter writer) {
+  private ListWriterAssert(List<List<SpanData>> traces, ListWriter writer) {
+    this.traces = traces
     this.writer = writer
-    size = writer.size()
   }
 
   static void assertTraces(ListWriter writer, int expectedSize,
@@ -26,8 +27,9 @@ class ListWriterAssert {
                            @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     try {
       writer.waitForTraces(expectedSize)
-      assert writer.size() == expectedSize
-      def asserter = new ListWriterAssert(writer)
+      def traces = new ArrayList<>(writer.traces)
+      assert traces.size() == expectedSize
+      def asserter = new ListWriterAssert(traces, writer)
       def clone = (Closure) spec.clone()
       clone.delegate = asserter
       clone.resolveStrategy = Closure.DELEGATE_FIRST
@@ -53,21 +55,18 @@ class ListWriterAssert {
     }
   }
 
-  List<SpanData> trace(int index) {
-    return writer.get(index)
+  List<List<SpanData>> getTraces() {
+    return traces
   }
 
   void trace(int index, int expectedSize,
              @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.TraceAssert'])
              @DelegatesTo(value = TraceAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
-    if (index >= size) {
+    if (index >= traces.size()) {
       throw new ArrayIndexOutOfBoundsException(index)
     }
-    if (writer.size() != size) {
-      throw new ConcurrentModificationException("ListWriter modified during assertion")
-    }
     assertedIndexes.add(index)
-    assertTrace(writer.get(index), expectedSize, spec)
+    assertTrace(writer, traces[index][0].traceId, expectedSize, spec)
   }
 
   // this doesn't provide any functionality, just a self-documenting marker
@@ -76,6 +75,6 @@ class ListWriterAssert {
   }
 
   void assertTracesAllVerified() {
-    assert assertedIndexes.size() == size
+    assert assertedIndexes.size() == traces.size()
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/ListWriterAssert.groovy
@@ -70,6 +70,11 @@ class ListWriterAssert {
     assertTrace(writer.get(index), expectedSize, spec)
   }
 
+  // this doesn't provide any functionality, just a self-documenting marker
+  void sortTraces(Closure callback) {
+    callback.call()
+  }
+
   void assertTracesAllVerified() {
     assert assertedIndexes.size() == size
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
@@ -1,36 +1,39 @@
 package datadog.trace.agent.test.asserts
 
 import com.google.common.base.Stopwatch
+import datadog.trace.agent.test.ListWriter
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import io.opentelemetry.sdk.trace.SpanData
+import io.opentelemetry.trace.TraceId
 
 import java.util.concurrent.TimeUnit
 
 import static SpanAssert.assertSpan
 
 class TraceAssert {
-  private final List<SpanData> trace
-  private final int size
+  private final List<SpanData> spans
+
   private final Set<Integer> assertedIndexes = new HashSet<>()
 
-  private TraceAssert(trace) {
-    this.trace = trace
-    size = trace.size()
+  private TraceAssert(spans) {
+    this.spans = spans
   }
 
-  static void assertTrace(List<SpanData> trace, int expectedSize,
+  static void assertTrace(ListWriter writer, TraceId traceId, int expectedSize,
                           @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.TraceAssert'])
                           @DelegatesTo(value = TraceAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+    def spans = getTrace(writer, traceId)
     Stopwatch stopwatch = Stopwatch.createStarted()
     while (stopwatch.elapsed(TimeUnit.SECONDS) < 10) {
-      if (trace.size() == expectedSize) {
+      if (spans.size() == expectedSize) {
         break
       }
       Thread.sleep(10)
+      spans = getTrace(writer, traceId)
     }
-    assert trace.size() == expectedSize
-    def asserter = new TraceAssert(trace)
+    assert spans.size() == expectedSize
+    def asserter = new TraceAssert(spans)
     def clone = (Closure) spec.clone()
     clone.delegate = asserter
     clone.resolveStrategy = Closure.DELEGATE_FIRST
@@ -38,25 +41,26 @@ class TraceAssert {
     asserter.assertSpansAllVerified()
   }
 
+  List<SpanData> getSpans() {
+    return spans
+  }
+
   SpanData span(int index) {
-    trace.get(index)
+    spans.get(index)
   }
 
   void span(int index, @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.SpanAssert']) @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
-    if (index >= size) {
+    if (index >= spans.size()) {
       throw new ArrayIndexOutOfBoundsException(index)
     }
-    if (trace.size() != size) {
-      throw new ConcurrentModificationException("Trace modified during assertion")
-    }
     assertedIndexes.add(index)
-    assertSpan(trace.get(index), spec)
+    assertSpan(spans.get(index), spec)
   }
 
   void span(String name, @ClosureParams(value = SimpleType, options = ['datadog.trace.agent.test.asserts.SpanAssert']) @DelegatesTo(value = SpanAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     int index = -1
-    for (int i = 0; i < trace.size(); i++) {
-      if (trace[i].name == name) {
+    for (int i = 0; i < spans.size(); i++) {
+      if (spans[i].name == name) {
         index = i
         break
       }
@@ -70,6 +74,15 @@ class TraceAssert {
   }
 
   void assertSpansAllVerified() {
-    assert assertedIndexes.size() == size
+    assert assertedIndexes.size() == spans.size()
+  }
+
+  private static List<SpanData> getTrace(ListWriter writer, TraceId traceId) {
+    for (List<SpanData> trace : writer.getTraces()) {
+      if (trace[0].traceId == traceId) {
+        return trace
+      }
+    }
+    throw new AssertionError("Trace not found: " + traceId)
   }
 }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/asserts/TraceAssert.groovy
@@ -64,6 +64,11 @@ class TraceAssert {
     span(index, spec)
   }
 
+  // this doesn't provide any functionality, just a self-documenting marker
+  void sortSpans(Closure callback) {
+    callback.call()
+  }
+
   void assertSpansAllVerified() {
     assert assertedIndexes.size() == size
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -179,8 +179,8 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
     assertTraces(1) {
       trace(0, 3 + extraClientSpans()) {
         basicSpan(it, 0, "parent")
-        basicSpan(it, 1, "child", null, span(0))
-        clientSpan(it, 2, span(0), method, false)
+        clientSpan(it, 1, span(0), method, false)
+        basicSpan(it, 2 + extraClientSpans(), "child", null, span(0))
       }
     }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -102,9 +102,7 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
   def "basic #method request with parent"() {
     when:
     def status = runUnderTrace("parent") {
-      def val = doRequest(method, server.address.resolve("/success"))
-      blockUntilChildSpansFinished(2)
-      return val
+      doRequest(method, server.address.resolve("/success"))
     }
 
     then:

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpClientTest.groovy
@@ -190,8 +190,6 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
     when:
     def status = doRequest(method, server.address.resolve("/success"), ["is-dd-server": "false"]) {
       runUnderTrace("callback") {
-        // Ensure consistent ordering of traces for assertion.
-        TEST_WRITER.waitForTraces(1)
       }
     }
 

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -80,15 +80,6 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     false
   }
 
-  // Return the handler span's name
-  String reorderHandlerSpan() {
-    null
-  }
-
-  boolean reorderControllerSpan() {
-    false
-  }
-
   boolean redirectHasBody() {
     false
   }
@@ -417,37 +408,6 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     }
     assert toRemove.size() == size
     TEST_WRITER.removeAll(toRemove)
-
-    if (reorderControllerSpan() || reorderHandlerSpan()) {
-      // this is needed temporarily to get DropWizardAsyncTest and GrizzlyAsyncTest to pass
-      // but no worries, this will go away later in this PR once the span re-ordering is no longer needed
-      Thread.sleep(100)
-    }
-
-    if (reorderHandlerSpan()) {
-      TEST_WRITER.each {
-        def controllerSpan = it.find {
-          it.name == reorderHandlerSpan()
-        }
-        if (controllerSpan) {
-          it.remove(controllerSpan)
-          it.add(controllerSpan)
-        }
-      }
-    }
-
-    if (reorderControllerSpan() || reorderHandlerSpan()) {
-      // Some frameworks close the handler span before the controller returns, so we need to manually reorder it.
-      TEST_WRITER.each {
-        def controllerSpan = it.find {
-          it.name == "controller"
-        }
-        if (controllerSpan) {
-          it.remove(controllerSpan)
-          it.add(controllerSpan)
-        }
-      }
-    }
 
     assertTraces(size, spec)
   }

--- a/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
+++ b/dd-java-agent/testing/src/main/groovy/datadog/trace/agent/test/base/HttpServerTest.groovy
@@ -2,15 +2,12 @@ package datadog.trace.agent.test.base
 
 import datadog.trace.agent.decorator.HttpServerDecorator
 import datadog.trace.agent.test.AgentTestRunner
-import datadog.trace.agent.test.asserts.ListWriterAssert
 import datadog.trace.agent.test.asserts.TraceAssert
 import datadog.trace.agent.test.utils.OkHttpUtils
 import datadog.trace.agent.test.utils.PortUtils
 import datadog.trace.api.DDSpanTypes
 import datadog.trace.api.DDTags
 import datadog.trace.instrumentation.api.Tags
-import groovy.transform.stc.ClosureParams
-import groovy.transform.stc.SimpleType
 import io.opentelemetry.sdk.trace.SpanData
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -21,7 +18,6 @@ import spock.lang.Unroll
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import static datadog.trace.agent.test.asserts.TraceAssert.assertTrace
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.ERROR
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.EXCEPTION
 import static datadog.trace.agent.test.base.HttpServerTest.ServerEndpoint.NOT_FOUND
@@ -77,6 +73,14 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
   abstract String expectedOperationName()
 
   boolean hasHandlerSpan() {
+    false
+  }
+
+  boolean hasRenderSpan(ServerEndpoint endpoint) {
+    false
+  }
+
+  boolean hasDispatchSpan(ServerEndpoint endpoint) {
     false
   }
 
@@ -175,22 +179,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     }
 
     and:
-    cleanAndAssertTraces(count) {
-      (1..count).eachWithIndex { val, i ->
-        if (hasHandlerSpan()) {
-          trace(i, 3) {
-            serverSpan(it, 0)
-            handlerSpan(it, 1, span(0))
-            controllerSpan(it, 2, span(1))
-          }
-        } else {
-          trace(i, 2) {
-            serverSpan(it, 0)
-            controllerSpan(it, 1, span(0))
-          }
-        }
-      }
-    }
+    assertTheTraces(count)
 
     where:
     method = "GET"
@@ -212,20 +201,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     response.body().string() == SUCCESS.body
 
     and:
-    cleanAndAssertTraces(1) {
-      if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, traceId, parentId)
-          handlerSpan(it, 1, span(0))
-          controllerSpan(it, 2, span(1))
-        }
-      } else {
-        trace(0, 2) {
-          serverSpan(it, 0, traceId, parentId)
-          controllerSpan(it, 1, span(0))
-        }
-      }
-    }
+    assertTheTraces(1, traceId, parentId)
 
     where:
     method = "GET"
@@ -244,20 +220,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     response.body().string() == endpoint.body
 
     and:
-    cleanAndAssertTraces(1) {
-      if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, endpoint)
-          handlerSpan(it, 1, span(0), method, endpoint)
-          controllerSpan(it, 2, span(1))
-        }
-      } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, endpoint)
-          controllerSpan(it, 1, span(0))
-        }
-      }
-    }
+    assertTheTraces(1, null, null, method, endpoint)
 
     where:
     method = "GET"
@@ -277,20 +240,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     response.body().contentLength() < 1 || redirectHasBody()
 
     and:
-    cleanAndAssertTraces(1) {
-      if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, REDIRECT)
-          handlerSpan(it, 1, span(0), method, REDIRECT)
-          controllerSpan(it, 2, span(1))
-        }
-      } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, REDIRECT)
-          controllerSpan(it, 1, span(0))
-        }
-      }
-    }
+    assertTheTraces(1, null, null, method, REDIRECT)
 
     where:
     method = "GET"
@@ -307,20 +257,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     response.body().string() == ERROR.body
 
     and:
-    cleanAndAssertTraces(1) {
-      if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, ERROR)
-          handlerSpan(it, 1, span(0), method, ERROR)
-          controllerSpan(it, 2, span(1))
-        }
-      } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, ERROR)
-          controllerSpan(it, 1, span(0))
-        }
-      }
-    }
+    assertTheTraces(1, null, null, method, ERROR)
 
     where:
     method = "GET"
@@ -339,20 +276,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     }
 
     and:
-    cleanAndAssertTraces(1) {
-      if (hasHandlerSpan()) {
-        trace(0, 3) {
-          serverSpan(it, 0, null, null, method, EXCEPTION)
-          handlerSpan(it, 1, span(0), method, EXCEPTION)
-          controllerSpan(it, 2, span(1), EXCEPTION.body)
-        }
-      } else {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, EXCEPTION)
-          controllerSpan(it, 1, span(0), EXCEPTION.body)
-        }
-      }
-    }
+    assertTheTraces(1, null, null, method, EXCEPTION, EXCEPTION.body)
 
     where:
     method = "GET"
@@ -369,18 +293,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
     response.code() == NOT_FOUND.status
 
     and:
-    cleanAndAssertTraces(1) {
-      if (hasHandlerSpan()) {
-        trace(0, 2) {
-          serverSpan(it, 0, null, null, method, NOT_FOUND)
-          handlerSpan(it, 1, span(0), method, NOT_FOUND)
-        }
-      } else {
-        trace(0, 1) {
-          serverSpan(it, 0, null, null, method, NOT_FOUND)
-        }
-      }
-    }
+    assertTheTraces(1, null, null, method, NOT_FOUND)
 
     where:
     method = "GET"
@@ -389,27 +302,47 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
 
   //FIXME: add tests for POST with large/chunked data
 
-  void cleanAndAssertTraces(
-    final int size,
-    @ClosureParams(value = SimpleType, options = "datadog.trace.agent.test.asserts.ListWriterAssert")
-    @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST)
-    final Closure spec) {
-
-    // If this is failing, make sure HttpServerTestAdvice is applied correctly.
-    TEST_WRITER.waitForTraces(size * 2)
-    // TEST_WRITER is a CopyOnWriteArrayList, which doesn't support remove()
-    def toRemove = TEST_WRITER.findAll {
-      it.size() == 1 && it.get(0).name == "TEST_SPAN"
+  void assertTheTraces(int size, String traceID = null, String parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS, String errorMessage = null) {
+    def spanCount = 1 // server span
+    if (hasDispatchSpan(endpoint)) {
+      spanCount++
     }
-    toRemove.each {
-      assertTrace(it, 1) {
-        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+    if (hasHandlerSpan()) {
+      spanCount++
+    }
+    if (endpoint != NOT_FOUND) {
+      spanCount++ // controller span
+      if (hasRenderSpan(endpoint)) {
+        spanCount++
       }
     }
-    assert toRemove.size() == size
-    TEST_WRITER.removeAll(toRemove)
-
-    assertTraces(size, spec)
+    assertTraces(size * 2) {
+      (0..size - 1).each {
+        trace(it * 2, 1) {
+          basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+        }
+        trace(it * 2 + 1, spanCount) {
+          def spanIndex = 0
+          serverSpan(it, spanIndex++, traceID, parentID, method, endpoint)
+          if (hasDispatchSpan(endpoint)) {
+            dispatchSpan(it, spanIndex++, span(0), method, endpoint)
+          }
+          if (hasHandlerSpan()) {
+            handlerSpan(it, spanIndex++, span(0), method, endpoint)
+          }
+          if (endpoint != NOT_FOUND) {
+            if (hasHandlerSpan() || hasDispatchSpan(endpoint)) { // currently there are no tests which have both
+              controllerSpan(it, spanIndex++, span(1), errorMessage)
+            } else {
+              controllerSpan(it, spanIndex++, span(0), errorMessage)
+            }
+            if (hasRenderSpan(endpoint)) {
+              renderSpan(it, spanIndex++, span(0), method, endpoint)
+            }
+          }
+        }
+      }
+    }
   }
 
   void controllerSpan(TraceAssert trace, int index, Object parent, String errorMessage = null) {
@@ -427,6 +360,14 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
 
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     throw new UnsupportedOperationException("handlerSpan not implemented in " + getClass().name)
+  }
+
+  void renderSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    throw new UnsupportedOperationException("renderSpan not implemented in " + getClass().name)
+  }
+
+  void dispatchSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
+    throw new UnsupportedOperationException("dispatchSpan not implemented in " + getClass().name)
   }
 
   // parent span must be cast otherwise it breaks debugging classloading (junit loads it early)

--- a/dd-java-agent/testing/testing.gradle
+++ b/dd-java-agent/testing/testing.gradle
@@ -7,6 +7,7 @@ excludedClassesCoverage += [
   'datadog.trace.agent.test.base.*',
   'datadog.trace.agent.test.log.*',
   'datadog.trace.agent.test.AgentTestRunner',
+  'datadog.trace.agent.test.ListWriter.*',
   'datadog.trace.agent.test.utils.*',
   // Avoid applying jacoco instrumentation to classes instrumented by tested agent
   'context.ContextTestInstrumentation**',


### PR DESCRIPTION
The main change here is to order the spans exposed for test verification.

Given:

```
spanA
├── spanB
│   ├── spanC
│   ├── spanD
├── spanE
    ├── spanF
    └── spanG
```

The spans are now exposed in the following order for test verification:

* spanA
* spanB
* spanC
* spanD
* spanE
* spanF
* spanG

(where spans with the same parent are ordered by _start time_ which is more predictable than ordering by _end time_)