### PR TITLE
Changed names of getters and removed instrumentationNames()

### DIFF
--- a/agent-tooling/src/main/java/io/opentelemetry/auto/decorator/BaseDecorator.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/decorator/BaseDecorator.java
@@ -19,11 +19,9 @@ public abstract class BaseDecorator {
 
   protected BaseDecorator() {}
 
-  protected abstract String[] instrumentationNames();
+  protected abstract String getSpanType();
 
-  protected abstract String spanType();
-
-  protected abstract String component();
+  protected abstract String getComponentName();
 
   @Deprecated
   public AgentSpan afterStart(final AgentSpan span) {
@@ -33,11 +31,11 @@ public abstract class BaseDecorator {
 
   public Span afterStart(final Span span) {
     assert span != null;
-    final String spanType = spanType();
+    final String spanType = getSpanType();
     if (spanType != null) {
       span.setAttribute(MoreTags.SPAN_TYPE, spanType);
     }
-    final String component = component();
+    final String component = getComponentName();
     if (component != null) {
       span.setAttribute(Tags.COMPONENT, component);
     }

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/decorator/HttpClientDecorator.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/decorator/HttpClientDecorator.java
@@ -25,7 +25,7 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
   protected abstract Integer status(RESPONSE response);
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.HTTP_CLIENT;
   }
 

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/decorator/HttpServerDecorator.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/decorator/HttpServerDecorator.java
@@ -34,7 +34,7 @@ public abstract class HttpServerDecorator<REQUEST, CONNECTION, RESPONSE> extends
   protected abstract Integer status(RESPONSE response);
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.HTTP_SERVER;
   }
 

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/BaseDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/BaseDecoratorTest.groovy
@@ -20,7 +20,7 @@ class BaseDecoratorTest extends AgentSpecification {
 
     then:
     1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.getSpanType())
-    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
+    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     _ * span.setAttribute(_, _) // Want to allow other calls from child implementations.
     0 * _
   }
@@ -127,7 +127,7 @@ class BaseDecoratorTest extends AgentSpecification {
 
       @Override
       protected String getComponentName() {
-        return "test-getComponentName"
+        return "test-component"
       }
     }
   }

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/BaseDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/BaseDecoratorTest.groovy
@@ -19,8 +19,8 @@ class BaseDecoratorTest extends AgentSpecification {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.spanType())
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
+    1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.getSpanType())
+    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
     _ * span.setAttribute(_, _) // Want to allow other calls from child implementations.
     0 * _
   }
