### PR TITLE
Move OpenTelemetry SDK out of the bootstrap loader

### DIFF
--- a/agent-bootstrap/agent-bootstrap.gradle
+++ b/agent-bootstrap/agent-bootstrap.gradle
@@ -8,7 +8,6 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   compile project(':trace-api')
   compile deps.opentelemetryApi
-  compile(project(path: ':opentelemetry-sdk', configuration: 'shadow'))
   compile deps.slf4j
   compile group: 'org.slf4j', name: 'slf4j-simple', version: versions.slf4j
   // ^ Generally a bad idea for libraries, but we're shadowing.

--- a/agent-tooling/agent-tooling.gradle
+++ b/agent-tooling/agent-tooling.gradle
@@ -18,7 +18,13 @@ dependencies {
     exclude group: 'org.slf4j', module: 'slf4j-simple'
   }
   compile deps.opentelemetryApi
-  compile(project(path: ':opentelemetry-sdk', configuration: 'shadow'))
+
+  // Gradle is happy with just single compile dependency on :java-agent:opentelemetry-sdk, configuration: shadow
+  // but Intellij doesn't understand this (see https://github.com/johnrengelman/shadow/issues/264)
+  // these two lines are a workaround to make Intellij happy also
+  compileOnly deps.opentelemetrySdk
+  runtime(project(path: ':opentelemetry-sdk', configuration: 'shadow'))
+
   compile group: 'com.blogspot.mydailyjava', name: 'weak-lock-free', version: '0.15'
   compile deps.bytebuddy
   compile deps.bytebuddyagent

--- a/agent-tooling/agent-tooling.gradle
+++ b/agent-tooling/agent-tooling.gradle
@@ -18,12 +18,7 @@ dependencies {
     exclude group: 'org.slf4j', module: 'slf4j-simple'
   }
   compile deps.opentelemetryApi
