### PR TITLE
Fix documentation about service definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ java -javaagent:/path/to/opentelemetry-auto-<version>.jar \
      -Dota.exporter.jar=exporter-adapters/logging-exporter-adapter/build/libs/logging-exporter-adapter-0.1.2-SNAPSHOT.jar \
      -Dota.jaeger.host=localhost \
      -Dota.jaeger.port=14250 \
-     -Dota.jaeger.service=shopping \
+     -Dota.service=shopping \
      -jar myapp.jar
 ```
 


### PR DESCRIPTION
with the service parameter `ota.jaeger.service=xxx` given in the documentation i got an `(unknown) ` service name in jaeger.

![image](https://user-images.githubusercontent.com/496277/75366233-b57b2b00-58be-11ea-8117-e17bd472c615.png)

Regarding the current implementation in https://github.com/open-telemetry/opentelemetry-auto-instr-java/blob/239eb53a44000f9f77e251a79e7189883451f5fc/agent-bootstrap/src/main/java/io/opentelemetry/auto/config/Config.java#L40 

We should replace the wrong ota.jaeger.service by ota.service in the documentation