@@ -119,19 +119,15 @@ class BaseDecoratorTest extends AgentSpecification {
 
   def newDecorator() {
     return new BaseDecorator() {
-      @Override
-      protected String[] instrumentationNames() {
-        return []
-      }
 
       @Override
-      protected String spanType() {
+      protected String getSpanType() {
         return "test-type"
       }
 
       @Override
-      protected String component() {
-        return "test-component"
+      protected String getComponentName() {
+        return "test-getComponentName"
       }
     }
   }

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ClientDecoratorTest.groovy
@@ -19,7 +19,7 @@ class ClientDecoratorTest extends BaseDecoratorTest {
     if (serviceName != null) {
       1 * span.setAttribute(MoreTags.SERVICE_NAME, serviceName)
     }
-    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
+    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     1 * span.setAttribute(Tags.SPAN_KIND, "client")
     1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.getSpanType())
     _ * span.setAttribute(_, _) // Want to allow other calls from child implementations.
@@ -57,7 +57,7 @@ class ClientDecoratorTest extends BaseDecoratorTest {
 
       @Override
       protected String getComponentName() {
-        return "test-getComponentName"
+        return "test-component"
       }
     }
   }

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ClientDecoratorTest.groovy
@@ -19,9 +19,9 @@ class ClientDecoratorTest extends BaseDecoratorTest {
     if (serviceName != null) {
       1 * span.setAttribute(MoreTags.SERVICE_NAME, serviceName)
     }
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
+    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
     1 * span.setAttribute(Tags.SPAN_KIND, "client")
-    1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.spanType())
+    1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.getSpanType())
     _ * span.setAttribute(_, _) // Want to allow other calls from child implementations.
     0 * _
 
@@ -44,10 +44,6 @@ class ClientDecoratorTest extends BaseDecoratorTest {
 
   def newDecorator(String serviceName) {
     return new ClientDecorator() {
-      @Override
-      protected String[] instrumentationNames() {
-        return ["test1", "test2"]
-      }
 
       @Override
       protected String service() {
@@ -55,13 +51,13 @@ class ClientDecoratorTest extends BaseDecoratorTest {
       }
 
       @Override
-      protected String spanType() {
+      protected String getSpanType() {
         return "test-type"
       }
 
       @Override
-      protected String component() {
-        return "test-component"
+      protected String getComponentName() {
+        return "test-getComponentName"
       }
     }
   }

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/DatabaseClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/DatabaseClientDecoratorTest.groovy
@@ -22,7 +22,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     if (serviceName != null) {
       1 * span.setAttribute(MoreTags.SERVICE_NAME, serviceName)
     }
-    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
+    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     1 * span.setAttribute(Tags.SPAN_KIND, "client")
     1 * span.setAttribute(Tags.DB_TYPE, "test-db")
     1 * span.setAttribute(MoreTags.SPAN_TYPE, "test-type")
@@ -115,7 +115,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
 
       @Override
       protected String getComponentName() {
-        return "test-getComponentName"
+        return "test-component"
       }
 
       @Override

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/DatabaseClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/DatabaseClientDecoratorTest.groovy
@@ -22,7 +22,7 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     if (serviceName != null) {
       1 * span.setAttribute(MoreTags.SERVICE_NAME, serviceName)
     }
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
+    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
     1 * span.setAttribute(Tags.SPAN_KIND, "client")
     1 * span.setAttribute(Tags.DB_TYPE, "test-db")
     1 * span.setAttribute(MoreTags.SPAN_TYPE, "test-type")
@@ -107,10 +107,6 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
   @Override
   def newDecorator(String serviceName = "test-service") {
     return new DatabaseClientDecorator<Map>() {
-      @Override
-      protected String[] instrumentationNames() {
-        return ["test1", "test2"]
-      }
 
       @Override
       protected String service() {
@@ -118,12 +114,12 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
       }
 
       @Override
-      protected String component() {
-        return "test-component"
+      protected String getComponentName() {
+        return "test-getComponentName"
       }
 
       @Override
-      protected String spanType() {
+      protected String getSpanType() {
         return "test-type"
       }
 

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpClientDecoratorTest.groovy
@@ -146,7 +146,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
 
       @Override
       protected String getComponentName() {
-        return "test-getComponentName"
+        return "test-component"
       }
 
       @Override

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpClientDecoratorTest.groovy
@@ -138,10 +138,6 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
   @Override
   def newDecorator(String serviceName = "test-service") {
     return new HttpClientDecorator<Map, Map>() {
-      @Override
-      protected String[] instrumentationNames() {
-        return ["test1", "test2"]
-      }
 
       @Override
       protected String service() {
@@ -149,8 +145,8 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       }
 
       @Override
-      protected String component() {
-        return "test-component"
+      protected String getComponentName() {
+        return "test-getComponentName"
       }
 
       @Override

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpServerDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpServerDecoratorTest.groovy
@@ -161,7 +161,7 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
 
       @Override
       protected String getComponentName() {
-        return "test-getComponentName"
+        return "test-component"
       }
 
       @Override

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpServerDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/HttpServerDecoratorTest.groovy
@@ -158,14 +158,10 @@ class HttpServerDecoratorTest extends ServerDecoratorTest {
   @Override
   def newDecorator() {
     return new HttpServerDecorator<Map, Map, Map>() {
-      @Override
-      protected String[] instrumentationNames() {
-        return ["test1", "test2"]
-      }
 
       @Override
-      protected String component() {
-        return "test-component"
+      protected String getComponentName() {
+        return "test-getComponentName"
       }
 
       @Override

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/OrmClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/OrmClientDecoratorTest.groovy
@@ -64,19 +64,15 @@ class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
         return "test-service"
       }
 
-      @Override
-      protected String[] instrumentationNames() {
-        return ["test1"]
-      }
 
       @Override
-      protected String spanType() {
+      protected String getSpanType() {
         return "test-type"
       }
 
       @Override
-      protected String component() {
-        return "test-component"
+      protected String getComponentName() {
+        return "test-getComponentName"
       }
     }
   }

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/OrmClientDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/OrmClientDecoratorTest.groovy
@@ -72,7 +72,7 @@ class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
 
       @Override
       protected String getComponentName() {
-        return "test-getComponentName"
+        return "test-component"
       }
     }
   }

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ServerDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ServerDecoratorTest.groovy
@@ -15,7 +15,7 @@ class ServerDecoratorTest extends BaseDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
+    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     1 * span.setAttribute(Tags.SPAN_KIND, "server")
     1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.getSpanType())
     0 * _
@@ -40,7 +40,7 @@ class ServerDecoratorTest extends BaseDecoratorTest {
 
       @Override
       protected String getComponentName() {
-        return "test-getComponentName"
+        return "test-component"
       }
     }
   }

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ServerDecoratorTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/decorator/ServerDecoratorTest.groovy
@@ -15,9 +15,9 @@ class ServerDecoratorTest extends BaseDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
+    1 * span.setAttribute(Tags.COMPONENT, "test-getComponentName")
     1 * span.setAttribute(Tags.SPAN_KIND, "server")
-    1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.spanType())
+    1 * span.setAttribute(MoreTags.SPAN_TYPE, decorator.getSpanType())
     0 * _
   }
 
@@ -32,19 +32,15 @@ class ServerDecoratorTest extends BaseDecoratorTest {
   @Override
   def newDecorator() {
     return new ServerDecorator() {
-      @Override
-      protected String[] instrumentationNames() {
-        return ["test1", "test2"]
-      }
 
       @Override
-      protected String spanType() {
+      protected String getSpanType() {
         return "test-type"
       }
 
       @Override
-      protected String component() {
-        return "test-component"
+      protected String getComponentName() {
+        return "test-getComponentName"
       }
     }
   }

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientDecorator.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientDecorator.java
@@ -14,12 +14,7 @@ public class AkkaHttpClientDecorator extends HttpClientDecorator<HttpRequest, Ht
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"akka-http", "akka-http-client"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "akka-http-client";
   }
 

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerDecorator.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerDecorator.java
@@ -15,12 +15,7 @@ public class AkkaHttpServerDecorator
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"akka-http", "akka-http-server"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "akka-http-server";
   }
 

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -49,7 +49,7 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object, 
       }
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"
         "$Tags.HTTP_METHOD" method

--- a/instrumentation/apache-httpasyncclient-4/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/instrumentation/apache-httpasyncclient-4/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -20,12 +20,7 @@ public class ApacheHttpAsyncClientDecorator extends HttpClientDecorator<HttpRequ
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"httpasyncclient", "apache-httpasyncclient"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "apache-httpasyncclient";
   }
 

--- a/instrumentation/apache-httpclient-4/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
+++ b/instrumentation/apache-httpclient-4/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/ApacheHttpClientDecorator.java
@@ -13,12 +13,7 @@ public class ApacheHttpClientDecorator extends HttpClientDecorator<HttpUriReques
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"httpclient", "apache-httpclient", "apache-http-client"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "apache-httpclient";
   }
 

--- a/instrumentation/aws-java-sdk-1.11.0/src/main/java/io/opentelemetry/auto/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/instrumentation/aws-java-sdk-1.11.0/src/main/java/io/opentelemetry/auto/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -102,12 +102,7 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"aws-sdk"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return COMPONENT_NAME;
   }
 

--- a/instrumentation/aws-java-sdk-1.11.0/src/main/java/io/opentelemetry/auto/instrumentation/aws/v0/OnErrorDecorator.java
+++ b/instrumentation/aws-java-sdk-1.11.0/src/main/java/io/opentelemetry/auto/instrumentation/aws/v0/OnErrorDecorator.java
@@ -6,17 +6,12 @@ public class OnErrorDecorator extends BaseDecorator {
   public static final OnErrorDecorator DECORATE = new OnErrorDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"aws-sdk"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-aws-sdk";
   }
 }

--- a/instrumentation/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseClientDecorator.java
+++ b/instrumentation/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseClientDecorator.java
@@ -7,22 +7,17 @@ class CouchbaseClientDecorator extends DatabaseClientDecorator {
   public static final CouchbaseClientDecorator DECORATE = new CouchbaseClientDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"couchbase"};
-  }
-
-  @Override
   protected String service() {
     return "couchbase";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "couchbase-client";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.COUCHBASE;
   }
 

--- a/instrumentation/datastax-cassandra-3/src/main/java/io/opentelemetry/auto/instrumentation/datastax/cassandra/CassandraClientDecorator.java
+++ b/instrumentation/datastax-cassandra-3/src/main/java/io/opentelemetry/auto/instrumentation/datastax/cassandra/CassandraClientDecorator.java
@@ -12,22 +12,17 @@ public class CassandraClientDecorator extends DatabaseClientDecorator<Session> {
   public static final CassandraClientDecorator DECORATE = new CassandraClientDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"cassandra"};
-  }
-
-  @Override
   protected String service() {
     return "cassandra";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-cassandra";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.CASSANDRA;
   }
 

--- a/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard/src/test/groovy/DropwizardTest.groovy
@@ -56,7 +56,7 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
   Servlet3Decorator decorator() {
     return new Servlet3Decorator() {
       @Override
-      protected String component() {
+      protected String getComponentName() {
         return "jax-rs"
       }
     }
@@ -90,7 +90,7 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
       tags {
         "$MoreTags.RESOURCE_NAME" "${this.testResource().simpleName}.${endpoint.name().toLowerCase()}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" JaxRsAnnotationsDecorator.DECORATE.component()
+        "$Tags.COMPONENT" JaxRsAnnotationsDecorator.DECORATE.getComponentName()
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
@@ -112,7 +112,7 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport, Servlet3Decor
       tags {
         "$MoreTags.RESOURCE_NAME" "$method ${endpoint.resolve(address).path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/elasticsearch/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/instrumentation/elasticsearch/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -15,22 +15,17 @@ public class ElasticsearchRestClientDecorator extends DatabaseClientDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"elasticsearch"};
-  }
-
-  @Override
   protected String service() {
     return "elasticsearch";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "elasticsearch-java";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.ELASTICSEARCH;
   }
 

--- a/instrumentation/elasticsearch/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/instrumentation/elasticsearch/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -14,22 +14,17 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"elasticsearch"};
-  }
-
-  @Override
   protected String service() {
     return "elasticsearch";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "elasticsearch-java";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.ELASTICSEARCH;
   }
 

--- a/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
+++ b/instrumentation/glassfish/src/test/groovy/GlassFishServerTest.groovy
@@ -94,7 +94,7 @@ class GlassFishServerTest extends HttpServerTest<GlassFish, Servlet3Decorator> {
       }
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/google-http-client/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/instrumentation/google-http-client/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -43,12 +43,7 @@ public class GoogleHttpClientDecorator extends HttpClientDecorator<HttpRequest, 
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"google-http-client"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "google-http-client";
   }
 }

--- a/instrumentation/grizzly-2/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/instrumentation/grizzly-2/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyDecorator.java
@@ -47,12 +47,7 @@ public class GrizzlyDecorator extends HttpServerDecorator<Request, Request, Resp
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"grizzly"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "grizzly";
   }
 }

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -12,17 +12,12 @@ public class GrpcClientDecorator extends ClientDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"grpc", "grpc-client"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "grpc-client";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.RPC;
   }
 

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -12,17 +12,12 @@ public class GrpcServerDecorator extends ServerDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"grpc", "grpc-server"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.RPC;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "grpc-server";
   }
 

