### PR TITLE
Fix open-telemetry/opentelemetry-auto-instr-java#226

### DIFF
--- a/instrumentation/servlet/request-3.0/src/test/groovy/TestServlet3.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/TestServlet3.groovy
@@ -67,7 +67,7 @@ class TestServlet3 {
       def context = req.startAsync()
       context.start {
         try {
-          phaser.arrive()
+          phaser.arriveAndAwaitAdvance()
           HttpServerTest.controller(endpoint) {
             resp.contentType = "text/plain"
             switch (endpoint) {


### PR DESCRIPTION
TestServlet3.Async had a race where the async worker would arrive twice before the service worker would arrive once.