### PR TITLE
Call setNoParent() consistently

### DIFF
--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -238,6 +238,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
             spanBuilder.setParent(TRACER.getHttpTextFormat().extract(headers, GETTER));
           } catch (final IllegalArgumentException e) {
             // couldn't extract a context
+            spanBuilder.setNoParent();
           }
         }
       }

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -72,6 +72,7 @@ public class TracedDelegatingConsumer implements Consumer {
           extractedContext = TRACER.getHttpTextFormat().extract(headers, GETTER);
         } catch (final IllegalArgumentException e) {
           // couldn't extract a context
+          spanBuilder.setNoParent();
         }
       }
       if (extractedContext != null) {

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -13,12 +13,14 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
+import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
 import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
 import java.lang.reflect.Method;
+import java.rmi.server.RemoteServer;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -56,11 +58,17 @@ public final class RmiServerInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = true)
     public static SpanWithScope onEnter(
         @Advice.This final Object thiz, @Advice.Origin final Method method) {
+      final int callDepth = CallDepthThreadLocalMap.incrementCallDepth(RemoteServer.class);
+      if (callDepth > 0) {
+        return null;
+      }
       final SpanContext context = THREAD_LOCAL_CONTEXT.getAndResetContext();
 
       final Span.Builder spanBuilder = TRACER.spanBuilder("rmi.request");
       if (context != null) {
         spanBuilder.setParent(context);
+      } else {
+        spanBuilder.setNoParent();
       }
       final Span span = spanBuilder.startSpan();
       span.setAttribute(MoreTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
@@ -76,6 +84,7 @@ public final class RmiServerInstrumentation extends Instrumenter.Default {
       if (spanWithScope == null) {
         return;
       }
+      CallDepthThreadLocalMap.reset(RemoteServer.class);
 
       final Span span = spanWithScope.getSpan();
       DECORATE.onError(span, throwable);

--- a/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -36,7 +36,7 @@ class RmiTest extends AgentTestRunner {
     then:
     response.contains("Hello you")
     assertTraces(1) {
-      trace(0, 4) {
+      trace(0, 3) {
         basicSpan(it, 0, "parent")
         span(1) {
           operationName "rmi.invoke"
@@ -53,16 +53,6 @@ class RmiTest extends AgentTestRunner {
           operationName "rmi.request"
           tags {
             "$MoreTags.RESOURCE_NAME" "Server.hello"
-            "$MoreTags.SPAN_TYPE" SpanTypes.RPC
-            "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
-            "$Tags.COMPONENT" "rmi-server"
-            "span.origin.type" server.class.canonicalName
-          }
-        }
-        span(3) {
-          operationName "rmi.request"
-          tags {
-            "$MoreTags.RESOURCE_NAME" "Server.someMethod"
             "$MoreTags.SPAN_TYPE" SpanTypes.RPC
             "$Tags.SPAN_KIND" Tags.SPAN_KIND_SERVER
             "$Tags.COMPONENT" "rmi-server"

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/server/http/TestHttpServer.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/server/http/TestHttpServer.groovy
@@ -245,6 +245,7 @@ class TestHttpServer implements AutoCloseable {
           spanBuilder.setParent(extractedContext)
         } catch (final IllegalArgumentException e) {
           // couldn't extract a context
+          spanBuilder.setNoParent()
         }
         final Span span = spanBuilder.startSpan()
         span.setAttribute(Tags.SPAN_KIND, Tags.SPAN_KIND_SERVER)


### PR DESCRIPTION
Calling `setNoParent()` in RMI server instrumentation required preventing nested RMI server spans (using the normal `CallDepthThreadLocalMap` approach).