--- a/instrumentation/hibernate/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/HibernateDecorator.java
+++ b/instrumentation/hibernate/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/HibernateDecorator.java
@@ -19,17 +19,12 @@ public class HibernateDecorator extends OrmClientDecorator {
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"hibernate-core"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.HIBERNATE;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-hibernate";
   }
 

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/http_url_connection/HttpUrlConnectionDecorator.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/http_url_connection/HttpUrlConnectionDecorator.java
@@ -13,12 +13,7 @@ public class HttpUrlConnectionDecorator extends HttpClientDecorator<HttpURLConne
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"httpurlconnection"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "http-url-connection";
   }
 

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
@@ -9,17 +9,12 @@ public class HystrixDecorator extends BaseDecorator {
   public static HystrixDecorator DECORATE = new HystrixDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[0];
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "hystrix";
   }
 

--- a/instrumentation/jax-rs-annotations-1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jax-rs-annotations-1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -26,17 +26,12 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[0];
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "jax-rs-controller";
   }
 

--- a/instrumentation/jax-rs-annotations-2/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jax-rs-annotations-2/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -35,17 +35,12 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
   private final WeakMap<Class, Map<Method, String>> resourceNames = newWeakMap();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[0];
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "jax-rs-controller";
   }
 

--- a/instrumentation/jax-rs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
+++ b/instrumentation/jax-rs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1/JaxRsClientV1Decorator.java
@@ -13,12 +13,7 @@ public class JaxRsClientV1Decorator extends HttpClientDecorator<ClientRequest, C
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jax-rs", "jaxrs", "jax-rs-client"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "jax-rs.client";
   }
 