-
-  // Gradle is happy with just single compile dependency on :java-agent:opentelemetry-sdk, configuration: shadow
-  // but Intellij doesn't understand this (see https://github.com/johnrengelman/shadow/issues/264)
-  // these two lines are a workaround to make Intellij happy also
-  compileOnly deps.opentelemetrySdk
-  runtime(project(path: ':opentelemetry-sdk', configuration: 'shadow'))
+  compile deps.opentelemetrySdk
 
   compile group: 'com.blogspot.mydailyjava', name: 'weak-lock-free', version: '0.15'
   compile deps.bytebuddy

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -80,7 +80,7 @@ configurations {
   // exclude bootstrap dependencies from shadowJar
   runtime.exclude module: deps.slf4j
   runtime.exclude group: 'org.slf4j'
-  runtime.exclude group: 'io.opentelemetry'
+  runtime.exclude group: 'io.opentelemetry', module: 'opentelemetry-api'
 }
 
 shadowJar {
@@ -101,7 +101,6 @@ shadowJar {
   dependencies {
     exclude(project(':agent-bootstrap'))
     exclude(project(':trace-api'))
-    exclude(project(':opentelemetry-sdk'))
   }
 
   // relocate OpenTelemetry API usage

--- a/instrumentation/instrumentation.gradle
+++ b/instrumentation/instrumentation.gradle
@@ -46,11 +46,19 @@ subprojects { Project subProj ->
     dependencies {
       // Apply common dependencies for instrumentation.
       compile project(':trace-api')
-      compile project(':agent-tooling')
+      compile(project(':agent-tooling')) {
+        // OpenTelemetry SDK is not needed for compilation, and :opentelemetry-sdk-shaded-for-testing
+        // is brought in for tests by project(:testing) below
+        exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
+      }
       compile deps.bytebuddy
       if (jdkCompile) {
         "$jdkCompile" project(':trace-api')
-        "$jdkCompile" project(':agent-tooling')
+        "$jdkCompile"(project(':agent-tooling')) {
+          // OpenTelemetry SDK is not needed for compilation, and :opentelemetry-sdk-shaded-for-testing
+          // is brought in for tests by project(:testing) below
+          exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
+        }
         "$jdkCompile" deps.bytebuddy
       }
       annotationProcessor deps.autoservice

--- a/java-agent/java-agent.gradle
+++ b/java-agent/java-agent.gradle
@@ -63,9 +63,6 @@ shadowJar {
 
   // relocate OpenTelemetry API dependency
   relocate "io.grpc", "io.opentelemetry.auto.shaded.io.grpc"
-
-  // relocate OpenTelemetry SDK
-  relocate "io.opentelemetry.sdk", "io.opentelemetry.auto.shaded.io.opentelemetry.sdk"
 }
 
 dependencies {

--- a/opentelemetry-sdk-shaded-for-testing/opentelemetry-sdk-shaded-for-testing.gradle
+++ b/opentelemetry-sdk-shaded-for-testing/opentelemetry-sdk-shaded-for-testing.gradle
@@ -10,8 +10,9 @@ dependencies {
 
 // OpenTelemetry SDK with shaded dependencies so that they do not conflict with other libraries (in particular guava)
 // when running various instrumentation tests (e.g. datastax-cassandra)
-// TODO build agent-tooling-and-instrumentation.isolated and use that in tests, then wouldn't need to shade guava, etc
-// (still need to shade OpenTelemetry API and grpc-context usage since those are shaded in bootstrap CL)
+// TODO this is not ideal because tests are run using this partially shaded OpenTelemetry SDK, while the agent ends up
+// running with unshaded OpenTelemetry SDK (because its in isolated class loader at that point)
+// build agent-tooling-and-instrumentation.isolated and use that in tests, then wouldn't need to shade guava, etc
 shadowJar {
 
   dependencies {

--- a/opentelemetry-sdk/opentelemetry-sdk.gradle
+++ b/opentelemetry-sdk/opentelemetry-sdk.gradle
@@ -9,8 +9,15 @@ dependencies {
 }
 
 // OpenTelemetry SDK with shaded dependencies so that they do not conflict with other libraries (in particular guava)
-// when running various instrumentation tests
+// when running various instrumentation tests (e.g. datastax-cassandra)
+// TODO build agent-tooling-and-instrumentation.isolated and use that in tests, then wouldn't need to shade guava, etc
+// (still need to shade OpenTelemetry API and grpc-context usage since those are shaded in bootstrap CL)
 shadowJar {
+
+  dependencies {
+    exclude(dependency('io.opentelemetry:opentelemetry-api'))
+  }
+
   mergeServiceFiles()
 
   relocate "com.google", "io.opentelemetry.auto.shaded.com.google"

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ include ':trace-api'
 
 // agent projects
 include ':java-agent'
-include ':opentelemetry-sdk'
+include ':opentelemetry-sdk-shaded-for-testing'
 include ':agent-bootstrap'
 include ':agent-tooling'
 include ':load-generator'

--- a/testing/testing.gradle
+++ b/testing/testing.gradle
@@ -15,7 +15,7 @@ excludedClassesCoverage += [
 
 dependencies {
   compile deps.opentelemetryApi
-  compile(project(path: ':opentelemetry-sdk', configuration: 'shadow'))
+  compile(project(path: ':opentelemetry-sdk-shaded-for-testing', configuration: 'shadow'))
   compile deps.bytebuddy
   compile deps.bytebuddyagent
   compile deps.slf4j
@@ -27,7 +27,10 @@ dependencies {
 
   compile group: 'org.eclipse.jetty', name: 'jetty-server', version: '8.0.0.v20110901'
 
-  compile project(':agent-tooling')
+  compile(project(':agent-tooling')) {
+    // including :opentelemetry-sdk-shaded-for-testing above instead
+    exclude group: 'io.opentelemetry', module: 'opentelemetry-sdk'
+  }
   compile project(':utils:test-utils')
 
   annotationProcessor deps.autoservice


### PR DESCRIPTION
Added benefit: then it and it's dependencies (e.g. guava) don't need to be shaded (still need to shade it's dependency on OpenTelemetry API since that remains shaded and in the bootstrap loader).