### PR TITLE
Fix the build

### DIFF
--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -228,6 +228,10 @@ public class AdditionalLibraryIgnoresMatcher<T extends TypeDescription>
       if (name.startsWith("com.google.inject.internal.AbstractBindingProcessor$")) {
         return false;
       }
+      // We instrument Callable there
+      if (name.startsWith("com.google.inject.internal.cglib.core.internal.$LoadingCache$")) {
+        return false;
+      }
       return true;
     }
     if (name.startsWith("com.google.api.")) {


### PR DESCRIPTION
The build is failing on `FinatraServerTest`, with

```
java.lang.AssertionError: Transformed classes match global libraries ignore matcher:
[class com.google.inject.internal.cglib.core.internal.$LoadingCache$2]
	at datadog.trace.agent.test.AgentTestRunner.agentCleanup(AgentTestRunner.java:201)
```