--- a/instrumentation/jax-rs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/JaxRsClientDecorator.java
+++ b/instrumentation/jax-rs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/JaxRsClientDecorator.java
@@ -14,12 +14,7 @@ public class JaxRsClientDecorator
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jax-rs", "jaxrs", "jax-rs-client"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "jax-rs.client";
   }
 

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceDecorator.java
@@ -10,17 +10,12 @@ public class DataSourceDecorator extends BaseDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jdbc-datasource"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-jdbc-connection";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 }

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
@@ -21,22 +21,17 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
   private static final String DB_QUERY = "DB Query";
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jdbc"};
-  }
-
-  @Override
   protected String service() {
     return "jdbc"; // Overridden by onConnection
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-jdbc"; // Overridden by onStatement and onPreparedStatement
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.SQL;
   }
 

--- a/instrumentation/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/JedisClientDecorator.java
+++ b/instrumentation/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/JedisClientDecorator.java
@@ -8,22 +8,17 @@ public class JedisClientDecorator extends DatabaseClientDecorator<Protocol.Comma
   public static final JedisClientDecorator DECORATE = new JedisClientDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jedis", "redis"};
-  }
-
-  @Override
   protected String service() {
     return "redis";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "redis-command";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.REDIS;
   }
 

--- a/instrumentation/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis30/JedisClientDecorator.java
+++ b/instrumentation/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis30/JedisClientDecorator.java
@@ -8,22 +8,17 @@ public class JedisClientDecorator extends DatabaseClientDecorator<ProtocolComman
   public static final JedisClientDecorator DECORATE = new JedisClientDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jedis", "redis"};
