### PR TITLE
Capture gRPC messages as events instead of child spans

### DIFF
--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -14,8 +14,12 @@ import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.trace.AttributeValue;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TracingServerInterceptor implements ServerInterceptor {
 
@@ -89,6 +93,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
   static final class TracingServerCallListener<ReqT>
       extends ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT> {
     private final Span span;
+    private final AtomicInteger messageId = new AtomicInteger();
 
     TracingServerCallListener(final Span span, final ServerCall.Listener<ReqT> delegate) {
       super(delegate);
@@ -97,26 +102,12 @@ public class TracingServerInterceptor implements ServerInterceptor {
 
     @Override
     public void onMessage(final ReqT message) {
-      final Span span =
-          TRACER
-              .spanBuilder("grpc.message")
-              .setSpanKind(SERVER)
-              .setParent(this.span.getContext())
-              .startSpan();
-      span.setAttribute("message.type", message.getClass().getName());
-      DECORATE.afterStart(span);
-      final Scope scope = TRACER.withSpan(span);
-      try {
+      final Map<String, AttributeValue> attributes = new HashMap<>();
+      attributes.put("message.type", AttributeValue.stringAttributeValue("RECEIVED"));
+      attributes.put("message.id", AttributeValue.longAttributeValue(messageId.incrementAndGet()));
+      span.addEvent("message", attributes);
+      try (final Scope scope = TRACER.withSpan(span)) {
         delegate().onMessage(message);
-      } catch (final Throwable e) {
-        DECORATE.onError(span, e);
-        DECORATE.beforeFinish(this.span);
-        this.span.end();
-        throw e;
-      } finally {
-        DECORATE.beforeFinish(span);
-        span.end();
-        scope.close();
       }
     }
 

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/EventAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/EventAssert.groovy
@@ -30,7 +30,7 @@ class EventAssert {
     clone(this)
   }
 
-  def name(String name) {
+  def eventName(String name) {
     assert event.name == name
     checked.name = true
   }

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/log/events/LogEventsTestBase.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/log/events/LogEventsTestBase.groovy
@@ -47,7 +47,7 @@ abstract class LogEventsTestBase extends AgentTestRunner {
           operationName "test"
           if (capture) {
             event(0) {
-              name "xyz"
+              eventName "xyz"
               attributes {
                 "level" testMethod.toUpperCase()
                 "loggerName" "abc"


### PR DESCRIPTION
See specification: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-rpc.md#events