### PR TITLE
Fix 3 minor javadoc issues.

### DIFF
--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/java/concurrent/RunnableCallableInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/java/concurrent/RunnableCallableInstrumentation.java
@@ -36,7 +36,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-/** Instrument {@link Runnable} and {@Callable} */
+/** Instrument {@link Runnable} and {@link Callable} */
 @Slf4j
 @AutoService(Instrumenter.class)
 public final class RunnableCallableInstrumentation extends Instrumenter.Default {

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
@@ -71,7 +71,7 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
 
   public Span onConnection(final Span span, final Connection connection) {
     DBInfo dbInfo = JDBCMaps.connectionInfo.get(connection);
-    /**
+    /*
      * Logic to get the DBInfo from a JDBC Connection, if the connection was not created via
      * Driver.connect, or it has never seen before, the connectionInfo map will return null and will
      * attempt to extract DBInfo from the connection. If the DBInfo can't be extracted, then the

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/ContextPropagator.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/ContextPropagator.java
@@ -77,7 +77,7 @@ public class ContextPropagator {
     return result;
   }
 
-  /** @returns true when no error happened during call */
+  /** @return true when no error happened during call */
   private boolean syntheticCall(
       final Connection c, final ContextPayload payload, final int operationId) {
     final StreamRemoteCall shareContextCall = new StreamRemoteCall(c);


### PR DESCRIPTION
I ran IntelliJ's Javadoc inspections and ignored the "missing description" warnings; these were the three syntax issues left.  I looked for a way to get the gradle build to emit similar warnings/errors but was unable to find a way to do that.