-  }
-
-  @Override
   protected String service() {
     return "redis";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "redis-command";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.REDIS;
   }
 

--- a/instrumentation/jetty-8/src/main/java/io/opentelemetry/auto/instrumentation/jetty8/JettyDecorator.java
+++ b/instrumentation/jetty-8/src/main/java/io/opentelemetry/auto/instrumentation/jetty8/JettyDecorator.java
@@ -12,12 +12,7 @@ public class JettyDecorator
   public static final JettyDecorator DECORATE = new JettyDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jetty", "jetty-8"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "jetty-handler";
   }
 

--- a/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty-8/src/test/groovy/JettyHandlerTest.groovy
@@ -129,7 +129,7 @@ class JettyHandlerTest extends HttpServerTest<Server, JettyDecorator> {
       tags {
         "$MoreTags.RESOURCE_NAME" "$method $handlerName"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/jms/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSDecorator.java
+++ b/instrumentation/jms/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSDecorator.java
@@ -24,7 +24,7 @@ public abstract class JMSDecorator extends ClientDecorator {
         }
 
         @Override
-        protected String spanType() {
+        protected String getSpanType() {
           return SpanTypes.MESSAGE_PRODUCER;
         }
       };
@@ -37,7 +37,7 @@ public abstract class JMSDecorator extends ClientDecorator {
         }
 
         @Override
-        protected String spanType() {
+        protected String getSpanType() {
           return SpanTypes.MESSAGE_CONSUMER;
         }
       };
@@ -45,17 +45,12 @@ public abstract class JMSDecorator extends ClientDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jms", "jms-1", "jms-2"};
-  }
-
-  @Override
   protected String service() {
     return "jms";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "jms";
   }
 

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPDecorator.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPDecorator.java
@@ -16,17 +16,12 @@ public class JSPDecorator extends BaseDecorator {
   public static JSPDecorator DECORATE = new JSPDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"jsp"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "jsp-http-servlet";
   }
 

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/KafkaDecorator.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/KafkaDecorator.java
@@ -17,7 +17,7 @@ public abstract class KafkaDecorator extends ClientDecorator {
         }
 
         @Override
-        protected String spanType() {
+        protected String getSpanType() {
           return SpanTypes.MESSAGE_PRODUCER;
         }
       };
@@ -30,15 +30,10 @@ public abstract class KafkaDecorator extends ClientDecorator {
         }
 
         @Override
-        protected String spanType() {
+        protected String getSpanType() {
           return SpanTypes.MESSAGE_CONSUMER;
         }
       };
-
-  @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"kafka"};
-  }
 
   @Override
   protected String service() {
@@ -46,7 +41,7 @@ public abstract class KafkaDecorator extends ClientDecorator {
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-kafka";
   }
 

--- a/instrumentation/lettuce-5/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientDecorator.java
+++ b/instrumentation/lettuce-5/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientDecorator.java
@@ -12,22 +12,17 @@ public class LettuceClientDecorator extends DatabaseClientDecorator<RedisURI> {
   public static final LettuceClientDecorator DECORATE = new LettuceClientDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"lettuce"};
-  }
-
-  @Override
   protected String service() {
     return "redis";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "redis-client";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.REDIS;
   }
 

