### PR TITLE
Remove non-delegating class loader check

### DIFF
--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ClassLoaderMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ClassLoaderMatcherTest.groovy
@@ -21,13 +21,6 @@ import io.opentelemetry.auto.util.test.AgentSpecification
 
 class ClassLoaderMatcherTest extends AgentSpecification {
 
-  def "skip non-delegating classloader"() {
-    setup:
-    final URLClassLoader badLoader = new NonDelegatingClassLoader()
-    expect:
-    ClassLoaderMatcher.skipClassLoader().matches(badLoader)
-  }
-
   def "skips agent classloader"() {
     setup:
     URL root = new URL("file://")
@@ -52,23 +45,4 @@ class ClassLoaderMatcherTest extends AgentSpecification {
     expect:
     AgentClassLoader.name == "io.opentelemetry.auto.bootstrap.AgentClassLoader"
   }
-
-  /*
-   * A URLClassloader which only delegates java.* classes
-   */
-
-  private static class NonDelegatingClassLoader extends URLClassLoader {
-    NonDelegatingClassLoader() {
-      super(new URL[0], (ClassLoader) null)
-    }
-
-    @Override
-    Class<?> loadClass(String className) {
-      if (className.startsWith("java.")) {
-        return super.loadClass(className)
-      }
-      throw new ClassNotFoundException(className)
-    }
-  }
-
 }


### PR DESCRIPTION
This is not needed anymore now that loadClass() is being instrumented to deal with non-delegating class loaders.