--- a/instrumentation/mongo/driver-3.1/src/main/java/io/opentelemetry/auto/instrumentation/mongo/MongoClientDecorator.java
+++ b/instrumentation/mongo/driver-3.1/src/main/java/io/opentelemetry/auto/instrumentation/mongo/MongoClientDecorator.java
@@ -21,22 +21,17 @@ public class MongoClientDecorator extends DatabaseClientDecorator<CommandStarted
   public static final MongoClientDecorator DECORATE = new MongoClientDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"mongo"};
-  }
-
-  @Override
   protected String service() {
     return "mongo";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-mongo";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.MONGO;
   }
 

--- a/instrumentation/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty40/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty40/client/NettyHttpClientDecorator.java
@@ -18,12 +18,7 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"netty", "netty-4.0"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "netty-client";
   }
 

--- a/instrumentation/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty40/server/NettyHttpServerDecorator.java
+++ b/instrumentation/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty40/server/NettyHttpServerDecorator.java
@@ -22,12 +22,7 @@ public class NettyHttpServerDecorator
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"netty", "netty-4.0"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "netty";
   }
 

--- a/instrumentation/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty41/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty41/client/NettyHttpClientDecorator.java
@@ -18,12 +18,7 @@ public class NettyHttpClientDecorator extends HttpClientDecorator<HttpRequest, H
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"netty", "netty-4.0"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "netty-client";
   }
 

--- a/instrumentation/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty41/server/NettyHttpServerDecorator.java
+++ b/instrumentation/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty41/server/NettyHttpServerDecorator.java
@@ -22,12 +22,7 @@ public class NettyHttpServerDecorator
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"netty", "netty-4.0"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "netty";
   }
 

--- a/instrumentation/okhttp-3/src/main/java/io/opentelemetry/auto/instrumentation/okhttp3/OkHttpClientDecorator.java
+++ b/instrumentation/okhttp-3/src/main/java/io/opentelemetry/auto/instrumentation/okhttp3/OkHttpClientDecorator.java
@@ -9,17 +9,12 @@ public class OkHttpClientDecorator extends HttpClientDecorator<Request, Response
   public static final OkHttpClientDecorator DECORATE = new OkHttpClientDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"okhttp", "okhttp-3"};
-  }
-
-  @Override
   protected String service() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "okhttp";
   }
 

--- a/instrumentation/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/instrumentation/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play24/PlayHttpServerDecorator.java
@@ -23,12 +23,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"play"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "play-action";
   }
 

--- a/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -87,7 +87,7 @@ class PlayServerTest extends HttpServerTest<Server, NettyHttpServerDecorator> {
       childOf((SpanData) parent)
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
+        "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" String

--- a/instrumentation/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/instrumentation/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play26/PlayHttpServerDecorator.java
@@ -25,12 +25,7 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"play"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "play-action";
   }
 

--- a/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -91,7 +91,7 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
       childOf((SpanData) parent)
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.component()
+        "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" String
@@ -119,7 +119,7 @@ class PlayServerTest extends HttpServerTest<Server, AkkaHttpServerDecorator> {
       }
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" "${endpoint.resolve(address)}"

--- a/instrumentation/play-ws-1/src/main/java/io/opentelemetry/auto/instrumentation/playws1/PlayWSClientDecorator.java
+++ b/instrumentation/play-ws-1/src/main/java/io/opentelemetry/auto/instrumentation/playws1/PlayWSClientDecorator.java
@@ -39,12 +39,7 @@ public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"play-ws"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "play-ws";
   }
 }

--- a/instrumentation/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws21/PlayWSClientDecorator.java
+++ b/instrumentation/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws21/PlayWSClientDecorator.java
@@ -39,12 +39,7 @@ public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"play-ws"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "play-ws";
   }
 }

--- a/instrumentation/play-ws-2/src/main/java/io/opentelemetry/auto/instrumentation/playws2/PlayWSClientDecorator.java
+++ b/instrumentation/play-ws-2/src/main/java/io/opentelemetry/auto/instrumentation/playws2/PlayWSClientDecorator.java
@@ -39,12 +39,7 @@ public class PlayWSClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"play-ws"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "play-ws";
   }
 }

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/RatpackServerDecorator.java
@@ -22,12 +22,7 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"ratpack"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "ratpack";
   }
 

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -110,7 +110,7 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp, NettyHttpServerD
       tags {
         "$MoreTags.RESOURCE_NAME" endpoint.status == 404 ? "$method /" : "$method ${endpoint.path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.component()
+        "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional
@@ -141,7 +141,7 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp, NettyHttpServerD
       tags {
         "$MoreTags.RESOURCE_NAME" endpoint.status == 404 ? "$method /" : "$method ${endpoint.path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_PORT" Long

--- a/instrumentation/reactor-core-3.1/src/main/java8/io/opentelemetry/auto/instrumentation/reactor/core/ReactorCoreDecorator.java
+++ b/instrumentation/reactor-core-3.1/src/main/java8/io/opentelemetry/auto/instrumentation/reactor/core/ReactorCoreDecorator.java
@@ -10,17 +10,12 @@ public class ReactorCoreDecorator extends BaseDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"reactor-core"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.HTTP_CLIENT; // TODO: Is this the correct type?
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "reactor-core";
   }
 }

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientDecorator.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientDecorator.java
@@ -11,17 +11,12 @@ public class RmiClientDecorator extends ClientDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"rmi", "rmi-client"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.RPC;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "rmi-client";
   }
 

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerDecorator.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerDecorator.java
@@ -11,17 +11,12 @@ public class RmiServerDecorator extends ServerDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"rmi", "rmi-server"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.RPC;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "rmi-server";
   }
 }

--- a/instrumentation/servlet/request-2/src/main/java/io/opentelemetry/auto/instrumentation/servlet2/Servlet2Decorator.java
+++ b/instrumentation/servlet/request-2/src/main/java/io/opentelemetry/auto/instrumentation/servlet2/Servlet2Decorator.java
@@ -15,12 +15,7 @@ public class Servlet2Decorator
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-2"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-web-servlet";
   }
 

--- a/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/request-2/src/test/groovy/JettyServlet2Test.groovy
@@ -89,7 +89,7 @@ class JettyServlet2Test extends HttpServerTest<Server, Servlet2Decorator> {
       }
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" "127.0.0.1"

--- a/instrumentation/servlet/request-3/src/main/java/io/opentelemetry/auto/instrumentation/servlet3/Servlet3Decorator.java
+++ b/instrumentation/servlet/request-3/src/main/java/io/opentelemetry/auto/instrumentation/servlet3/Servlet3Decorator.java
@@ -17,12 +17,7 @@ public class Servlet3Decorator
   public static final Servlet3Decorator DECORATE = new Servlet3Decorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-3"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-web-servlet";
   }
 

--- a/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/request-3/src/test/groovy/AbstractServlet3Test.groovy
@@ -79,7 +79,7 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
       }
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
+++ b/instrumentation/servlet/request-3/src/test/groovy/JettyServlet3Test.groovy
@@ -223,7 +223,7 @@ abstract class JettyDispatchTest extends JettyServlet3Test {
       errored endpoint.errored
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/request-3/src/test/groovy/TomcatServlet3Test.groovy
@@ -265,7 +265,7 @@ abstract class TomcatDispatchTest extends TomcatServlet3Test {
       errored endpoint.errored
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
@@ -9,17 +9,12 @@ public class RequestDispatcherDecorator extends BaseDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-dispatcher"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-web-servlet-dispatcher";
   }
 }

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterDecorator.java
@@ -9,17 +9,12 @@ public class FilterDecorator extends BaseDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"servlet-filter"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-web-servlet-filter";
   }
 }

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletDecorator.java
@@ -9,17 +9,12 @@ public class HttpServletDecorator extends BaseDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"servlet-service"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-web-servlet-service";
   }
 }

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseDecorator.java
@@ -9,17 +9,12 @@ public class HttpServletResponseDecorator extends BaseDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"servlet", "servlet-response"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-web-servlet-response";
   }
 }

--- a/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringDataDecorator.java
+++ b/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringDataDecorator.java
@@ -18,17 +18,12 @@ public final class SpringDataDecorator extends ClientDecorator {
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"spring-data"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "spring-data";
   }
 

--- a/instrumentation/spring-webflux-5/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
+++ b/instrumentation/spring-webflux-5/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
@@ -23,12 +23,7 @@ public class SpringWebfluxHttpClientDecorator
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"spring-webflux", "spring-webflux-client"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "spring-webflux-client";
   }
 

--- a/instrumentation/spring-webflux-5/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/SpringWebfluxHttpServerDecorator.java
+++ b/instrumentation/spring-webflux-5/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/SpringWebfluxHttpServerDecorator.java
@@ -13,17 +13,12 @@ public class SpringWebfluxHttpServerDecorator extends ServerDecorator {
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"spring-webflux"};
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.HTTP_SERVER;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "spring-webflux-controller";
   }
 }

--- a/instrumentation/spring-webflux-5/src/test/groovy/dd/io/opentelemetry/test/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
+++ b/instrumentation/spring-webflux-5/src/test/groovy/dd/io/opentelemetry/test/instrumentation/springwebflux/client/SpringWebfluxHttpClientTest.groovy
@@ -53,7 +53,7 @@ class SpringWebfluxHttpClientTest extends HttpClientTest<SpringWebfluxHttpClient
         tags {
           "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
           "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
-          "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.component()
+          "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.getComponentName()
           "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
           "$Tags.PEER_HOSTNAME" "localhost"
           "$Tags.PEER_PORT" uri.port

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springweb/SpringWebHttpServerDecorator.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springweb/SpringWebHttpServerDecorator.java
@@ -27,18 +27,13 @@ public class SpringWebHttpServerDecorator
   public static final SpringWebHttpServerDecorator DECORATE_RENDER =
       new SpringWebHttpServerDecorator() {
         @Override
-        protected String component() {
+        protected String getComponentName() {
           return "spring-webmvc";
         }
       };
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"spring-web"};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return "spring-web-controller";
   }
 

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -83,7 +83,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
       tags {
         "$MoreTags.RESOURCE_NAME" "TestController.${endpoint.name().toLowerCase()}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.component()
+        "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
@@ -106,7 +106,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext,
       tags {
         "$MoreTags.RESOURCE_NAME" "$method ${endpoint.resolve(address).path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -14,22 +14,17 @@ public class MemcacheClientDecorator extends DatabaseClientDecorator<MemcachedCo
   public static final Tracer TRACER = OpenTelemetry.getTracerFactory().get("io.opentelemetry.auto");
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {"spymemcached"};
-  }
-
-  @Override
   protected String service() {
     return "memcached";
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "java-spymemcached";
   }
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.MEMCACHED;
   }
 

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/trace_annotation/TraceDecorator.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/trace_annotation/TraceDecorator.java
@@ -6,17 +6,12 @@ public class TraceDecorator extends BaseDecorator {
   public static TraceDecorator DECORATE = new TraceDecorator();
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[0];
-  }
-
-  @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return null;
   }
 
   @Override
-  protected String component() {
+  protected String getComponentName() {
     return "trace";
   }
 }

--- a/instrumentation/twilio/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioClientDecorator.java
+++ b/instrumentation/twilio/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioClientDecorator.java
@@ -25,17 +25,12 @@ public class TwilioClientDecorator extends ClientDecorator {
   static final String COMPONENT_NAME = "twilio-sdk";
 
   @Override
-  protected String spanType() {
+  protected String getSpanType() {
     return SpanTypes.HTTP_CLIENT;
   }
 
   @Override
-  protected String[] instrumentationNames() {
-    return new String[] {COMPONENT_NAME};
-  }
-
-  @Override
-  protected String component() {
+  protected String getComponentName() {
     return COMPONENT_NAME;
   }
 

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
@@ -321,7 +321,7 @@ abstract class HttpClientTest<DECORATOR extends HttpClientDecorator> extends Age
       tags {
         "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
-        "$Tags.COMPONENT" clientDecorator.component()
+        "$Tags.COMPONENT" clientDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_CLIENT
         "$Tags.PEER_HOSTNAME" "localhost"
         "$Tags.PEER_HOST_IPV4" { it == null || it == "127.0.0.1" } // Optional

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
@@ -383,7 +383,7 @@ abstract class HttpServerTest<SERVER, DECORATOR extends HttpServerDecorator> ext
       }
       tags {
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
-        "$Tags.COMPONENT" serverDecorator.component()
+        "$Tags.COMPONENT" serverDecorator.getComponentName()
         "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
         "$Tags.PEER_HOSTNAME" { it == "localhost" || it == "127.0.0.1" }
         "$Tags.PEER_PORT" Long

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
@@ -16,15 +16,12 @@ import static io.opentelemetry.auto.instrumentation.api.AgentTracer.startSpan
 class TraceUtils {
 
   private static final BaseDecorator DECORATOR = new BaseDecorator() {
-    protected String[] instrumentationNames() {
-      return new String[0]
-    }
 
-    protected String spanType() {
+    protected String getSpanType() {
       return null
     }
 
-    protected String component() {
+    protected String getComponentName() {
       return null
     }
   }


### PR DESCRIPTION
* Changed names of ```BaseDecorator``` getter methods to conform to getX() convention.

* Removed unused ```BaseDecorator::instrumentationNames()```