### PR TITLE
Better span names

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -102,7 +102,11 @@ public abstract class BaseDecorator {
    * @return
    */
   public String spanNameForMethod(final Method method) {
-    return spanNameForClass(method.getDeclaringClass()) + "." + method.getName();
+    return spanNameForClass(method.getDeclaringClass()) + "/" + method.getName();
+  }
+
+  public String spanNameForClass(final Class clazz, final String methodName) {
+    return spanNameForClass(clazz) + "/" + methodName;
   }
 
   /**

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecorator.java
@@ -15,22 +15,17 @@
  */
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
-import io.opentelemetry.trace.Span;
-
 public abstract class OrmClientDecorator extends DatabaseClientDecorator {
 
   public abstract String entityName(final Object entity);
 
-  public Span onOperation(final Span span, final Object entity) {
-
-    assert span != null;
+  public String spanNameForOperation(final String operationName, final Object entity) {
     if (entity != null) {
-      final String name = entityName(entity);
-      if (name != null) {
-        span.setAttribute(MoreTags.RESOURCE_NAME, name);
-      } // else we keep any existing resource.
+      final String entityName = entityName(entity);
+      if (entityName != null) {
+        return operationName + "/" + entityName;
+      }
     }
-    return span;
+    return operationName;
   }
 }

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -116,7 +116,7 @@ class BaseDecoratorTest extends AgentSpecification {
     def result = decorator.spanNameForMethod(method)
 
     then:
-    result == "${name}.run"
+    result == "${name}/run"
 
     where:
     target                         | name

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
@@ -15,42 +15,24 @@
  */
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags
-import io.opentelemetry.trace.Span
-
 class OrmClientDecoratorTest extends DatabaseClientDecoratorTest {
 
-  def "test onOperation #testName"() {
+  def "test spanNameForOperation #testName"() {
     setup:
     decorator = newDecorator({ e -> entityName })
 
     when:
-    decorator.onOperation(span, entity)
+    def result = decorator.spanNameForOperation("orm", entity)
 
     then:
-    if (isSet) {
-      1 * span.setAttribute(MoreTags.RESOURCE_NAME, entityName)
-    }
-    0 * _
+    result == spanName
 
     where:
-    testName          | entity     | entityName | isSet
-    "null entity"     | null       | "name"     | false
-    "null entityName" | "not null" | null       | false
-    "name set"        | "not null" | "name"     | true
+    testName          | entity     | entityName | spanName
+    "null entity"     | null       | "name"     | "orm"
+    "null entityName" | "not null" | null       | "orm"
+    "name set"        | "not null" | "name"     | "orm/name"
   }
-
-  def "test onOperation null span"() {
-    setup:
-    decorator = newDecorator({ e -> null })
-
-    when:
-    decorator.onOperation((Span) null, null)
-
-    then:
-    thrown(AssertionError)
-  }
-
 
   def newDecorator(name) {
     return new OrmClientDecorator() {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/aws/v0/AwsSdkClientDecorator.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/aws/v0/AwsSdkClientDecorator.java
@@ -21,7 +21,6 @@ import com.amazonaws.Request;
 import com.amazonaws.Response;
 import io.opentelemetry.auto.bootstrap.ContextStore;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 import java.net.URI;
 import java.util.Map;
@@ -41,6 +40,16 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
   }
 
   @Override
+  public String spanNameForRequest(final Request request) {
+    if (request == null) {
+      return DEFAULT_SPAN_NAME;
+    }
+    final String awsServiceName = request.getServiceName();
+    final Class<?> awsOperation = request.getOriginalRequest().getClass();
+    return remapServiceName(awsServiceName) + "/" + remapOperationName(awsOperation);
+  }
+
+  @Override
   public Span onRequest(final Span span, final Request request) {
     // Call super first because we override the resource name below.
     super.onRequest(span, request);
@@ -53,10 +62,6 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<Request, Response
     span.setAttribute("aws.service", awsServiceName);
     span.setAttribute("aws.operation", awsOperation.getSimpleName());
     span.setAttribute("aws.endpoint", request.getEndpoint().toString());
-
-    span.setAttribute(
-        MoreTags.RESOURCE_NAME,
-        remapServiceName(awsServiceName) + "." + remapOperationName(awsOperation));
 
     if (contextStore != null) {
       final RequestMeta requestMeta = contextStore.get(originalRequest);

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
@@ -151,13 +151,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName expectedOperationName(method)
+          operationName "$service/$operation"
           spanKind CLIENT
           errored false
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "$service.$operation"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
@@ -242,13 +241,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName expectedOperationName(method)
+          operationName "$service/$operation"
           spanKind CLIENT
           errored true
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "$service.$operation"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
@@ -305,13 +303,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName expectedOperationName("HEAD")
+          operationName "S3/HeadBucket"
           spanKind CLIENT
           errored true
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "S3.HeadBucket"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
@@ -350,13 +347,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          operationName expectedOperationName("GET")
+          operationName "S3/GetObject"
           spanKind CLIENT
           errored true
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "S3.GetObject"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -114,13 +114,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName expectedOperationName(method)
+          operationName "$service/$operation"
           spanKind CLIENT
           errored false
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "$service.$operation"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
@@ -187,13 +186,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName expectedOperationName(method)
+          operationName "$service/$operation"
           spanKind CLIENT
           errored true
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "$service.$operation"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
@@ -250,13 +248,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName expectedOperationName("GET")
+          operationName "S3/GetObject"
           spanKind CLIENT
           errored true
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "S3.GetObject"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
@@ -296,13 +293,12 @@ class AWSClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          operationName expectedOperationName("GET")
+          operationName "S3/GetObject"
           spanKind CLIENT
           errored true
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "S3.GetObject"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/aws/v2/AwsSdkClientDecorator.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/aws/v2/AwsSdkClientDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.aws.v2;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.net.URI;
@@ -60,13 +59,17 @@ public class AwsSdkClientDecorator extends HttpClientDecorator<SdkHttpRequest, S
     return span;
   }
 
+  public String spanName(final ExecutionAttributes attributes) {
+    final String awsServiceName = attributes.getAttribute(SdkExecutionAttribute.SERVICE_NAME);
+    final String awsOperation = attributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
+
+    return awsServiceName + "/" + awsOperation;
+  }
+
   public Span onAttributes(final Span span, final ExecutionAttributes attributes) {
 
     final String awsServiceName = attributes.getAttribute(SdkExecutionAttribute.SERVICE_NAME);
     final String awsOperation = attributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME);
-
-    // Resource Name has to be set after the HTTP_URL because otherwise decorators overwrite it
-    span.setAttribute(MoreTags.RESOURCE_NAME, awsServiceName + "." + awsOperation);
 
     span.setAttribute("aws.agent", COMPONENT_NAME);
     span.setAttribute("aws.service", awsServiceName);

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/aws/v2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/aws/v2/TracingExecutionInterceptor.java
@@ -15,7 +15,6 @@
  */
 package io.opentelemetry.auto.instrumentation.aws.v2;
 
-import static io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator.DEFAULT_SPAN_NAME;
 import static io.opentelemetry.auto.instrumentation.aws.v2.AwsSdkClientDecorator.DECORATE;
 import static io.opentelemetry.auto.instrumentation.aws.v2.AwsSdkClientDecorator.TRACER;
 import static io.opentelemetry.trace.Span.Kind.CLIENT;
@@ -49,7 +48,8 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void beforeExecution(
       final Context.BeforeExecution context, final ExecutionAttributes executionAttributes) {
-    final Span span = TRACER.spanBuilder(DEFAULT_SPAN_NAME).setSpanKind(CLIENT).startSpan();
+    final Span span =
+        TRACER.spanBuilder(DECORATE.spanName(executionAttributes)).setSpanKind(CLIENT).startSpan();
     try (final Scope scope = TRACER.withSpan(span)) {
       DECORATE.afterStart(span);
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);
@@ -61,7 +61,6 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
       final Context.AfterMarshalling context, final ExecutionAttributes executionAttributes) {
     final Span span = executionAttributes.getAttribute(SPAN_ATTRIBUTE);
 
-    span.updateName(DECORATE.spanNameForRequest(context.httpRequest()));
     DECORATE.onRequest(span, context.httpRequest());
     DECORATE.onSdkRequest(span, context.request());
     DECORATE.onAttributes(span, executionAttributes);

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -92,13 +92,12 @@ class AwsClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName expectedOperationName(method)
+          operationName "$service/$operation"
           spanKind CLIENT
           errored false
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "$service.$operation"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -198,13 +197,12 @@ class AwsClientTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
-          operationName expectedOperationName(method)
+          operationName "$service/$operation"
           spanKind CLIENT
           errored false
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "$service.$operation"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -315,13 +313,12 @@ class AwsClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          operationName expectedOperationName("GET")
+          operationName "S3/GetObject"
           spanKind CLIENT
           errored true
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "java-aws-sdk"
-            "$MoreTags.RESOURCE_NAME" "S3.GetObject"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/datastax/cassandra/TracingSession.java
+++ b/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/datastax/cassandra/TracingSession.java
@@ -260,7 +260,7 @@ public class TracingSession implements Session {
   }
 
   private Span startSpan(final String query) {
-    final Span span = TRACER.spanBuilder("cassandra.query").setSpanKind(CLIENT).startSpan();
+    final Span span = TRACER.spanBuilder(query).setSpanKind(CLIENT).startSpan();
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, session);
     DECORATE.onStatement(span, query);

--- a/instrumentation/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
@@ -125,7 +125,7 @@ class CassandraClientTest extends AgentTestRunner {
 
   def cassandraSpan(TraceAssert trace, int index, String statement, String keyspace, boolean renameService, Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      operationName "cassandra.query"
+      operationName statement
       spanKind CLIENT
       if (parentSpan == null) {
         parent()

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
@@ -18,7 +18,6 @@ package io.opentelemetry.auto.instrumentation.couchbase.client;
 import static io.opentelemetry.auto.instrumentation.couchbase.client.CouchbaseClientDecorator.DECORATE;
 import static io.opentelemetry.trace.Span.Kind.CLIENT;
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.instrumentation.rxjava.TracedOnSubscribe;
 import io.opentelemetry.trace.Span;
@@ -49,7 +48,7 @@ public class CouchbaseOnSubscribe extends TracedOnSubscribe {
   protected void afterStart(final Span span) {
     super.afterStart(span);
 
-    span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+    span.updateName(resourceName);
 
     if (bucket != null) {
       span.setAttribute(Tags.DB_INSTANCE, bucket);

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -124,7 +124,7 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
 
   void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     trace.span(index) {
-      operationName "couchbase.call"
+      operationName name
       spanKind CLIENT
       errored false
       if (parentSpan == null) {
@@ -134,7 +134,6 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       }
       tags {
         "$MoreTags.SERVICE_NAME" "couchbase"
-        "$MoreTags.RESOURCE_NAME" name
         "$MoreTags.SPAN_TYPE" SpanTypes.COUCHBASE
         "$Tags.COMPONENT" "couchbase-client"
         "$Tags.DB_TYPE" "couchbase"

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -26,7 +26,7 @@ class CouchbaseSpanUtil {
   // Of the class hierarchy of these tests
   static void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     trace.span(index) {
-      operationName "couchbase.call"
+      operationName name
       spanKind CLIENT
       errored false
       if (parentSpan == null) {
@@ -36,7 +36,6 @@ class CouchbaseSpanUtil {
       }
       tags {
         "$MoreTags.SERVICE_NAME" "couchbase"
-        "$MoreTags.RESOURCE_NAME" name
         "$MoreTags.SPAN_TYPE" SpanTypes.COUCHBASE
         "$Tags.COMPONENT" "couchbase-client"
 

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -100,12 +100,11 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
   @Override
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      operationName "jax-rs.request"
+      operationName "${this.testResource().simpleName}/${endpoint.name().toLowerCase()}"
       spanKind INTERNAL
       errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$MoreTags.RESOURCE_NAME" "${this.testResource().simpleName}.${endpoint.name().toLowerCase()}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" JaxRsAnnotationsDecorator.DECORATE.getComponentName()
         if (endpoint == EXCEPTION) {
@@ -128,7 +127,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         parent()
       }
       tags {
-        "$MoreTags.RESOURCE_NAME" "$method ${endpoint == PATH_PARAM ? "/path/{id}/param" : endpoint.resolvePath(address).path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -27,7 +27,6 @@ import com.google.auto.service.AutoService;
 import io.dropwizard.views.View;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
@@ -83,8 +82,7 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Default {
       if (!TRACER.getCurrentSpan().getContext().isValid()) {
         return null;
       }
-      final Span span = TRACER.spanBuilder("view.render").startSpan();
-      span.setAttribute(MoreTags.RESOURCE_NAME, "View " + view.getTemplateName());
+      final Span span = TRACER.spanBuilder("Render " + view.getTemplateName()).startSpan();
       span.setAttribute(Tags.COMPONENT, "dropwizard-view");
       span.setAttribute("span.origin.type", obj.getClass().getSimpleName());
       return new SpanWithScope(span, TRACER.withSpan(span));

--- a/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
+++ b/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
@@ -16,7 +16,6 @@
 import io.dropwizard.views.View
 import io.dropwizard.views.freemarker.FreemarkerViewRenderer
 import io.dropwizard.views.mustache.MustacheViewRenderer
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
@@ -42,10 +41,9 @@ class ViewRenderTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "view.render"
+          operationName "Render $template"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "View $template"
             "$Tags.COMPONENT" "dropwizard-view"
             "span.origin.type" renderer.class.simpleName
           }

--- a/instrumentation/elasticsearch/elasticsearch-common/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/instrumentation/elasticsearch/elasticsearch-common/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.elasticsearch;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanTypes;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -59,13 +58,8 @@ public class ElasticsearchTransportClientDecorator extends DatabaseClientDecorat
   }
 
   public Span onRequest(final Span span, final Class action, final Class request) {
-    if (action != null) {
-      span.setAttribute(MoreTags.RESOURCE_NAME, action.getSimpleName());
-      span.setAttribute("elasticsearch.action", action.getSimpleName());
-    }
-    if (request != null) {
-      span.setAttribute("elasticsearch.request", request.getSimpleName());
-    }
+    span.setAttribute("elasticsearch.action", action.getSimpleName());
+    span.setAttribute("elasticsearch.request", request.getSimpleName());
     return span;
   }
 }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -97,7 +97,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "elasticsearch.rest.query"
+          operationName "Elasticsearch/RestQuery"
           spanKind CLIENT
           parent()
           tags {

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch5/Elasticsearch5RestClientInstrumentation.java
@@ -76,7 +76,7 @@ public class Elasticsearch5RestClientInstrumentation extends Instrumenter.Defaul
         @Advice.Argument(value = 5, readOnly = false) ResponseListener responseListener) {
 
       final Span span =
-          TRACER.spanBuilder("elasticsearch.rest.query").setSpanKind(CLIENT).startSpan();
+          TRACER.spanBuilder("Elasticsearch/RestQuery").setSpanKind(CLIENT).startSpan();
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, method, endpoint);
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -101,7 +101,7 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "elasticsearch.rest.query"
+          operationName "Elasticsearch/RestQuery"
           spanKind CLIENT
           parent()
           tags {

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -101,7 +101,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "elasticsearch.rest.query"
+          operationName "Elasticsearch/RestQuery"
           spanKind CLIENT
           parent()
           tags {

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch6_4/Elasticsearch6RestClientInstrumentation.java
@@ -75,7 +75,7 @@ public class Elasticsearch6RestClientInstrumentation extends Instrumenter.Defaul
         @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener) {
 
       final Span span =
-          TRACER.spanBuilder("elasticsearch.rest.query").setSpanKind(CLIENT).startSpan();
+          TRACER.spanBuilder("Elasticsearch/RestQuery").setSpanKind(CLIENT).startSpan();
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, request.getMethod(), request.getEndpoint());
 

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -97,7 +97,7 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "elasticsearch.rest.query"
+          operationName "Elasticsearch/RestQuery"
           spanKind CLIENT
           parent()
           tags {

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -88,11 +88,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -115,12 +114,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -180,11 +178,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(5) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -196,11 +193,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -211,11 +207,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -230,11 +225,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(3, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -245,12 +239,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -262,11 +255,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -99,11 +99,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -129,12 +128,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -194,7 +192,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (traces[3][0].attributes[MoreTags.RESOURCE_NAME].stringValue == "IndexAction") {
+        if (traces[3][0].name == "Elasticsearch/IndexAction") {
           def tmp = traces[3]
           traces[3] = traces[4]
           traces[4] = tmp
@@ -202,11 +200,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -221,11 +218,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -239,11 +235,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -261,11 +256,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(3, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -277,11 +271,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -297,11 +290,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(5, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -53,12 +53,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -86,11 +85,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -101,12 +99,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -118,11 +115,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -145,11 +141,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -176,11 +171,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(3) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -193,11 +187,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -212,11 +205,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -242,11 +234,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(3) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/DeleteAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "DeleteAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -259,11 +250,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -278,11 +268,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -94,12 +94,11 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -148,11 +147,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(6) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -164,11 +162,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -179,11 +176,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -196,11 +192,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(3, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -211,12 +206,11 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -228,11 +222,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -247,11 +240,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(5, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -328,11 +320,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch2/Elasticsearch2TransportClientInstrumentation.java
@@ -85,7 +85,11 @@ public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.D
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final Span span = TRACER.spanBuilder("elasticsearch.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder("Elasticsearch/" + action.getClass().getSimpleName())
+              .setSpanKind(CLIENT)
+              .startSpan();
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -88,11 +88,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -115,12 +114,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -180,11 +178,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
     assertTraces(5) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -196,11 +193,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -211,11 +207,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -233,11 +228,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(3, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -251,12 +245,11 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -268,11 +261,10 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -100,11 +100,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
@@ -133,10 +132,9 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterStatsAction"
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterStatsAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
@@ -163,12 +161,11 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -228,7 +225,7 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
     assertTraces(6) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (traces[3][0].attributes[MoreTags.RESOURCE_NAME].stringValue == "IndexAction") {
+        if (traces[3][0].name == "Elasticsearch/IndexAction") {
           def tmp = traces[3]
           traces[3] = traces[4]
           traces[4] = tmp
@@ -236,11 +233,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
@@ -255,11 +251,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
@@ -273,11 +268,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
@@ -295,11 +289,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(3, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -311,11 +304,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
@@ -331,11 +323,10 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
       }
       trace(5, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -53,12 +53,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -86,11 +85,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -104,12 +102,11 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -121,11 +118,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -148,11 +144,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -182,11 +177,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(3) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -202,11 +196,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -221,11 +214,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -254,11 +246,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
     assertTraces(3) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/DeleteAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "DeleteAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -274,11 +265,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -293,11 +283,10 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -94,12 +94,11 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -148,11 +147,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(6) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -164,11 +162,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -179,11 +176,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -196,11 +192,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(3, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
@@ -214,12 +209,11 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -231,11 +225,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -250,11 +243,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
       }
       trace(5, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -330,11 +322,10 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch5/Elasticsearch5TransportClientInstrumentation.java
@@ -85,7 +85,11 @@ public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.D
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final Span span = TRACER.spanBuilder("elasticsearch.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder("Elasticsearch/" + action.getClass().getSimpleName())
+              .setSpanKind(CLIENT)
+              .startSpan();
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -94,11 +94,10 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -121,12 +120,11 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           errored true
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -187,11 +185,10 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
     assertTraces(5) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -203,11 +200,10 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -218,11 +214,10 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -237,11 +232,10 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       }
       trace(3, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -256,12 +250,11 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -272,11 +265,10 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -106,11 +106,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
@@ -136,12 +135,11 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -201,7 +199,7 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
     assertTraces(5) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (traces[2][0].attributes[MoreTags.RESOURCE_NAME].stringValue == "IndexAction") {
+        if (traces[2][0].name == "Elasticsearch/IndexAction") {
           def tmp = traces[2]
           traces[2] = traces[3]
           traces[3] = tmp
@@ -209,11 +207,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
       }
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
@@ -228,11 +225,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
@@ -250,11 +246,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -265,11 +260,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
       }
       trace(3, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
@@ -289,11 +283,10 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -86,7 +86,11 @@ public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final Span span = TRACER.spanBuilder("elasticsearch.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder("Elasticsearch/" + action.getClass().getSimpleName())
+              .setSpanKind(CLIENT)
+              .startSpan();
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -94,11 +94,10 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -121,12 +120,11 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -187,11 +185,10 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
     assertTraces(5) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -203,11 +200,10 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -218,11 +214,10 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -237,11 +232,10 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
       }
       trace(3, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -257,12 +251,11 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -273,11 +266,10 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -106,11 +106,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -136,12 +135,11 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -201,7 +199,7 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
     assertTraces(5) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (traces[2][0].attributes[MoreTags.RESOURCE_NAME].stringValue == "IndexAction") {
+        if (traces[2][0].name == "Elasticsearch/IndexAction") {
           def tmp = traces[2]
           traces[2] = traces[3]
           traces[3] = tmp
@@ -209,11 +207,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
       }
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -228,11 +225,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -250,11 +246,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -265,11 +260,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
       }
       trace(3, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -290,11 +284,10 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -86,22 +86,20 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           sort(spans)
         }
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/findAll"
           spanKind INTERNAL
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.findAll"
             "$Tags.COMPONENT" "spring-data"
           }
         }
 
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           errored false
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -132,20 +130,18 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           sort(spans)
         }
         span(0) {
-          operationName "repository.operation"
+          operationName "ElasticsearchRepository/index"
           spanKind INTERNAL
           tags {
-            "$MoreTags.RESOURCE_NAME" "ElasticsearchRepository.index"
             "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -161,12 +157,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -175,12 +170,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
         span(3) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -206,21 +200,19 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           sort(spans)
         }
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/findById"
           spanKind INTERNAL
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.findById"
             "$Tags.COMPONENT" "spring-data"
           }
         }
 
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -250,20 +242,18 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           sort(spans)
         }
         span(0) {
-          operationName "repository.operation"
+          operationName "ElasticsearchRepository/index"
           spanKind INTERNAL
           tags {
-            "$MoreTags.RESOURCE_NAME" "ElasticsearchRepository.index"
             "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -279,12 +269,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -302,21 +291,19 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           sort(spans)
         }
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/findById"
           spanKind INTERNAL
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.findById"
             "$Tags.COMPONENT" "spring-data"
           }
         }
 
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -345,21 +332,19 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           sort(spans)
         }
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/deleteById"
           spanKind INTERNAL
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.deleteById"
             "$Tags.COMPONENT" "spring-data"
           }
         }
 
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/DeleteAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "DeleteAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -374,12 +359,11 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -398,21 +382,19 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           sort(spans)
         }
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/findAll"
           spanKind INTERNAL
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.findAll"
             "$Tags.COMPONENT" "spring-data"
           }
         }
 
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -113,12 +113,11 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -167,11 +166,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
     assertTraces(6) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -183,11 +181,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -198,11 +195,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -215,11 +211,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       }
       trace(3, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -235,12 +230,11 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -251,11 +245,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/RefreshAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "RefreshAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -270,11 +263,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
       }
       trace(5, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -351,11 +343,10 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/SearchAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "SearchAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch6/Elasticsearch6TransportClientInstrumentation.java
@@ -89,7 +89,11 @@ public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.D
         @Advice.Argument(value = 2, readOnly = false)
             ActionListener<ActionResponse> actionListener) {
 
-      final Span span = TRACER.spanBuilder("elasticsearch.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder("Elasticsearch/" + action.getClass().getSimpleName())
+              .setSpanKind(CLIENT)
+              .startSpan();
       DECORATE.afterStart(span);
       DECORATE.onRequest(span, action.getClass(), actionRequest.getClass());
 

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -91,11 +91,10 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -118,12 +117,11 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -183,11 +181,10 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
     assertTraces(4) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -199,11 +196,10 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -218,11 +214,10 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       }
       trace(2, 2) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -238,12 +233,11 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -254,11 +248,10 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
       }
       trace(3, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -103,11 +103,10 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/ClusterHealthAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "ClusterHealthAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -133,12 +132,11 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -198,7 +196,7 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
     assertTraces(5) {
       sortTraces {
         // IndexAction and PutMappingAction run in separate threads and so their order is not always the same
-        if (traces[2][0].attributes[MoreTags.RESOURCE_NAME].stringValue == "IndexAction") {
+        if (traces[2][0].name == "Elasticsearch/IndexAction") {
           def tmp = traces[2]
           traces[2] = traces[3]
           traces[3] = tmp
@@ -206,11 +204,10 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
       }
       trace(0, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/CreateIndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "CreateIndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -225,11 +222,10 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -247,11 +243,10 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
       }
       trace(2, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/PutMappingAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "PutMappingAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
@@ -262,11 +257,10 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
       }
       trace(3, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/IndexAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "IndexAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -287,11 +281,10 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
       }
       trace(4, 1) {
         span(0) {
-          operationName "elasticsearch.query"
+          operationName "Elasticsearch/GetAction"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "elasticsearch"
-            "$MoreTags.RESOURCE_NAME" "GetAction"
             "$MoreTags.SPAN_TYPE" SpanTypes.ELASTICSEARCH
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
@@ -33,7 +33,6 @@ import com.twitter.finatra.http.contexts.RouteInfo;
 import com.twitter.util.Future;
 import com.twitter.util.FutureEventListener;
 import io.opentelemetry.auto.config.Config;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
@@ -91,16 +90,13 @@ public class FinatraInstrumentation extends Instrumenter.Default {
         @Advice.FieldValue("clazz") final Class clazz,
         @Advice.Origin final Method method) {
 
-      // Update the parent "netty.request"
       final Span parent = TRACER.getCurrentSpan();
       final String resourceName = request.method().name() + " " + routeInfo.path();
-      parent.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
       parent.setAttribute(Tags.COMPONENT, "finatra");
       parent.updateName(resourceName);
 
-      final Span span = TRACER.spanBuilder("finatra.controller").startSpan();
+      final Span span = TRACER.spanBuilder(DECORATE.spanNameForClass(clazz)).startSpan();
       DECORATE.afterStart(span);
-      span.setAttribute(MoreTags.RESOURCE_NAME, DECORATE.spanNameForClass(clazz));
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -89,12 +89,11 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
     trace.span(index) {
-      operationName "finatra.controller"
+      operationName "FinatraController"
       spanKind INTERNAL
       errored errorEndpoint
       childOf(parent as SpanData)
       tags {
-        "$MoreTags.RESOURCE_NAME" "FinatraController"
         "$MoreTags.SPAN_TYPE" "web"
         "$Tags.COMPONENT" FinatraDecorator.DECORATE.getComponentName()
 
@@ -104,7 +103,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
     }
   }
 
-  // need to override in order to add RESOURCE_NAME
   @Override
   void serverSpan(TraceAssert trace, int index, String traceID = null, String parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
@@ -118,7 +116,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
         parent()
       }
       tags {
-        "$MoreTags.RESOURCE_NAME" "$method ${endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.resolvePath(address).path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_PORT" Long

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/CriteriaInstrumentation.java
@@ -59,22 +59,24 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope startMethod(
-        @Advice.This final Criteria criteria, @Advice.Origin("#m") final String name) {
+        @Advice.This final Criteria criteria, @Advice.Origin("#m") final String methodName) {
 
       final ContextStore<Criteria, Span> contextStore =
           InstrumentationContext.get(Criteria.class, Span.class);
 
       return SessionMethodUtils.startScopeFrom(
-          contextStore, criteria, "hibernate.criteria." + name, null, true);
+          contextStore, criteria, "hibernate/criteria/" + methodName, null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void endMethod(
         @Advice.Enter final SpanWithScope spanWithScope,
         @Advice.Thrown final Throwable throwable,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) final Object entity) {
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC) final Object entity,
+        @Advice.Origin("#m") final String methodName) {
 
-      SessionMethodUtils.closeScope(spanWithScope, throwable, entity);
+      SessionMethodUtils.closeScope(
+          spanWithScope, throwable, "hibernate/criteria/" + methodName, entity);
     }
   }
 }

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/SessionFactoryInstrumentation.java
@@ -75,7 +75,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final Object session) {
 
-      final Span span = TRACER.spanBuilder("hibernate.session").startSpan();
+      final Span span = TRACER.spanBuilder("hibernate/session").startSpan();
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/SessionInstrumentation.java
@@ -153,20 +153,20 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope startMethod(
         @Advice.This final Object session,
-        @Advice.Origin("#m") final String name,
+        @Advice.Origin("#m") final String methodName,
         @Advice.Argument(0) final Object entity) {
 
-      final boolean startSpan = !SCOPE_ONLY_METHODS.contains(name);
+      final boolean startSpan = !SCOPE_ONLY_METHODS.contains(methodName);
       if (session instanceof Session) {
         final ContextStore<Session, Span> contextStore =
             InstrumentationContext.get(Session.class, Span.class);
         return SessionMethodUtils.startScopeFrom(
-            contextStore, (Session) session, "hibernate." + name, entity, startSpan);
+            contextStore, (Session) session, "hibernate/" + methodName, entity, startSpan);
       } else if (session instanceof StatelessSession) {
         final ContextStore<StatelessSession, Span> contextStore =
             InstrumentationContext.get(StatelessSession.class, Span.class);
         return SessionMethodUtils.startScopeFrom(
-            contextStore, (StatelessSession) session, "hibernate." + name, entity, startSpan);
+            contextStore, (StatelessSession) session, "hibernate/" + methodName, entity, startSpan);
       }
       return null;
     }
@@ -175,9 +175,10 @@ public class SessionInstrumentation extends AbstractHibernateInstrumentation {
     public static void endMethod(
         @Advice.Enter final SpanWithScope spanWithScope,
         @Advice.Thrown final Throwable throwable,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) final Object returned) {
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC) final Object returned,
+        @Advice.Origin("#m") final String methodName) {
 
-      SessionMethodUtils.closeScope(spanWithScope, throwable, returned);
+      SessionMethodUtils.closeScope(spanWithScope, throwable, "hibernate/" + methodName, returned);
     }
   }
 

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v3_3/TransactionInstrumentation.java
@@ -64,14 +64,14 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
           InstrumentationContext.get(Transaction.class, Span.class);
 
       return SessionMethodUtils.startScopeFrom(
-          contextStore, transaction, "hibernate.transaction.commit", null, true);
+          contextStore, transaction, "hibernate/transaction/commit", null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void endCommit(
         @Advice.Enter final SpanWithScope spanWithScope, @Advice.Thrown final Throwable throwable) {
 
-      SessionMethodUtils.closeScope(spanWithScope, throwable, null);
+      SessionMethodUtils.closeScope(spanWithScope, throwable, null, null);
     }
   }
 }

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
@@ -41,7 +41,7 @@ class CriteriaTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -51,7 +51,7 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.criteria.$methodName"
+          operationName "hibernate/criteria/$methodName"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -61,11 +61,11 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(2) {
+          operationName ~/^select /
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -76,7 +76,7 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
@@ -46,7 +46,7 @@ class QueryTest extends AbstractHibernateTest {
       // With Transaction
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -56,12 +56,15 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.$queryMethodName"
+          if (resource) {
+            operationName "hibernate/$queryMethodName/$resource"
+          } else {
+            operationName "hibernate/$queryMethodName"
+          }
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" resource
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.DB_STATEMENT" queryMethodName == "iterate" ? null : String
@@ -72,7 +75,6 @@ class QueryTest extends AbstractHibernateTest {
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -83,7 +85,7 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -97,7 +99,7 @@ class QueryTest extends AbstractHibernateTest {
         // Without Transaction
         trace(1, 3) {
           span(0) {
-            operationName "hibernate.session"
+            operationName "hibernate/session"
             spanKind INTERNAL
             parent()
             tags {
@@ -107,23 +109,26 @@ class QueryTest extends AbstractHibernateTest {
             }
           }
           span(1) {
-            operationName "hibernate.$queryMethodName"
+            if (resource) {
+              operationName "hibernate/$queryMethodName/$resource"
+            } else {
+              operationName "hibernate/$queryMethodName"
+            }
             spanKind INTERNAL
             childOf span(0)
             tags {
               "$MoreTags.SERVICE_NAME" "hibernate"
-              "$MoreTags.RESOURCE_NAME" resource
               "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
               "$Tags.COMPONENT" "java-hibernate"
               "$Tags.DB_STATEMENT" queryMethodName == "iterate" ? null : String
             }
           }
           span(2) {
+            operationName ~/^select /
             spanKind CLIENT
             childOf span(1)
             tags {
               "$MoreTags.SERVICE_NAME" "h2"
-              "$MoreTags.RESOURCE_NAME" ~/^select /
               "$MoreTags.SPAN_TYPE" "sql"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "h2"
@@ -139,15 +144,15 @@ class QueryTest extends AbstractHibernateTest {
 
     where:
     queryMethodName       | resource     | requiresTransaction | queryInteraction
-    "query.list"          | "Value"      | false               | { sess ->
+    "query/list"          | "Value"      | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.list()
     }
-    "query.executeUpdate" | null         | true                | { sess ->
+    "query/executeUpdate" | null         | true                | { sess ->
       Query q = sess.createQuery("update Value set name = 'alyx'")
       q.executeUpdate()
     }
-    "query.uniqueResult"  | "Value"      | false               | { sess ->
+    "query/uniqueResult"  | "Value"      | false               | { sess ->
       Query q = sess.createQuery("from Value where id = 1")
       q.uniqueResult()
     }
@@ -155,7 +160,7 @@ class QueryTest extends AbstractHibernateTest {
       Query q = sess.createQuery("from Value")
       q.iterate()
     }
-    "query.scroll"        | null         | false               | { sess ->
+    "query/scroll"        | null         | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.scroll()
     }
@@ -178,7 +183,7 @@ class QueryTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -188,22 +193,21 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.iterate"
+          operationName "hibernate/iterate/from Value"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "from Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
+          operationName ~/^select /
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -214,7 +218,7 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
@@ -58,7 +58,7 @@ class SessionTest extends AbstractHibernateTest {
       for (int i = 0; i < sessionImplementations.size(); i++) {
         trace(i, 4) {
           span(0) {
-            operationName "hibernate.session"
+            operationName "hibernate/session"
             spanKind INTERNAL
             parent()
             tags {
@@ -68,33 +68,32 @@ class SessionTest extends AbstractHibernateTest {
             }
           }
           span(1) {
-            operationName "hibernate.$methodName"
+            operationName "hibernate/$methodName/$resource"
             spanKind INTERNAL
             childOf span(0)
             tags {
               "$MoreTags.SERVICE_NAME" "hibernate"
-              "$MoreTags.RESOURCE_NAME" resource
               "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(2) {
+            operationName ~/^select /
             spanKind CLIENT
             childOf span(1)
             tags {
               "$MoreTags.SERVICE_NAME" "h2"
-              "$MoreTags.RESOURCE_NAME" String
               "$MoreTags.SPAN_TYPE" "sql"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "h2"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
-              "$Tags.DB_STATEMENT" String
+              "$Tags.DB_STATEMENT" ~/^select /
               "span.origin.type" "org.h2.jdbc.JdbcPreparedStatement"
             }
           }
           span(3) {
-            operationName "hibernate.transaction.commit"
+            operationName "hibernate/transaction/commit"
             spanKind INTERNAL
             childOf span(0)
             tags {
@@ -140,7 +139,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -150,18 +149,17 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.$methodName"
+          operationName "hibernate/$methodName/$resource"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" resource
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -175,7 +173,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(2)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -226,7 +223,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -236,22 +233,21 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.$methodName"
+          operationName "hibernate/$methodName/$resource"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" resource
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
+          operationName ~/^select /
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -262,7 +258,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -276,7 +272,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(3)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -324,7 +319,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -334,7 +329,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.replicate"
+          operationName "hibernate/replicate"
           spanKind INTERNAL
           childOf span(0)
           errored(true)
@@ -346,7 +341,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(2) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -380,7 +375,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -390,18 +385,17 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.$methodName"
+          operationName "hibernate/$methodName/$resource"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" resource
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -415,7 +409,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(2)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -473,7 +466,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -483,12 +476,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.query.list"
+          operationName "hibernate/query/list/$resource"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "$resource"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.DB_STATEMENT" String
@@ -499,7 +491,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -510,7 +501,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -560,7 +551,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -570,29 +561,27 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(2) {
-          operationName "hibernate.save"
+          operationName "hibernate/save/Value"
           spanKind INTERNAL
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(3) {
-          operationName "hibernate.delete"
+          operationName "hibernate/delete/Value"
           spanKind INTERNAL
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(4) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(1)
           tags {
@@ -602,11 +591,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(5) {
+          operationName ~/^insert /
           spanKind CLIENT
           childOf span(4)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^insert /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -617,11 +606,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(6) {
+          operationName ~/^delete /
           spanKind CLIENT
           childOf span(4)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^delete /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -632,7 +621,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(7) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -642,18 +631,17 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(8) {
-          operationName "hibernate.insert"
+          operationName "hibernate/insert/Value"
           spanKind INTERNAL
           childOf span(7)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(9) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -663,12 +651,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(10) {
-          operationName "hibernate.save"
+          operationName "hibernate/save/Value"
           spanKind INTERNAL
           childOf span(9)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_0/CriteriaInstrumentation.java
@@ -59,22 +59,24 @@ public class CriteriaInstrumentation extends AbstractHibernateInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope startMethod(
-        @Advice.This final Criteria criteria, @Advice.Origin("#m") final String name) {
+        @Advice.This final Criteria criteria, @Advice.Origin("#m") final String methodName) {
 
       final ContextStore<Criteria, Span> contextStore =
           InstrumentationContext.get(Criteria.class, Span.class);
 
       return SessionMethodUtils.startScopeFrom(
-          contextStore, criteria, "hibernate.criteria." + name, null, true);
+          contextStore, criteria, "hibernate/criteria/" + methodName, null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void endMethod(
         @Advice.Enter final SpanWithScope spanWithScope,
         @Advice.Thrown final Throwable throwable,
-        @Advice.Return(typing = Assigner.Typing.DYNAMIC) final Object entity) {
+        @Advice.Return(typing = Assigner.Typing.DYNAMIC) final Object entity,
+        @Advice.Origin("#m") final String methodName) {
 
-      SessionMethodUtils.closeScope(spanWithScope, throwable, entity);
+      SessionMethodUtils.closeScope(
+          spanWithScope, throwable, "hibernate/criteria/" + methodName, entity);
     }
   }
 }

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_0/SessionFactoryInstrumentation.java
@@ -66,7 +66,7 @@ public class SessionFactoryInstrumentation extends AbstractHibernateInstrumentat
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void openSession(@Advice.Return final SharedSessionContract session) {
 
-      final Span span = TRACER.spanBuilder("hibernate.session").startSpan();
+      final Span span = TRACER.spanBuilder("hibernate/session").startSpan();
       DECORATOR.afterStart(span);
       DECORATOR.onConnection(span, session);
 

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_0/TransactionInstrumentation.java
@@ -64,14 +64,14 @@ public class TransactionInstrumentation extends AbstractHibernateInstrumentation
           InstrumentationContext.get(Transaction.class, Span.class);
 
       return SessionMethodUtils.startScopeFrom(
-          contextStore, transaction, "hibernate.transaction.commit", null, true);
+          contextStore, transaction, "hibernate/transaction/commit", null, true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void endCommit(
         @Advice.Enter final SpanWithScope spanWithScope, @Advice.Thrown final Throwable throwable) {
 
-      SessionMethodUtils.closeScope(spanWithScope, throwable, null);
+      SessionMethodUtils.closeScope(spanWithScope, throwable, null, null);
     }
   }
 }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
@@ -41,7 +41,7 @@ class CriteriaTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -51,7 +51,7 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.criteria.$methodName"
+          operationName "hibernate/criteria/$methodName"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -61,11 +61,11 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(2) {
+          operationName ~/^select /
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -76,7 +76,7 @@ class CriteriaTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
@@ -46,7 +46,7 @@ class QueryTest extends AbstractHibernateTest {
       // With Transaction
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -56,12 +56,15 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.$queryMethodName"
+          if (resource) {
+            operationName "hibernate/$queryMethodName/$resource"
+          } else {
+            operationName "hibernate/$queryMethodName"
+          }
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" resource
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.DB_STATEMENT" queryMethodName == "iterate" ? null : String
@@ -72,7 +75,6 @@ class QueryTest extends AbstractHibernateTest {
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -83,7 +85,7 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -97,7 +99,7 @@ class QueryTest extends AbstractHibernateTest {
         // Without Transaction
         trace(1, 3) {
           span(0) {
-            operationName "hibernate.session"
+            operationName "hibernate/session"
             spanKind INTERNAL
             parent()
             tags {
@@ -107,23 +109,26 @@ class QueryTest extends AbstractHibernateTest {
             }
           }
           span(1) {
-            operationName "hibernate.$queryMethodName"
+            if (resource) {
+              operationName "hibernate/$queryMethodName/$resource"
+            } else {
+              operationName "hibernate/$queryMethodName"
+            }
             spanKind INTERNAL
             childOf span(0)
             tags {
               "$MoreTags.SERVICE_NAME" "hibernate"
-              "$MoreTags.RESOURCE_NAME" resource
               "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
               "$Tags.COMPONENT" "java-hibernate"
               "$Tags.DB_STATEMENT" queryMethodName == "iterate" ? null : String
             }
           }
           span(2) {
+            operationName ~/^select /
             spanKind CLIENT
             childOf span(1)
             tags {
               "$MoreTags.SERVICE_NAME" "h2"
-              "$MoreTags.RESOURCE_NAME" ~/^select /
               "$MoreTags.SPAN_TYPE" "sql"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "h2"
@@ -139,15 +144,15 @@ class QueryTest extends AbstractHibernateTest {
 
     where:
     queryMethodName       | resource     | requiresTransaction | queryInteraction
-    "query.list"          | "Value"      | false               | { sess ->
+    "query/list"          | "Value"      | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.list()
     }
-    "query.executeUpdate" | null         | true                | { sess ->
+    "query/executeUpdate" | null         | true                | { sess ->
       Query q = sess.createQuery("update Value set name = 'alyx'")
       q.executeUpdate()
     }
-    "query.uniqueResult"  | "Value"      | false               | { sess ->
+    "query/uniqueResult"  | "Value"      | false               | { sess ->
       Query q = sess.createQuery("from Value where id = 1")
       q.uniqueResult()
     }
@@ -155,7 +160,7 @@ class QueryTest extends AbstractHibernateTest {
       Query q = sess.createQuery("from Value")
       q.iterate()
     }
-    "query.scroll"        | null         | false               | { sess ->
+    "query/scroll"        | null         | false               | { sess ->
       Query q = sess.createQuery("from Value")
       q.scroll()
     }
@@ -178,7 +183,7 @@ class QueryTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -188,22 +193,21 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.iterate"
+          operationName "hibernate/iterate/from Value"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "from Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
+          operationName ~/^select /
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -214,7 +218,7 @@ class QueryTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
@@ -58,7 +58,7 @@ class SessionTest extends AbstractHibernateTest {
       for (int i = 0; i < sessionImplementations.size(); i++) {
         trace(i, 4) {
           span(0) {
-            operationName "hibernate.session"
+            operationName "hibernate/session"
             spanKind INTERNAL
             parent()
             tags {
@@ -68,12 +68,11 @@ class SessionTest extends AbstractHibernateTest {
             }
           }
           span(1) {
-            operationName "hibernate.$methodName"
+            operationName "hibernate/$methodName/$resource"
             spanKind INTERNAL
             childOf span(0)
             tags {
               "$MoreTags.SERVICE_NAME" "hibernate"
-              "$MoreTags.RESOURCE_NAME" resource
               "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
               "$Tags.COMPONENT" "java-hibernate"
             }
@@ -83,7 +82,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind CLIENT
             tags {
               "$MoreTags.SERVICE_NAME" "h2"
-              "$MoreTags.RESOURCE_NAME" String
               "$MoreTags.SPAN_TYPE" "sql"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "h2"
@@ -94,7 +92,7 @@ class SessionTest extends AbstractHibernateTest {
             }
           }
           span(3) {
-            operationName "hibernate.transaction.commit"
+            operationName "hibernate/transaction/commit"
             spanKind INTERNAL
             childOf span(0)
             tags {
@@ -154,7 +152,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 5) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -164,22 +162,21 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.$methodName"
+          operationName "hibernate/$methodName/$resource"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" resource
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
+          operationName ~/^select /
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -190,7 +187,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -204,7 +201,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(3)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -252,7 +248,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -262,7 +258,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.replicate"
+          operationName "hibernate/replicate"
           spanKind INTERNAL
           childOf span(0)
           errored(true)
@@ -274,7 +270,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(2) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -308,7 +304,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -318,18 +314,17 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.$methodName"
+          operationName "hibernate/$methodName/$resource"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" resource
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -343,7 +338,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(2)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -401,7 +395,7 @@ class SessionTest extends AbstractHibernateTest {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -411,12 +405,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.query.list"
+          operationName "hibernate/query/list/$resource"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "$resource"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             "$Tags.DB_STATEMENT" String
@@ -427,7 +420,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" String
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -438,7 +430,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(3) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -488,7 +480,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(1) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -498,29 +490,27 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(2) {
-          operationName "hibernate.save"
+          operationName "hibernate/save/Value"
           spanKind INTERNAL
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(3) {
-          operationName "hibernate.delete"
+          operationName "hibernate/delete/Value"
           spanKind INTERNAL
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(4) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(1)
           tags {
@@ -530,11 +520,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(5) {
+          operationName ~/^insert /
           spanKind CLIENT
           childOf span(4)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^insert /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -545,11 +535,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(6) {
+          operationName ~/^delete /
           spanKind CLIENT
           childOf span(4)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^delete /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -560,7 +550,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(7) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -570,22 +560,21 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(8) {
-          operationName "hibernate.insert"
+          operationName "hibernate/insert/Value"
           spanKind INTERNAL
           childOf span(7)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(9) {
+          operationName ~/^insert /
           spanKind CLIENT
           childOf span(8)
           tags {
             "$MoreTags.SERVICE_NAME" "h2"
-            "$MoreTags.RESOURCE_NAME" ~/^insert /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "h2"
@@ -596,7 +585,7 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(10) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           childOf span(0)
           tags {
@@ -606,12 +595,11 @@ class SessionTest extends AbstractHibernateTest {
           }
         }
         span(11) {
-          operationName "hibernate.save"
+          operationName "hibernate/save/Value"
           spanKind INTERNAL
           childOf span(10)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "Value"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }

--- a/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/core/v4_3/ProcedureCallInstrumentation.java
@@ -83,13 +83,13 @@ public class ProcedureCallInstrumentation extends Instrumenter.Default {
           InstrumentationContext.get(ProcedureCall.class, Span.class);
 
       return SessionMethodUtils.startScopeFrom(
-          contextStore, call, "hibernate.procedure." + name, call.getProcedureName(), true);
+          contextStore, call, "hibernate/procedure/" + name, call.getProcedureName(), true);
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
     public static void endMethod(
         @Advice.Enter final SpanWithScope spanWithScope, @Advice.Thrown final Throwable throwable) {
-      SessionMethodUtils.closeScope(spanWithScope, throwable, null);
+      SessionMethodUtils.closeScope(spanWithScope, throwable, null, null);
     }
   }
 }

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -84,7 +84,7 @@ class ProcedureCallTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 4) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -94,22 +94,21 @@ class ProcedureCallTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hibernate.procedure.getOutputs"
+          operationName "hibernate/procedure/getOutputs/TEST_PROC"
           spanKind INTERNAL
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "TEST_PROC"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
+          operationName "{call TEST_PROC()}"
           spanKind CLIENT
           childOf span(1)
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" "{call TEST_PROC()}"
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -121,7 +120,7 @@ class ProcedureCallTest extends AgentTestRunner {
         }
         span(3) {
           spanKind INTERNAL
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
@@ -155,7 +154,7 @@ class ProcedureCallTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          operationName "hibernate.session"
+          operationName "hibernate/session"
           spanKind INTERNAL
           parent()
           tags {
@@ -165,20 +164,19 @@ class ProcedureCallTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hibernate.procedure.getOutputs"
+          operationName "hibernate/procedure/getOutputs/TEST_PROC"
           spanKind INTERNAL
           childOf span(0)
           errored(true)
           tags {
             "$MoreTags.SERVICE_NAME" "hibernate"
-            "$MoreTags.RESOURCE_NAME" "TEST_PROC"
             "$MoreTags.SPAN_TYPE" SpanTypes.HIBERNATE
             "$Tags.COMPONENT" "java-hibernate"
             errorTags(SQLGrammarException, "could not prepare statement")
           }
         }
         span(2) {
-          operationName "hibernate.transaction.commit"
+          operationName "hibernate/transaction/commit"
           spanKind INTERNAL
           childOf span(0)
           tags {

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -46,10 +46,10 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
+          operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -75,10 +75,10 @@ class SpringJpaTest extends AgentTestRunner {
       if (extraTrace) {
         trace(0, 1) {
           span(0) {
+            operationName "call next value for hibernate_sequence"
             spanKind CLIENT
             tags {
               "$MoreTags.SERVICE_NAME" "hsqldb"
-              "$MoreTags.RESOURCE_NAME" "call next value for hibernate_sequence"
               "$MoreTags.SPAN_TYPE" "sql"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "hsqldb"
@@ -92,10 +92,10 @@ class SpringJpaTest extends AgentTestRunner {
       }
       trace(extraTrace ? 1 : 0, 1) {
         span(0) {
+          operationName ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -118,10 +118,10 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
+          operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -134,10 +134,10 @@ class SpringJpaTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
+          operationName "update Customer set firstName=?, lastName=? where id=?"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" "update Customer set firstName=?, lastName=? where id=?"
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -160,10 +160,10 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
+          operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -184,10 +184,10 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
+          operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -200,10 +200,10 @@ class SpringJpaTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
+          operationName "delete from Customer where id=?"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" "delete from Customer where id=?"
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"

--- a/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/SessionMethodUtils.java
+++ b/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/SessionMethodUtils.java
@@ -51,9 +51,12 @@ public class SessionMethodUtils {
     }
 
     if (createSpan) {
-      final Span span = TRACER.spanBuilder(operationName).setParent(sessionSpan).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(DECORATOR.spanNameForOperation(operationName, entity))
+              .setParent(sessionSpan)
+              .startSpan();
       DECORATOR.afterStart(span);
-      DECORATOR.onOperation(span, entity);
       return new SpanWithScope(span, TRACER.withSpan(span));
     } else {
       return new SpanWithScope(null, TRACER.withSpan(sessionSpan));
@@ -62,7 +65,10 @@ public class SessionMethodUtils {
 
   // Closes a Scope/Span, adding an error tag if the given Throwable is not null.
   public static void closeScope(
-      final SpanWithScope spanWithScope, final Throwable throwable, final Object entity) {
+      final SpanWithScope spanWithScope,
+      final Throwable throwable,
+      final String operationName,
+      final Object entity) {
 
     if (spanWithScope == null) {
       // This method call was re-entrant. Do nothing, since it is being traced by the parent/first
@@ -74,8 +80,11 @@ public class SessionMethodUtils {
     final Span span = spanWithScope.getSpan();
     if (span != null) {
       DECORATOR.onError(span, throwable);
-      if (entity != null) {
-        DECORATOR.onOperation(span, entity);
+      if (operationName != null && entity != null) {
+        final String entityName = DECORATOR.entityName(entity);
+        if (entityName != null) {
+          span.updateName(operationName + "/" + entityName);
+        }
       }
       DECORATOR.beforeFinish(span);
       span.end();

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -109,7 +109,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
-            "$MoreTags.RESOURCE_NAME" "GET $url.path"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -126,7 +125,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
-            "$MoreTags.RESOURCE_NAME" "GET $url.path"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -191,7 +189,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
-            "$MoreTags.RESOURCE_NAME" "GET $url.path"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -208,7 +205,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
-            "$MoreTags.RESOURCE_NAME" "GET $url.path"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -258,7 +254,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
-            "$MoreTags.RESOURCE_NAME" "GET $url.path"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -324,7 +319,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
-            "$MoreTags.RESOURCE_NAME" "POST $url.path"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.hystrix;
 
 import com.netflix.hystrix.HystrixInvokableInfo;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 
 public class HystrixDecorator extends BaseDecorator {
@@ -40,9 +39,9 @@ public class HystrixDecorator extends BaseDecorator {
       final String groupName = command.getCommandGroup().name();
       final boolean circuitOpen = command.isCircuitBreakerOpen();
 
-      final String resourceName = groupName + "." + commandName + "." + methodName;
+      final String resourceName = groupName + "/" + commandName + "/" + methodName;
 
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+      span.updateName(resourceName);
       span.setAttribute("hystrix.command", commandName);
       span.setAttribute("hystrix.group", groupName);
       span.setAttribute("hystrix.circuit-open", circuitOpen);

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.netflix.hystrix.HystrixObservableCommand
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import rx.Observable
@@ -86,11 +85,10 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup/HystrixObservableChainTest\$1/execute"
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableChainTest\$1.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -105,11 +103,10 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(3) {
-          operationName "hystrix.cmd"
+          operationName "OtherGroup/HystrixObservableChainTest\$2/execute"
           childOf span(1)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "OtherGroup.HystrixObservableChainTest\$2.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$2"
             "hystrix.group" "OtherGroup"

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -16,7 +16,6 @@
 import com.netflix.hystrix.HystrixObservable
 import com.netflix.hystrix.HystrixObservableCommand
 import com.netflix.hystrix.exception.HystrixRuntimeException
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import rx.Observable
@@ -79,11 +78,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup/HystrixObservableTest\$1/execute"
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableTest\$1.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -176,11 +174,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup/HystrixObservableTest\$2/execute"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableTest\$2.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
@@ -189,11 +186,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup/HystrixObservableTest\$2/fallback"
           childOf span(1)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableTest\$2.fallback"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
@@ -279,11 +275,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "FailingGroup/HystrixObservableTest\$3/execute"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "FailingGroup.HystrixObservableTest\$3.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"
@@ -292,11 +287,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "hystrix.cmd"
+          operationName "FailingGroup/HystrixObservableTest\$3/fallback"
           childOf span(1)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "FailingGroup.HystrixObservableTest\$3.fallback"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.netflix.hystrix.HystrixCommand
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import spock.lang.Timeout
@@ -65,11 +64,10 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup/HystrixTest\$1/execute"
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixTest\$1.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -130,11 +128,10 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup/HystrixTest\$2/execute"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixTest\$2.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"
@@ -143,11 +140,10 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup/HystrixTest\$2/fallback"
           childOf span(1)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixTest\$2.fallback"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"

--- a/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -43,13 +43,12 @@ class SlickTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "database.query"
+          operationName SlickUtils.TestQuery()
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" SlickUtils.Driver()
-            "$MoreTags.RESOURCE_NAME" SlickUtils.TestQuery()
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" SlickUtils.Driver()

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -61,10 +61,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = !parent.getContext().isValid();
     if (isRootScope && !resourceName.isEmpty()) {
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+      span.updateName(resourceName);
     } else {
-      span.setAttribute(
-          MoreTags.RESOURCE_NAME, DECORATE.spanNameForClass(target) + "." + method.getName());
+      span.updateName(DECORATE.spanNameForClass(target) + "/" + method.getName());
     }
   }
 
@@ -76,7 +75,6 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
 
     if (!resourceName.isEmpty()) {
       span.updateName(resourceName);
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
     }
   }
 

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -45,9 +45,8 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "jax-rs.request"
+          operationName "POST /a"
           tags {
-            "$MoreTags.RESOURCE_NAME" "POST /a"
             "$MoreTags.SPAN_TYPE" "web"
             "$Tags.COMPONENT" "jax-rs-controller"
           }
@@ -70,15 +69,13 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
           operationName name
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" name
             "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
-          operationName "jax-rs.request"
+          operationName "${className}/call"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "${className}.call"
             "$MoreTags.SPAN_TYPE" "web"
             "$Tags.COMPONENT" "jax-rs-controller"
           }

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
@@ -48,16 +48,14 @@ class JerseyTest extends AgentTestRunner {
         span(0) {
           operationName expectedResourceName
           tags {
-            "$MoreTags.RESOURCE_NAME" expectedResourceName
             "$Tags.COMPONENT" "jax-rs"
           }
         }
 
         span(1) {
           childOf span(0)
-          operationName "jax-rs.request"
+          operationName expectedSpanName
           tags {
-            "$MoreTags.RESOURCE_NAME" controllerName
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "jax-rs-controller"
           }
@@ -66,9 +64,9 @@ class JerseyTest extends AgentTestRunner {
     }
 
     where:
-    resource           | expectedResourceName       | controllerName | expectedResponse
-    "/test/hello/bob"  | "POST /test/hello/{name}"  | "Test1.hello"  | "Test1 bob!"
-    "/test2/hello/bob" | "POST /test2/hello/{name}" | "Test2.hello"  | "Test2 bob!"
-    "/test3/hi/bob"    | "POST /test3/hi/{name}"    | "Test3.hello"  | "Test3 bob!"
+    resource           | expectedResourceName       | expectedSpanName | expectedResponse
+    "/test/hello/bob"  | "POST /test/hello/{name}"  | "Test1/hello"    | "Test1 bob!"
+    "/test2/hello/bob" | "POST /test2/hello/{name}" | "Test2/hello"    | "Test2 bob!"
+    "/test3/hi/bob"    | "POST /test3/hi/{name}"    | "Test3/hello"    | "Test3 bob!"
   }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -71,11 +71,10 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = !parent.getContext().isValid();
     if (isRootScope && !resourceName.isEmpty()) {
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+      span.updateName(resourceName);
     } else {
-      span.setAttribute(
-          MoreTags.RESOURCE_NAME,
-          DECORATE.spanNameForClass(target) + (method == null ? "" : "." + method.getName()));
+      span.updateName(
+          DECORATE.spanNameForClass(target) + (method == null ? "" : "/" + method.getName()));
     }
   }
 
@@ -87,7 +86,6 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
 
     if (!resourceName.isEmpty()) {
       span.updateName(resourceName);
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
     }
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -45,9 +45,8 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "jax-rs.request"
+          operationName "POST /a"
           tags {
-            "$MoreTags.RESOURCE_NAME" "POST /a"
             "$MoreTags.SPAN_TYPE" "web"
             "$Tags.COMPONENT" "jax-rs-controller"
           }
@@ -70,15 +69,13 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
           operationName name
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" name
             "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
-          operationName "jax-rs.request"
+          operationName "${className}/call"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "${className}.call"
             "$MoreTags.SPAN_TYPE" "web"
             "$Tags.COMPONENT" "jax-rs-controller"
           }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
@@ -76,15 +76,13 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
         span(0) {
           operationName parentResourceName != null ? parentResourceName : "test.span"
           tags {
-            "$MoreTags.RESOURCE_NAME" parentResourceName
             "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
           childOf span(0)
-          operationName abort ? "jax-rs.request.abort" : "jax-rs.request"
+          operationName expectedSpanName
           tags {
-            "$MoreTags.RESOURCE_NAME" controllerName
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "jax-rs-controller"
           }
@@ -93,21 +91,21 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     }
 
     where:
-    resource           | abortNormal | abortPrematch | parentResourceName         | controllerName                 | expectedResponse
-    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Test1 bob!"
-    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Test2 bob!"
-    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Test3 bob!"
+    resource           | abortNormal | abortPrematch | parentResourceName         | expectedSpanName               | expectedResponse
+    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "Test1/hello"                  | "Test1 bob!"
+    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "Test2/hello"                  | "Test2 bob!"
+    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "Test3/hello"                  | "Test3 bob!"
 
     // Resteasy and Jersey give different resource class names for just the below case
     // Resteasy returns "SubResource.class"
     // Jersey returns "Test1.class
-    // "/test/hello/bob"  | true        | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Aborted"
+    // "/test/hello/bob"  | true        | false         | "POST /test/hello/{name}"  | "Test1/hello"                  | "Aborted"
 
-    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Aborted"
-    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Aborted"
-    "/test/hello/bob"  | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
-    "/test2/hello/bob" | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
-    "/test3/hi/bob"    | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
+    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "Test2/hello"                  | "Aborted"
+    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "Test3/hello"                  | "Aborted"
+    "/test/hello/bob"  | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
+    "/test2/hello/bob" | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
+    "/test3/hi/bob"    | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
   }
 
   @Provider

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -23,7 +23,6 @@ import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
@@ -71,10 +70,12 @@ public final class DataSourceInstrumentation extends Instrumenter.Default {
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("database.connection").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(DECORATE.spanNameForClass(ds.getClass(), "getConnection"))
+              .setSpanKind(CLIENT)
+              .startSpan();
       DECORATE.afterStart(span);
-
-      span.setAttribute(MoreTags.RESOURCE_NAME, ds.getClass().getSimpleName() + ".getConnection");
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
@@ -109,18 +109,23 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     return super.onConnection(span, dbInfo);
   }
 
+  public String spanNameOnStatement(final String statement) {
+    return statement == null ? DB_QUERY : statement;
+  }
+
+  public String spanNameOnPreparedStatement(final PreparedStatement statement) {
+    final String sql = JDBCMaps.preparedStatements.get(statement);
+    return sql == null ? DB_QUERY : sql;
+  }
+
   @Override
   public Span onStatement(final Span span, final String statement) {
-    final String resourceName = statement == null ? DB_QUERY : statement;
-    span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
     span.setAttribute(Tags.COMPONENT, "java-jdbc-statement");
     return super.onStatement(span, statement);
   }
 
   public Span onPreparedStatement(final Span span, final PreparedStatement statement) {
     final String sql = JDBCMaps.preparedStatements.get(statement);
-    final String resourceName = sql == null ? DB_QUERY : sql;
-    span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
     span.setAttribute(Tags.COMPONENT, "java-jdbc-prepared_statement");
     return super.onStatement(span, sql);
   }

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -79,7 +79,11 @@ public final class PreparedStatementInstrumentation extends Instrumenter.Default
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("database.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(DECORATE.spanNameOnPreparedStatement(statement))
+              .setSpanKind(CLIENT)
+              .startSpan();
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, connection);
       DECORATE.onPreparedStatement(span, statement);

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/StatementInstrumentation.java
@@ -80,7 +80,8 @@ public final class StatementInstrumentation extends Instrumenter.Default {
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("database.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER.spanBuilder(DECORATE.spanNameOnStatement(sql)).setSpanKind(CLIENT).startSpan();
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, connection);
       DECORATE.onStatement(span, sql);

--- a/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -193,13 +193,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" renameService ? dbName.toLowerCase() : driver
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.DB_TYPE" driver
@@ -253,13 +252,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" driver
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" driver
@@ -305,13 +303,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" driver
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" driver
@@ -357,13 +354,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" driver
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" driver
@@ -409,13 +405,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" driver
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.DB_TYPE" driver
@@ -464,13 +459,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" driver
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" driver
@@ -531,13 +525,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" driver
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             if (prepareStatement) {
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
@@ -595,19 +588,17 @@ class JDBCInstrumentationTest extends AgentTestRunner {
         basicSpan(it, 0, "parent")
 
         span(1) {
-          operationName "database.connection"
+          operationName "${datasource.class.simpleName}/getConnection"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "${datasource.class.simpleName}.getConnection"
             "$Tags.COMPONENT" "java-jdbc-connection"
           }
         }
         if (recursive) {
           span(2) {
-            operationName "database.connection"
+            operationName "${datasource.class.simpleName}/getConnection"
             childOf span(1)
             tags {
-              "$MoreTags.RESOURCE_NAME" "${datasource.class.simpleName}.getConnection"
               "$Tags.COMPONENT" "java-jdbc-connection"
             }
           }
@@ -646,13 +637,12 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" database
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.DB_TYPE" database
@@ -711,12 +701,11 @@ class JDBCInstrumentationTest extends AgentTestRunner {
     assertTraces(5) {
       trace(0, 1) {
         span(0) {
-          operationName "database.query"
+          operationName query
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" dbType
-            "$MoreTags.RESOURCE_NAME" query
             "$MoreTags.SPAN_TYPE" SpanTypes.SQL
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" dbType
@@ -730,12 +719,11 @@ class JDBCInstrumentationTest extends AgentTestRunner {
       for (int i = 1; i < numQueries; ++i) {
         trace(i, 1) {
           span(0) {
-            operationName "database.query"
+            operationName query
             spanKind CLIENT
             errored false
             tags {
               "$MoreTags.SERVICE_NAME" dbType
-              "$MoreTags.RESOURCE_NAME" query
               "$MoreTags.SPAN_TYPE" SpanTypes.SQL
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" dbType

--- a/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/JedisInstrumentation.java
@@ -77,7 +77,8 @@ public final class JedisInstrumentation extends Instrumenter.Default {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope onEnter(@Advice.Argument(1) final Command command) {
-      final Span span = TRACER.spanBuilder("redis.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER.spanBuilder("redis/" + command.name()).setSpanKind(CLIENT).startSpan();
       DECORATE.afterStart(span);
       DECORATE.onStatement(span, command.name());
       return new SpanWithScope(span, TRACER.withSpan(span));

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -68,7 +68,7 @@ class JedisClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -93,7 +93,7 @@ class JedisClientTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -106,7 +106,7 @@ class JedisClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -131,7 +131,7 @@ class JedisClientTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -144,7 +144,7 @@ class JedisClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/RANDOMKEY"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -68,7 +68,7 @@ class Jedis30ClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -93,7 +93,7 @@ class Jedis30ClientTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -106,7 +106,7 @@ class Jedis30ClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -131,7 +131,7 @@ class Jedis30ClientTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
@@ -144,7 +144,7 @@ class Jedis30ClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/RANDOMKEY"
           spanKind CLIENT
           tags {
             "$MoreTags.SERVICE_NAME" "redis"

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty8/JettyHandlerAdvice.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty8/JettyHandlerAdvice.java
@@ -42,8 +42,8 @@ public class JettyHandlerAdvice {
       return null;
     }
 
-    final String resourceName = req.getMethod() + " " + source.getClass().getName();
-    final Span.Builder spanBuilder = TRACER.spanBuilder(resourceName).setSpanKind(SERVER);
+    final String spanName = req.getMethod() + " " + source.getClass().getName();
+    final Span.Builder spanBuilder = TRACER.spanBuilder(spanName).setSpanKind(SERVER);
     try {
       final SpanContext extractedContext = TRACER.getHttpTextFormat().extract(req, GETTER);
       spanBuilder.setParent(extractedContext);
@@ -57,7 +57,6 @@ public class JettyHandlerAdvice {
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, req);
     DECORATE.onRequest(span, req);
-    span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
 
     req.setAttribute(SPAN_ATTRIBUTE, span);
     req.setAttribute("traceId", span.getContext().getTraceId().toLowerBase16());

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -66,7 +66,7 @@ abstract class JettyContinuationHandlerTest extends JettyHandlerTest {
 //    }
 //    toRemove.each {
 //      assertTrace(it, 1) {
-//        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+//        basicSpan(it, 0, "TEST_SPAN")
 //      }
 //    }
 //    assert toRemove.size() == size * 2

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
@@ -139,7 +139,6 @@ class JettyHandlerTest extends HttpServerTest<Server> {
         parent()
       }
       tags {
-        "$MoreTags.RESOURCE_NAME" "$method $handlerName"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
@@ -182,12 +182,11 @@ class JMS2Test extends AgentTestRunner {
       trace(0, 1) { // Consumer trace
         span(0) {
           parent()
-          operationName "jms.consume"
+          operationName "jms/receiveNoWait"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "jms"
-            "$MoreTags.RESOURCE_NAME" "JMS receiveNoWait"
             "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_PRODUCER
             "$Tags.COMPONENT" "jms"
             "span.origin.type" HornetQMessageConsumer.name
@@ -218,12 +217,11 @@ class JMS2Test extends AgentTestRunner {
       trace(0, 1) { // Consumer trace
         span(0) {
           parent()
-          operationName "jms.consume"
+          operationName "jms/receive"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "jms"
-            "$MoreTags.RESOURCE_NAME" "JMS receive"
             "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_PRODUCER
             "$Tags.COMPONENT" "jms"
             "span.origin.type" HornetQMessageConsumer.name
@@ -244,12 +242,11 @@ class JMS2Test extends AgentTestRunner {
   static producerSpan(TraceAssert trace, int index, String jmsResourceName) {
     trace.span(index) {
       parent()
-      operationName "jms.produce"
+      operationName "jms/produce/$jmsResourceName"
       spanKind PRODUCER
       errored false
       tags {
         "$MoreTags.SERVICE_NAME" "jms"
-        "$MoreTags.RESOURCE_NAME" "Produced for $jmsResourceName"
         "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_PRODUCER
         "$Tags.COMPONENT" "jms"
         "span.origin.type" HornetQMessageProducer.name
@@ -260,11 +257,11 @@ class JMS2Test extends AgentTestRunner {
   static consumerSpan(TraceAssert trace, int index, String jmsResourceName, boolean messageListener, Class origin, Object parentOrLinkSpan) {
     trace.span(index) {
       if (messageListener) {
-        operationName "jms.onMessage"
+        operationName "jms/consume/$jmsResourceName"
         spanKind CONSUMER
         childOf((SpanData) parentOrLinkSpan)
       } else {
-        operationName "jms.consume"
+        operationName "jms/receive/$jmsResourceName"
         spanKind CLIENT
         parent()
         hasLink((SpanData) parentOrLinkSpan)
@@ -273,7 +270,6 @@ class JMS2Test extends AgentTestRunner {
 
       tags {
         "$MoreTags.SERVICE_NAME" "jms"
-        "$MoreTags.RESOURCE_NAME" messageListener ? "Received from $jmsResourceName" : "Consumed from $jmsResourceName"
         "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_CONSUMER
         "$Tags.COMPONENT" "jms"
         "span.origin.type" origin.name

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSDecorator.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSDecorator.java
@@ -17,9 +17,7 @@ package io.opentelemetry.auto.instrumentation.jms;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanTypes;
-import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.lang.reflect.Method;
 import javax.jms.Destination;
@@ -59,21 +57,20 @@ public abstract class JMSDecorator extends ClientDecorator {
     return "jms";
   }
 
-  public void onConsume(final Span span, final Message message) {
-    span.setAttribute(MoreTags.RESOURCE_NAME, "Consumed from " + toResourceName(message, null));
+  public String spanNameForReceive(final Message message) {
+    return "jms/receive/" + toResourceName(message, null);
   }
 
-  public void onReceive(final Span span, final Method method) {
-    span.setAttribute(MoreTags.RESOURCE_NAME, "JMS " + method.getName());
+  public String spanNameForReceive(final Method method) {
+    return "jms/" + method.getName();
   }
 
-  public void onReceive(final Span span, final Message message) {
-    span.setAttribute(MoreTags.RESOURCE_NAME, "Received from " + toResourceName(message, null));
+  public String spanNameForConsumer(final Message message) {
+    return "jms/consume/" + toResourceName(message, null);
   }
 
-  public void onProduce(final Span span, final Message message, final Destination destination) {
-    span.setAttribute(
-        MoreTags.RESOURCE_NAME, "Produced for " + toResourceName(message, destination));
+  public String spanNameForProducer(final Message message, final Destination destination) {
+    return "jms/produce/" + toResourceName(message, destination);
   }
 
   private static final String TIBCO_TMP_PREFIX = "$TMP$";

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageListenerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageListenerInstrumentation.java
@@ -81,7 +81,8 @@ public final class JMSMessageListenerInstrumentation extends Instrumenter.Defaul
     public static SpanWithScope onEnter(
         @Advice.Argument(0) final Message message, @Advice.This final MessageListener listener) {
 
-      final Span.Builder spanBuilder = TRACER.spanBuilder("jms.onMessage").setSpanKind(CONSUMER);
+      final Span.Builder spanBuilder =
+          TRACER.spanBuilder(CONSUMER_DECORATE.spanNameForConsumer(message)).setSpanKind(CONSUMER);
       try {
         final SpanContext extractedContext = TRACER.getHttpTextFormat().extract(message, GETTER);
         spanBuilder.setParent(extractedContext);
@@ -93,7 +94,6 @@ public final class JMSMessageListenerInstrumentation extends Instrumenter.Defaul
       final Span span = spanBuilder.startSpan();
       span.setAttribute("span.origin.type", listener.getClass().getName());
       CONSUMER_DECORATE.afterStart(span);
-      CONSUMER_DECORATE.onReceive(span, message);
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -102,10 +102,13 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
         defaultDestination = null;
       }
 
-      final Span span = TRACER.spanBuilder("jms.produce").setSpanKind(PRODUCER).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(PRODUCER_DECORATE.spanNameForProducer(message, defaultDestination))
+              .setSpanKind(PRODUCER)
+              .startSpan();
       span.setAttribute("span.origin.type", producer.getClass().getName());
       PRODUCER_DECORATE.afterStart(span);
-      PRODUCER_DECORATE.onProduce(span, message, defaultDestination);
 
       TRACER.getHttpTextFormat().inject(span.getContext(), message, SETTER);
 
@@ -141,10 +144,13 @@ public final class JMSMessageProducerInstrumentation extends Instrumenter.Defaul
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("jms.produce").setSpanKind(PRODUCER).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(PRODUCER_DECORATE.spanNameForProducer(message, destination))
+              .setSpanKind(PRODUCER)
+              .startSpan();
       span.setAttribute("span.origin.type", producer.getClass().getName());
       PRODUCER_DECORATE.afterStart(span);
-      PRODUCER_DECORATE.onProduce(span, message, destination);
 
       TRACER.getHttpTextFormat().inject(span.getContext(), message, SETTER);
 

--- a/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
@@ -145,12 +145,11 @@ class JMS1Test extends AgentTestRunner {
       trace(0, 1) { // Consumer trace
         span(0) {
           parent()
-          operationName "jms.consume"
+          operationName "jms/receiveNoWait"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "jms"
-            "$MoreTags.RESOURCE_NAME" "JMS receiveNoWait"
             "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_CONSUMER
             "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
@@ -181,12 +180,11 @@ class JMS1Test extends AgentTestRunner {
       trace(0, 1) { // Consumer trace
         span(0) {
           parent()
-          operationName "jms.consume"
+          operationName "jms/receive"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "jms"
-            "$MoreTags.RESOURCE_NAME" "JMS receive"
             "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_CONSUMER
             "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
@@ -232,12 +230,11 @@ class JMS1Test extends AgentTestRunner {
       trace(1, 1) {
         span(0) {
           parent()
-          operationName "jms.consume"
+          operationName "jms/receive/$jmsResourceName"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "jms"
-            "$MoreTags.RESOURCE_NAME" "Consumed from $jmsResourceName"
             "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_CONSUMER
             "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
@@ -260,13 +257,12 @@ class JMS1Test extends AgentTestRunner {
 
   static producerSpan(TraceAssert trace, int index, String jmsResourceName) {
     trace.span(index) {
-      operationName "jms.produce"
+      operationName "jms/produce/$jmsResourceName"
       spanKind PRODUCER
       errored false
       parent()
       tags {
         "$MoreTags.SERVICE_NAME" "jms"
-        "$MoreTags.RESOURCE_NAME" "Produced for $jmsResourceName"
         "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_PRODUCER
         "$Tags.COMPONENT" "jms"
         "span.origin.type" ActiveMQMessageProducer.name
@@ -277,11 +273,11 @@ class JMS1Test extends AgentTestRunner {
   static consumerSpan(TraceAssert trace, int index, String jmsResourceName, boolean messageListener, Class origin, Object parentOrLinkedSpan) {
     trace.span(index) {
       if (messageListener) {
-        operationName "jms.onMessage"
+        operationName "jms/consume/$jmsResourceName"
         spanKind CONSUMER
         childOf((SpanData) parentOrLinkedSpan)
       } else {
-        operationName "jms.consume"
+        operationName "jms/receive/$jmsResourceName"
         spanKind CLIENT
         parent()
         hasLink((SpanData) parentOrLinkedSpan)
@@ -289,7 +285,6 @@ class JMS1Test extends AgentTestRunner {
       errored false
       tags {
         "$MoreTags.SERVICE_NAME" "jms"
-        "$MoreTags.RESOURCE_NAME" messageListener ? "Received from $jmsResourceName" : "Consumed from $jmsResourceName"
         "$MoreTags.SPAN_TYPE" SpanTypes.MESSAGE_CONSUMER
         "$Tags.COMPONENT" "jms"
         "span.origin.type" origin.name

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPDecorator.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.jsp;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.net.URI;
@@ -44,10 +43,14 @@ public class JSPDecorator extends BaseDecorator {
     return "jsp-http-servlet";
   }
 
+  public String spanNameOnCompile(final JspCompilationContext jspCompilationContext) {
+    return jspCompilationContext == null
+        ? "Compile JSP"
+        : "Compile " + jspCompilationContext.getJspFile();
+  }
+
   public void onCompile(final Span span, final JspCompilationContext jspCompilationContext) {
     if (jspCompilationContext != null) {
-      span.setAttribute(MoreTags.RESOURCE_NAME, jspCompilationContext.getJspFile());
-
       if (jspCompilationContext.getServletContext() != null) {
         span.setAttribute(
             "servlet.context", jspCompilationContext.getServletContext().getContextPath());
@@ -60,15 +63,17 @@ public class JSPDecorator extends BaseDecorator {
     }
   }
 
-  public void onRender(final Span span, final HttpServletRequest req) {
+  public String spanNameOnRender(final HttpServletRequest req) {
     // get the JSP file name being rendered in an include action
     final Object includeServletPath = req.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
     String resourceName = req.getServletPath();
     if (includeServletPath instanceof String) {
       resourceName = includeServletPath.toString();
     }
-    span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+    return "Render " + resourceName;
+  }
 
+  public void onRender(final Span span, final HttpServletRequest req) {
     final Object forwardOrigin = req.getAttribute(RequestDispatcher.FORWARD_SERVLET_PATH);
     if (forwardOrigin instanceof String) {
       span.setAttribute("jsp.forwardOrigin", forwardOrigin.toString());

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
@@ -75,7 +75,7 @@ public final class JSPInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope onEnter(
         @Advice.This final Object obj, @Advice.Argument(0) final HttpServletRequest req) {
-      final Span span = TRACER.spanBuilder("jsp.render").startSpan();
+      final Span span = TRACER.spanBuilder(DECORATE.spanNameOnRender(req)).startSpan();
       span.setAttribute("span.origin.type", obj.getClass().getSimpleName());
       span.setAttribute("servlet.context", req.getContextPath());
       DECORATE.afterStart(span);

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -63,8 +63,10 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
   public static class JasperJspCompilationContext {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static SpanWithScope onEnter() {
-      final Span span = TRACER.spanBuilder("jsp.compile").startSpan();
+    public static SpanWithScope onEnter(
+        @Advice.This final JspCompilationContext jspCompilationContext) {
+      final Span span =
+          TRACER.spanBuilder(DECORATE.spanNameOnCompile(jspCompilationContext)).startSpan();
       DECORATE.afterStart(span);
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -125,10 +125,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$jspFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
@@ -137,10 +136,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /$jspFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
@@ -193,10 +191,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /getQuery.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/getQuery.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
@@ -205,10 +202,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /getQuery.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/getQuery.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "getQuery_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -258,10 +254,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /post.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/post.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
@@ -270,10 +265,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /post.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/post.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "post_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -327,10 +321,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$jspFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
@@ -339,10 +332,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /$jspFileName"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
@@ -401,10 +393,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /includes/includeHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
@@ -413,10 +404,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /includes/includeHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeHtml_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -462,10 +452,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
@@ -474,10 +463,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -486,10 +474,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -498,10 +485,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -510,10 +496,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(5) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -522,10 +507,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(6) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -572,10 +556,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$jspFileName"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -124,10 +124,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$forwardFromFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardFromFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
@@ -136,10 +135,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /$forwardFromFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardFromFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardFromClassName
             "servlet.context" "/$jspWebappContext"
@@ -148,10 +146,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /$forwardDestFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardDestFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
@@ -160,10 +157,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /$forwardDestFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardDestFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
@@ -215,10 +211,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
@@ -227,10 +222,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToHtml_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -276,10 +270,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToIncludeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
@@ -288,10 +281,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToIncludeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToIncludeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -300,10 +292,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
@@ -312,10 +303,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -325,10 +315,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(5) {
           childOf span(4)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -337,10 +326,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(6) {
           childOf span(4)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -350,10 +338,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(7) {
           childOf span(4)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -362,10 +349,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(8) {
           childOf span(4)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -412,10 +398,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToJspForward.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
@@ -424,10 +409,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToJspForward.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToJspForward_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -436,10 +420,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToSimpleJava.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
@@ -448,10 +431,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToSimpleJava.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToSimpleJava_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -461,10 +443,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(5) {
           childOf span(4)
-          operationName "jsp.compile"
+          operationName "Compile /common/loop.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/loop.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
@@ -473,10 +454,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(6) {
           childOf span(4)
-          operationName "jsp.render"
+          operationName "Render /common/loop.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/loop.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -524,10 +504,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToCompileError.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToCompileError.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
@@ -536,10 +515,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToCompileError.jsp"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToCompileError.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToCompileError_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -549,10 +527,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /compileError.jsp"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/compileError.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
@@ -599,10 +576,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToNonExistent.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
@@ -611,10 +587,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToNonExistent.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToNonExistent_jsp"
             "servlet.context" "/$jspWebappContext"

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/KafkaConsumerInstrumentation.java
@@ -92,7 +92,7 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void wrap(@Advice.Return(readOnly = false) Iterable<ConsumerRecord> iterable) {
       if (iterable != null) {
-        iterable = new TracingIterable(iterable, "kafka.consume", CONSUMER_DECORATE);
+        iterable = new TracingIterable(iterable, CONSUMER_DECORATE);
       }
     }
   }
@@ -102,7 +102,7 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void wrap(@Advice.Return(readOnly = false) List<ConsumerRecord> iterable) {
       if (iterable != null) {
-        iterable = new TracingList(iterable, "kafka.consume", CONSUMER_DECORATE);
+        iterable = new TracingList(iterable, CONSUMER_DECORATE);
       }
     }
   }
@@ -112,7 +112,7 @@ public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void wrap(@Advice.Return(readOnly = false) Iterator<ConsumerRecord> iterator) {
       if (iterator != null) {
-        iterator = new TracingIterator(iterator, "kafka.consume", CONSUMER_DECORATE);
+        iterator = new TracingIterator(iterator, CONSUMER_DECORATE);
       }
     }
   }

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/KafkaProducerInstrumentation.java
@@ -82,7 +82,11 @@ public final class KafkaProducerInstrumentation extends Instrumenter.Default {
         @Advice.FieldValue("apiVersions") final ApiVersions apiVersions,
         @Advice.Argument(value = 0, readOnly = false) ProducerRecord record,
         @Advice.Argument(value = 1, readOnly = false) Callback callback) {
-      final Span span = TRACER.spanBuilder("kafka.produce").setSpanKind(PRODUCER).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(PRODUCER_DECORATE.spanNameOnProduce(record))
+              .setSpanKind(PRODUCER)
+              .startSpan();
       PRODUCER_DECORATE.afterStart(span);
       PRODUCER_DECORATE.onProduce(span, record);
 

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/TracingIterable.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/TracingIterable.java
@@ -20,16 +20,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 public class TracingIterable implements Iterable<ConsumerRecord> {
   private final Iterable<ConsumerRecord> delegate;
-  private final String operationName;
   private final KafkaDecorator decorator;
   private boolean firstIterator = true;
 
-  public TracingIterable(
-      final Iterable<ConsumerRecord> delegate,
-      final String operationName,
-      final KafkaDecorator decorator) {
+  public TracingIterable(final Iterable<ConsumerRecord> delegate, final KafkaDecorator decorator) {
     this.delegate = delegate;
-    this.operationName = operationName;
     this.decorator = decorator;
   }
 
@@ -40,7 +35,7 @@ public class TracingIterable implements Iterable<ConsumerRecord> {
     // However, this is not thread-safe, but usually the first (hopefully only) traversal of
     // ConsumerRecords is performed in the same thread that called poll()
     if (firstIterator) {
-      it = new TracingIterator(delegate.iterator(), operationName, decorator);
+      it = new TracingIterator(delegate.iterator(), decorator);
       firstIterator = false;
     } else {
       it = delegate.iterator();

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/TracingIterator.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/TracingIterator.java
@@ -29,7 +29,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 @Slf4j
 public class TracingIterator implements Iterator<ConsumerRecord> {
   private final Iterator<ConsumerRecord> delegateIterator;
-  private final String operationName;
   private final KafkaDecorator decorator;
 
   /**
@@ -39,11 +38,8 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
   private SpanWithScope currentSpanWithScope;
 
   public TracingIterator(
-      final Iterator<ConsumerRecord> delegateIterator,
-      final String operationName,
-      final KafkaDecorator decorator) {
+      final Iterator<ConsumerRecord> delegateIterator, final KafkaDecorator decorator) {
     this.delegateIterator = delegateIterator;
-    this.operationName = operationName;
     this.decorator = decorator;
   }
 
@@ -71,7 +67,7 @@ public class TracingIterator implements Iterator<ConsumerRecord> {
     try {
       if (next != null) {
         final boolean consumer = !TRACER.getCurrentSpan().getContext().isValid();
-        final Span.Builder spanBuilder = TRACER.spanBuilder(operationName);
+        final Span.Builder spanBuilder = TRACER.spanBuilder(decorator.spanNameOnConsume(next));
         if (consumer) {
           spanBuilder.setSpanKind(CONSUMER);
         }

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/TracingList.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_clients/TracingList.java
@@ -23,11 +23,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public class TracingList extends TracingIterable implements List<ConsumerRecord> {
   private final List<ConsumerRecord> delegate;
 
-  public TracingList(
-      final List<ConsumerRecord> delegate,
-      final String operationName,
-      final KafkaDecorator decorator) {
-    super(delegate, operationName, decorator);
+  public TracingList(final List<ConsumerRecord> delegate, final KafkaDecorator decorator) {
+    super(delegate, decorator);
     this.delegate = delegate;
   }
 

--- a/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -99,25 +99,23 @@ class KafkaClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "kafka.produce"
+          operationName "kafka/produce/$SHARED_TOPIC"
           spanKind PRODUCER
           errored false
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Produce Topic $SHARED_TOPIC"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
           }
         }
         span(1) {
-          operationName "kafka.consume"
+          operationName "kafka/consume/$SHARED_TOPIC"
           spanKind CONSUMER
           errored false
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Consume Topic $SHARED_TOPIC"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
@@ -170,26 +168,24 @@ class KafkaClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "kafka.produce"
+          operationName "kafka/produce/$SHARED_TOPIC"
           spanKind PRODUCER
           errored false
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Produce Topic $SHARED_TOPIC"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
             "kafka.partition" { it >= 0 }
           }
         }
         span(1) {
-          operationName "kafka.consume"
+          operationName "kafka/consume/$SHARED_TOPIC"
           spanKind CONSUMER
           errored false
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Consume Topic $SHARED_TOPIC"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_streams/KafkaStreamsDecorator.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_streams/KafkaStreamsDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.kafka_streams;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanTypes;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -44,10 +43,20 @@ public class KafkaStreamsDecorator extends ClientDecorator {
     return SpanTypes.MESSAGE_CONSUMER;
   }
 
+  public String spanNameForConsume(final StampedRecord record) {
+    if (record == null) {
+      return null;
+    }
+    final String topic = record.topic();
+    if (topic != null) {
+      return "kafka/consume/" + topic;
+    } else {
+      return "kafka/consume";
+    }
+  }
+
   public void onConsume(final Span span, final StampedRecord record) {
     if (record != null) {
-      final String topic = record.topic() == null ? "kafka" : record.topic();
-      span.setAttribute(MoreTags.RESOURCE_NAME, "Consume Topic " + topic);
       span.setAttribute("partition", record.partition());
       span.setAttribute("offset", record.offset());
     }

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafka_streams/KafkaStreamsProcessorInstrumentation.java
@@ -103,7 +103,8 @@ public class KafkaStreamsProcessorInstrumentation {
           return;
         }
 
-        final Span.Builder spanBuilder = TRACER.spanBuilder("kafka.consume").setSpanKind(CONSUMER);
+        final Span.Builder spanBuilder =
+            TRACER.spanBuilder(CONSUMER_DECORATE.spanNameForConsume(record)).setSpanKind(CONSUMER);
         try {
           final SpanContext extractedContext =
               TRACER.getHttpTextFormat().extract(record.value.headers(), GETTER);

--- a/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -138,26 +138,24 @@ class KafkaStreamsTest extends AgentTestRunner {
       trace(0, 5) {
         // PRODUCER span 0
         span(0) {
-          operationName "kafka.produce"
+          operationName "kafka/produce/$STREAM_PENDING"
           spanKind PRODUCER
           errored false
           parent()
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Produce Topic $STREAM_PENDING"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
           }
         }
         // CONSUMER span 0
         span(1) {
-          operationName "kafka.consume"
+          operationName "kafka/consume/$STREAM_PENDING"
           spanKind CONSUMER
           errored false
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Consume Topic $STREAM_PENDING"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
@@ -166,13 +164,12 @@ class KafkaStreamsTest extends AgentTestRunner {
         }
         // STREAMING span 1
         span(2) {
-          operationName "kafka.consume"
+          operationName "kafka/consume/$STREAM_PENDING"
           spanKind CONSUMER
           errored false
           childOf span(0)
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Consume Topic $STREAM_PENDING"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
@@ -182,26 +179,24 @@ class KafkaStreamsTest extends AgentTestRunner {
         }
         // STREAMING span 0
         span(3) {
-          operationName "kafka.produce"
+          operationName "kafka/produce/$STREAM_PROCESSED"
           spanKind PRODUCER
           errored false
           childOf span(2)
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Produce Topic $STREAM_PROCESSED"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
           }
         }
         // CONSUMER span 0
         span(4) {
-          operationName "kafka.consume"
+          operationName "kafka/consume/$STREAM_PROCESSED"
           spanKind CONSUMER
           errored false
           childOf span(3)
           tags {
             "$MoreTags.SERVICE_NAME" "kafka"
-            "$MoreTags.RESOURCE_NAME" "Consume Topic $STREAM_PROCESSED"
             "$MoreTags.SPAN_TYPE" "queue"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/ConnectionFutureAdvice.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/ConnectionFutureAdvice.java
@@ -29,7 +29,11 @@ public class ConnectionFutureAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static SpanWithScope onEnter(@Advice.Argument(1) final RedisURI redisURI) {
-    final Span span = TRACER.spanBuilder("redis.query").setSpanKind(CLIENT).startSpan();
+    final Span span =
+        TRACER
+            .spanBuilder(DECORATE.spanNameForConnection(redisURI))
+            .setSpanKind(CLIENT)
+            .startSpan();
     DECORATE.afterStart(span);
     DECORATE.onConnection(span, redisURI);
     return new SpanWithScope(span, TRACER.withSpan(span));

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
@@ -31,9 +31,9 @@ public class LettuceAsyncCommandsAdvice {
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static SpanWithScope onEnter(@Advice.Argument(0) final RedisCommand command) {
 
-    final Span span = TRACER.spanBuilder("redis.query").setSpanKind(CLIENT).startSpan();
+    final Span span =
+        TRACER.spanBuilder(DECORATE.spanNameForCommand(command)).setSpanKind(CLIENT).startSpan();
     DECORATE.afterStart(span);
-    DECORATE.onCommand(span, command);
 
     return new SpanWithScope(span, TRACER.withSpan(span));
   }

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientDecorator.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientDecorator.java
@@ -60,6 +60,18 @@ public class LettuceClientDecorator extends DatabaseClientDecorator<RedisURI> {
     return null;
   }
 
+  public String spanNameForConnection(final RedisURI connection) {
+    if (connection == null) {
+      return "redis/CONNECT";
+    }
+    return "redis/CONNECT/"
+        + connection.getHost()
+        + ":"
+        + connection.getPort()
+        + "/"
+        + connection.getDatabase();
+  }
+
   @Override
   public Span onConnection(final Span span, final RedisURI connection) {
     if (connection != null) {
@@ -67,22 +79,12 @@ public class LettuceClientDecorator extends DatabaseClientDecorator<RedisURI> {
       span.setAttribute(MoreTags.NET_PEER_PORT, connection.getPort());
 
       span.setAttribute("db.redis.dbIndex", connection.getDatabase());
-      span.setAttribute(
-          MoreTags.RESOURCE_NAME,
-          "CONNECT:"
-              + connection.getHost()
-              + ":"
-              + connection.getPort()
-              + "/"
-              + connection.getDatabase());
     }
     return super.onConnection(span, connection);
   }
 
-  public Span onCommand(final Span span, final RedisCommand command) {
+  public String spanNameForCommand(final RedisCommand command) {
     final String commandName = LettuceInstrumentationUtil.getCommandName(command);
-    span.setAttribute(
-        MoreTags.RESOURCE_NAME, LettuceInstrumentationUtil.getCommandResourceName(commandName));
-    return span;
+    return "redis/" + LettuceInstrumentationUtil.getCommandResourceName(commandName);
   }
 }

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceFluxTerminationRunnable.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceFluxTerminationRunnable.java
@@ -99,10 +99,10 @@ public class LettuceFluxTerminationRunnable implements Consumer<Signal>, Runnabl
 
     @Override
     public void accept(final Subscription subscription) {
-      final Span span = TRACER.spanBuilder("redis.query").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER.spanBuilder(DECORATE.spanNameForCommand(command)).setSpanKind(CLIENT).startSpan();
       owner.span = span;
       DECORATE.afterStart(span);
-      DECORATE.onCommand(span, command);
       if (finishSpanOnClose) {
         DECORATE.beforeFinish(span);
         span.end();

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceMonoDualConsumer.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceMonoDualConsumer.java
@@ -40,9 +40,8 @@ public class LettuceMonoDualConsumer<R, T, U extends Throwable>
 
   @Override
   public void accept(final R r) {
-    span = TRACER.spanBuilder("redis.query").setSpanKind(CLIENT).startSpan();
+    span = TRACER.spanBuilder(DECORATE.spanNameForCommand(command)).setSpanKind(CLIENT).startSpan();
     DECORATE.afterStart(span);
-    DECORATE.onCommand(span, command);
     if (finishSpanOnClose) {
       span.end();
     }

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -132,12 +132,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/CONNECT/" + dbAddr
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "CONNECT:" + dbAddr
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
@@ -169,12 +168,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/CONNECT/" + dbAddrNonExistent
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "CONNECT:" + dbAddrNonExistent
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
@@ -198,12 +196,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "SET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -234,12 +231,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "GET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -284,12 +280,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "GET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -320,12 +315,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/RANDOMKEY"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "RANDOMKEY"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -374,12 +368,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/HMSET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "HMSET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -388,12 +381,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
       }
       trace(1, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/HGETALL"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "HGETALL"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -432,12 +424,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/DEL"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "DEL"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -471,12 +462,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SADD"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "SADD"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -495,12 +485,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/" + AGENT_CRASHING_COMMAND_PREFIX + "DEBUG"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" AGENT_CRASHING_COMMAND_PREFIX + "DEBUG"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -519,12 +508,11 @@ class LettuceAsyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SHUTDOWN"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "SHUTDOWN"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -105,12 +105,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "SET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -132,12 +131,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "GET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -167,12 +165,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "GET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -200,12 +197,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/RANDOMKEY"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "RANDOMKEY"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -223,12 +219,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/" + AGENT_CRASHING_COMMAND_PREFIX + "COMMAND"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" AGENT_CRASHING_COMMAND_PREFIX + "COMMAND"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -247,12 +242,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/" + AGENT_CRASHING_COMMAND_PREFIX + "COMMAND"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" AGENT_CRASHING_COMMAND_PREFIX + "COMMAND"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -284,12 +278,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/" + AGENT_CRASHING_COMMAND_PREFIX + "DEBUG"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" AGENT_CRASHING_COMMAND_PREFIX + "DEBUG"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -307,12 +300,11 @@ class LettuceReactiveClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SHUTDOWN"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "SHUTDOWN"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -112,12 +112,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/CONNECT/" + dbAddr
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "CONNECT:" + dbAddr
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
@@ -146,12 +145,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/CONNECT/" + dbAddrNonExistent
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "CONNECT:" + dbAddrNonExistent
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
@@ -174,12 +172,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "SET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -198,12 +195,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "GET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -222,12 +218,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/GET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "GET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -246,12 +241,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/RANDOMKEY"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "RANDOMKEY"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -270,12 +264,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/LPUSH"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "LPUSH"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -294,12 +287,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/HMSET"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "HMSET"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -318,12 +310,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/HGETALL"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "HGETALL"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -341,12 +332,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/" + AGENT_CRASHING_COMMAND_PREFIX + "DEBUG"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" AGENT_CRASHING_COMMAND_PREFIX + "DEBUG"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
@@ -364,12 +354,11 @@ class LettuceSyncClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "redis.query"
+          operationName "redis/SHUTDOWN"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "redis"
-            "$MoreTags.RESOURCE_NAME" "SHUTDOWN"
             "$MoreTags.SPAN_TYPE" SpanTypes.REDIS
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -252,7 +252,7 @@ class MongoClientTest extends MongoBaseTest {
 
   def mongoSpan(TraceAssert trace, int index, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      operationName "mongo.query"
+      operationName { it.replace(" ", "") == statement }
       spanKind CLIENT
       if (parentSpan == null) {
         parent()
@@ -261,7 +261,6 @@ class MongoClientTest extends MongoBaseTest {
       }
       tags {
         "$MoreTags.SERVICE_NAME" renameService ? instance : "mongo"
-        "$MoreTags.RESOURCE_NAME" { it.replace(" ", "") == statement }
         "$MoreTags.SPAN_TYPE" SpanTypes.MONGO
         "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -255,7 +255,7 @@ class MongoClientTest extends MongoBaseTest {
 
   def mongoSpan(TraceAssert trace, int index, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      operationName "mongo.query"
+      operationName { it.replace(" ", "") == statement }
       spanKind CLIENT
       if (parentSpan == null) {
         parent()
@@ -264,7 +264,6 @@ class MongoClientTest extends MongoBaseTest {
       }
       tags {
         "$MoreTags.SERVICE_NAME" renameService ? instance : "mongo"
-        "$MoreTags.RESOURCE_NAME" { it.replace(" ", "") == statement }
         "$MoreTags.SPAN_TYPE" SpanTypes.MONGO
         "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -290,7 +290,7 @@ class MongoAsyncClientTest extends MongoBaseTest {
 
   def mongoSpan(TraceAssert trace, int index, Closure<Boolean> statementEval, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
-      operationName "mongo.query"
+      operationName statementEval
       spanKind CLIENT
       if (parentSpan == null) {
         parent()
@@ -299,7 +299,6 @@ class MongoAsyncClientTest extends MongoBaseTest {
       }
       tags {
         "$MoreTags.SERVICE_NAME" "mongo"
-        "$MoreTags.RESOURCE_NAME" statementEval
         "$MoreTags.SPAN_TYPE" SpanTypes.MONGO
         "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"

--- a/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/MongoClientDecorator.java
+++ b/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/MongoClientDecorator.java
@@ -22,9 +22,7 @@ import com.mongodb.connection.ServerId;
 import com.mongodb.event.CommandStartedEvent;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanTypes;
-import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.util.Arrays;
 import java.util.List;
@@ -89,14 +87,10 @@ public class MongoClientDecorator extends DatabaseClientDecorator<CommandStarted
     return event.getDatabaseName();
   }
 
-  public Span onStatement(final Span span, final BsonDocument statement) {
-
+  public String statement(final BsonDocument statement) {
     // scrub the Mongo command so that parameters are removed from the string
     final BsonDocument scrubbed = scrub(statement);
-    final String mongoCmd = scrubbed.toString();
-
-    span.setAttribute(MoreTags.RESOURCE_NAME, mongoCmd);
-    return onStatement(span, mongoCmd);
+    return scrubbed.toString();
   }
 
   /**

--- a/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/TracingCommandListener.java
+++ b/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/TracingCommandListener.java
@@ -36,7 +36,8 @@ public class TracingCommandListener implements CommandListener {
 
   @Override
   public void commandStarted(final CommandStartedEvent event) {
-    final Span span = TRACER.spanBuilder("mongo.query").setSpanKind(CLIENT).startSpan();
+    final String statement = DECORATE.statement(event.getCommand());
+    final Span span = TRACER.spanBuilder(statement).setSpanKind(CLIENT).startSpan();
     try (final Scope scope = TRACER.withSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, event);
@@ -46,7 +47,7 @@ public class TracingCommandListener implements CommandListener {
         DECORATE.onPeerConnection(
             span, event.getConnectionDescription().getServerAddress().getSocketAddress());
       }
-      DECORATE.onStatement(span, event.getCommand());
+      DECORATE.onStatement(span, statement);
       spanMap.put(event.getRequestId(), span);
     }
   }

--- a/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -86,7 +86,7 @@ class Netty40ClientTest extends HttpClientTest {
     assertTraces(1) {
       def size = traces[0].size()
       trace(0, size) {
-        basicSpan(it, 0, "parent", null, null, thrownException)
+        basicSpan(it, 0, "parent", null, thrownException)
 
         // AsyncHttpClient retries across multiple resolved IP addresses (e.g. 127.0.0.1 and 0:0:0:0:0:0:0:1)
         // for up to a total of 10 seconds (default connection time limit)

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -96,7 +96,7 @@ class Netty41ClientTest extends HttpClientTest {
     assertTraces(1) {
       def size = traces[0].size()
       trace(0, size) {
-        basicSpan(it, 0, "parent", null, null, thrownException)
+        basicSpan(it, 0, "parent", null, thrownException)
 
         // AsyncHttpClient retries across multiple resolved IP addresses (e.g. 127.0.0.1 and 0:0:0:0:0:0:0:1)
         // for up to a total of 10 seconds (default connection time limit)

--- a/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play24/PlayHttpServerDecorator.java
+++ b/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play24/PlayHttpServerDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.play24;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
@@ -78,7 +77,6 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       if (!pathOption.isEmpty()) {
         final String path = (String) pathOption.get();
         span.updateName(request.method() + " " + path);
-        span.setAttribute(MoreTags.RESOURCE_NAME, request.method() + " " + path);
       }
     }
     return span;

--- a/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play26/PlayHttpServerDecorator.java
+++ b/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play26/PlayHttpServerDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.play26;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
@@ -81,7 +80,6 @@ public class PlayHttpServerDecorator extends HttpServerDecorator<Request, Reques
       if (!defOption.isEmpty()) {
         final String path = defOption.get().path();
         span.updateName(request.method() + " " + path);
-        span.setAttribute(MoreTags.RESOURCE_NAME, request.method() + " " + path);
       }
     }
     return span;

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -138,14 +138,13 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
 
       final Connection connection = channel.getConnection();
 
-      final Span.Builder spanBuilder = TRACER.spanBuilder("amqp.command");
+      final Span.Builder spanBuilder = TRACER.spanBuilder("amqp/" + method);
       if (method.equals("Channel.basicPublish")) {
         spanBuilder.setSpanKind(PRODUCER);
       } else {
         spanBuilder.setSpanKind(CLIENT);
       }
       final Span span = spanBuilder.startSpan();
-      span.setAttribute(MoreTags.RESOURCE_NAME, method);
       span.setAttribute(MoreTags.NET_PEER_PORT, connection.getPort());
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, connection.getAddress());
@@ -245,7 +244,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
       // span creation
       final Span.Builder spanBuilder =
           TRACER
-              .spanBuilder("amqp.command")
+              .spanBuilder(CONSUMER_DECORATE.spanNameOnGet(queue))
               .setSpanKind(CLIENT)
               .setStartTimestamp(TimeUnit.MILLISECONDS.toNanos(startTime));
 

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -81,7 +81,8 @@ public class TracedDelegatingConsumer implements Consumer {
     Scope scope = null;
     try {
       final Map<String, Object> headers = properties.getHeaders();
-      final Span.Builder spanBuilder = TRACER.spanBuilder("amqp.command").setSpanKind(CONSUMER);
+      final Span.Builder spanBuilder =
+          TRACER.spanBuilder(CONSUMER_DECORATE.spanNameOnDeliver(queue)).setSpanKind(CONSUMER);
       SpanContext extractedContext = null;
       if (headers != null) {
         try {
@@ -101,7 +102,7 @@ public class TracedDelegatingConsumer implements Consumer {
       span.setAttribute("message.size", body == null ? 0 : body.length);
       span.setAttribute("span.origin.type", delegate.getClass().getName());
       CONSUMER_DECORATE.afterStart(span);
-      CONSUMER_DECORATE.onDeliver(span, queue, envelope);
+      CONSUMER_DECORATE.onDeliver(span, envelope);
 
       scope = TRACER.withSpan(span);
 

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/RatpackServerDecorator.java
@@ -18,7 +18,6 @@ package io.opentelemetry.auto.instrumentation.ratpack;
 import com.google.common.net.HostAndPort;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpServerDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import java.net.URI;
@@ -87,9 +86,7 @@ public class RatpackServerDecorator extends HttpServerDecorator<Request, Request
       description = "/" + description;
     }
 
-    final String resourceName = ctx.getRequest().getMethod().getName() + " " + description;
-    span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
-    span.updateName(resourceName);
+    span.updateName(ctx.getRequest().getMethod().getName() + " " + description);
 
     return span;
   }

--- a/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
@@ -87,7 +87,6 @@ class RatpackOtherTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET /$route"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -103,7 +102,6 @@ class RatpackOtherTest extends AgentTestRunner {
           childOf(span(0))
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET /$route"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "ratpack"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -134,7 +134,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$MoreTags.RESOURCE_NAME" endpoint.status == 404 ? "$method /" : "$method ${endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.getComponentName()
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
@@ -164,7 +163,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
         parent()
       }
       tags {
-        "$MoreTags.RESOURCE_NAME" endpoint.status == 404 ? "$method /" : "$method ${endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_PORT" Long

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -25,7 +25,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
@@ -69,8 +68,8 @@ public final class RmiClientInstrumentation extends Instrumenter.Default {
       if (!TRACER.getCurrentSpan().getContext().isValid()) {
         return null;
       }
-      final Span span = TRACER.spanBuilder("rmi.invoke").setSpanKind(CLIENT).startSpan();
-      span.setAttribute(MoreTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
+      final Span span =
+          TRACER.spanBuilder(DECORATE.spanNameForMethod(method)).setSpanKind(CLIENT).startSpan();
       span.setAttribute("span.origin.type", method.getDeclaringClass().getCanonicalName());
 
       DECORATE.afterStart(span);

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -29,7 +29,6 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.bootstrap.CallDepthThreadLocalMap;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
@@ -75,14 +74,14 @@ public final class RmiServerInstrumentation extends Instrumenter.Default {
       }
       final SpanContext context = THREAD_LOCAL_CONTEXT.getAndResetContext();
 
-      final Span.Builder spanBuilder = TRACER.spanBuilder("rmi.request").setSpanKind(SERVER);
+      final Span.Builder spanBuilder =
+          TRACER.spanBuilder(DECORATE.spanNameForMethod(method)).setSpanKind(SERVER);
       if (context != null) {
         spanBuilder.setParent(context);
       } else {
         spanBuilder.setNoParent();
       }
       final Span span = spanBuilder.startSpan();
-      span.setAttribute(MoreTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
       span.setAttribute("span.origin.type", thiz.getClass().getCanonicalName());
 
       DECORATE.afterStart(span);

--- a/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -56,21 +56,19 @@ class RmiTest extends AgentTestRunner {
       trace(0, 3) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "rmi.invoke"
+          operationName "Greeter/hello"
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "Greeter.hello"
             "$MoreTags.SPAN_TYPE" SpanTypes.RPC
             "$Tags.COMPONENT" "rmi-client"
             "span.origin.type" Greeter.canonicalName
           }
         }
         span(2) {
-          operationName "rmi.request"
+          operationName "Server/hello"
           spanKind SERVER
           tags {
-            "$MoreTags.RESOURCE_NAME" "Server.hello"
             "$MoreTags.SPAN_TYPE" SpanTypes.RPC
             "$Tags.COMPONENT" "rmi-server"
             "span.origin.type" server.class.canonicalName
@@ -117,14 +115,13 @@ class RmiTest extends AgentTestRunner {
     def thrownException = thrown(RuntimeException)
     assertTraces(1) {
       trace(0, 3) {
-        basicSpan(it, 0, "parent", null, null, thrownException)
+        basicSpan(it, 0, "parent", null, thrownException)
         span(1) {
-          operationName "rmi.invoke"
+          operationName "Greeter/exceptional"
           spanKind CLIENT
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "Greeter.exceptional"
             "$MoreTags.SPAN_TYPE" SpanTypes.RPC
             "$Tags.COMPONENT" "rmi-client"
             "span.origin.type" Greeter.canonicalName
@@ -132,11 +129,10 @@ class RmiTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "rmi.request"
+          operationName "Server/exceptional"
           spanKind SERVER
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "Server.exceptional"
             "$MoreTags.SPAN_TYPE" SpanTypes.RPC
             "$Tags.COMPONENT" "rmi-server"
             "span.origin.type" server.class.canonicalName
@@ -167,11 +163,10 @@ class RmiTest extends AgentTestRunner {
       trace(0, 3) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "rmi.invoke"
+          operationName "Greeter/hello"
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "Greeter.hello"
             "$MoreTags.SPAN_TYPE" SpanTypes.RPC
             "$Tags.COMPONENT" "rmi-client"
             "span.origin.type" Greeter.canonicalName
@@ -179,10 +174,9 @@ class RmiTest extends AgentTestRunner {
         }
         span(2) {
           childOf span(1)
-          operationName "rmi.request"
+          operationName "ServerLegacy/hello"
           spanKind SERVER
           tags {
-            "$MoreTags.RESOURCE_NAME" "ServerLegacy.hello"
             "$MoreTags.SPAN_TYPE" SpanTypes.RPC
             "$Tags.COMPONENT" "rmi-server"
             "span.origin.type" server.class.canonicalName

--- a/instrumentation/servlet/request-3.0/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/TomcatServlet3Test.groovy
@@ -122,7 +122,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
     assertTraces(count * 2) {
       (0..count - 1).each {
         trace(it * 2, 1) {
-          basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+          basicSpan(it, 0, "TEST_SPAN")
         }
         trace(it * 2 + 1, 2) {
           serverSpan(it, 0)
@@ -153,7 +153,7 @@ abstract class TomcatServlet3Test extends AbstractServlet3Test<Tomcat, Context> 
     and:
     assertTraces(2) {
       trace(0, 1) {
-        basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+        basicSpan(it, 0, "TEST_SPAN")
       }
       trace(1, 2) {
         serverSpan(it, 0, null, null, method, ERROR)

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -24,7 +24,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
@@ -84,11 +83,10 @@ public final class FilterInstrumentation extends Instrumenter.Default {
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("servlet.filter").startSpan();
-      FilterDecorator.DECORATE.afterStart(span);
-
       // Here we use "this" instead of "the method target" to distinguish abstract filter instances.
-      span.setAttribute(MoreTags.RESOURCE_NAME, filter.getClass().getSimpleName() + ".doFilter");
+      final Span span =
+          TRACER.spanBuilder(filter.getClass().getSimpleName() + "/doFilter").startSpan();
+      FilterDecorator.DECORATE.afterStart(span);
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -27,7 +27,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
@@ -92,11 +91,9 @@ public final class HttpServletInstrumentation extends Instrumenter.Default {
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("servlet." + method.getName()).startSpan();
-      DECORATE.afterStart(span);
-
       // Here we use the Method instead of "this.class.name" to distinguish calls to "super".
-      span.setAttribute(MoreTags.RESOURCE_NAME, DECORATE.spanNameForMethod(method));
+      final Span span = TRACER.spanBuilder(DECORATE.spanNameForMethod(method)).startSpan();
+      DECORATE.afterStart(span);
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -24,7 +24,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.bootstrap.InstrumentationContext;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
@@ -88,10 +87,8 @@ public final class HttpServletResponseInstrumentation extends Instrumenter.Defau
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("servlet.response").startSpan();
+      final Span span = TRACER.spanBuilder("HttpServletResponse/" + method).startSpan();
       DECORATE.afterStart(span);
-
-      span.setAttribute(MoreTags.RESOURCE_NAME, "HttpServletResponse." + method);
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/servlet/src/test/groovy/FilterTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/FilterTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
@@ -54,10 +53,9 @@ class FilterTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "servlet.filter"
+          operationName "${filter.class.simpleName}/doFilter"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "${filter.class.simpleName}.doFilter"
             "$Tags.COMPONENT" "java-web-servlet-filter"
           }
         }
@@ -89,13 +87,12 @@ class FilterTest extends AgentTestRunner {
 
     assertTraces(1) {
       trace(0, 2) {
-        basicSpan(it, 0, "parent", null, null, ex)
+        basicSpan(it, 0, "parent", null, ex)
         span(1) {
-          operationName "servlet.filter"
+          operationName "${filter.class.simpleName}/doFilter"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "${filter.class.simpleName}.doFilter"
             "$Tags.COMPONENT" "java-web-servlet-filter"
             errorTags(ex.class, ex.message)
           }

--- a/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import spock.lang.Subject
@@ -72,26 +71,23 @@ class HttpServletResponseTest extends AgentTestRunner {
       trace(0, 4) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "servlet.response"
+          operationName "HttpServletResponse/sendError"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "HttpServletResponse.sendError"
             "$Tags.COMPONENT" "java-web-servlet-response"
           }
         }
         span(2) {
-          operationName "servlet.response"
+          operationName "HttpServletResponse/sendError"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "HttpServletResponse.sendError"
             "$Tags.COMPONENT" "java-web-servlet-response"
           }
         }
         span(3) {
-          operationName "servlet.response"
+          operationName "HttpServletResponse/sendRedirect"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "HttpServletResponse.sendRedirect"
             "$Tags.COMPONENT" "java-web-servlet-response"
           }
         }
@@ -125,13 +121,12 @@ class HttpServletResponseTest extends AgentTestRunner {
 
     assertTraces(1) {
       trace(0, 2) {
-        basicSpan(it, 0, "parent", null, null, ex)
+        basicSpan(it, 0, "parent", null, ex)
         span(1) {
-          operationName "servlet.response"
+          operationName "HttpServletResponse/sendRedirect"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "HttpServletResponse.sendRedirect"
             "$Tags.COMPONENT" "java-web-servlet-response"
             errorTags(ex.class, ex.message)
           }

--- a/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
@@ -57,18 +56,16 @@ class HttpServletTest extends AgentTestRunner {
       trace(0, 3) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "servlet.service"
+          operationName "HttpServlet/service"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "HttpServlet.service"
             "$Tags.COMPONENT" "java-web-servlet-service"
           }
         }
         span(2) {
-          operationName "servlet.doGet"
+          operationName "${expectedResourceName}/doGet"
           childOf span(1)
           tags {
-            "$MoreTags.RESOURCE_NAME" "${expectedResourceName}.doGet"
             "$Tags.COMPONENT" "java-web-servlet-service"
           }
         }
@@ -106,23 +103,21 @@ class HttpServletTest extends AgentTestRunner {
 
     assertTraces(1) {
       trace(0, 3) {
-        basicSpan(it, 0, "parent", null, null, ex)
+        basicSpan(it, 0, "parent", null, ex)
         span(1) {
-          operationName "servlet.service"
+          operationName "HttpServlet/service"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "HttpServlet.service"
             "$Tags.COMPONENT" "java-web-servlet-service"
             errorTags(ex.class, ex.message)
           }
         }
         span(2) {
-          operationName "servlet.doGet"
+          operationName "${servlet.class.name}/doGet"
           childOf span(1)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "${servlet.class.name}.doGet"
             "$Tags.COMPONENT" "java-web-servlet-service"
             errorTags(ex.class, ex.message)
           }

--- a/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
@@ -70,7 +70,7 @@ class RequestDispatcherTest extends AgentTestRunner {
             "$Tags.COMPONENT" "java-web-servlet-dispatcher"
           }
         }
-        basicSpan(it, 2, "$operation-child", null, span(1))
+        basicSpan(it, 2, "$operation-child", span(1))
       }
     }
 
@@ -108,7 +108,7 @@ class RequestDispatcherTest extends AgentTestRunner {
 
     assertTraces(1) {
       trace(0, 3) {
-        basicSpan(it, 0, "parent", null, null, ex)
+        basicSpan(it, 0, "parent", null, ex)
         span(1) {
           operationName "servlet.$operation"
           childOf span(0)
@@ -119,7 +119,7 @@ class RequestDispatcherTest extends AgentTestRunner {
             errorTags(ex.class, ex.message)
           }
         }
-        basicSpan(it, 2, "$operation-child", null, span(1))
+        basicSpan(it, 2, "$operation-child", span(1))
       }
     }
 

--- a/instrumentation/sparkjava-2.3/src/main/java/io/opentelemetry/auto/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/instrumentation/sparkjava-2.3/src/main/java/io/opentelemetry/auto/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -23,7 +23,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -82,9 +81,7 @@ public class RoutesInstrumentation extends Instrumenter.Default {
 
       final Span span = TracerHolder.TRACER.getCurrentSpan();
       if (span != null && routeMatch != null) {
-        final String resourceName = method.name().toUpperCase() + " " + routeMatch.getMatchUri();
-        span.updateName(resourceName);
-        span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+        span.updateName(method.name().toUpperCase() + " " + routeMatch.getMatchUri());
       }
     }
   }

--- a/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -67,7 +67,6 @@ class SparkJavaBasedTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET /param/:param"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "jetty-handler"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringDataDecorator.java
+++ b/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringDataDecorator.java
@@ -17,10 +17,7 @@ package io.opentelemetry.auto.instrumentation.springdata;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
-import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
-import java.lang.reflect.Method;
 
 public final class SpringDataDecorator extends ClientDecorator {
   public static final SpringDataDecorator DECORATOR = new SpringDataDecorator();
@@ -43,15 +40,5 @@ public final class SpringDataDecorator extends ClientDecorator {
   @Override
   protected String getComponentName() {
     return "spring-data";
-  }
-
-  public Span onOperation(final Span span, final Method method) {
-    assert span != null;
-    assert method != null;
-
-    if (method != null) {
-      span.setAttribute(MoreTags.RESOURCE_NAME, spanNameForMethod(method));
-    }
-    return span;
   }
 }

--- a/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringRepositoryInstrumentation.java
+++ b/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringRepositoryInstrumentation.java
@@ -118,9 +118,8 @@ public final class SpringRepositoryInstrumentation extends Instrumenter.Default 
         return methodInvocation.proceed();
       }
 
-      final Span span = TRACER.spanBuilder("repository.operation").startSpan();
+      final Span span = TRACER.spanBuilder(DECORATOR.spanNameForMethod(invokedMethod)).startSpan();
       DECORATOR.afterStart(span);
-      DECORATOR.onOperation(span, invokedMethod);
 
       final Scope scope = TRACER.withSpan(span);
 

--- a/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -70,20 +70,19 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "repository.operation"
+          operationName "JpaRepository/findAll"
           spanKind INTERNAL
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "JpaRepository.findAll"
             "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
+          operationName ~/^select /
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -106,20 +105,19 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/save"
           spanKind INTERNAL
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.save"
             "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // insert
+          operationName ~/^insert /
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/^insert /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -142,20 +140,19 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/save"
           spanKind INTERNAL
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.save"
             "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
+          operationName ~/^select /
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -166,11 +163,11 @@ class SpringJpaTest extends AgentTestRunner {
           }
         }
         span(2) { // update
+          operationName ~/^update /
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/^update /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -191,20 +188,19 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 2) {
         span(0) {
-          operationName "repository.operation"
+          operationName "JpaCustomerRepository/findByLastName"
           spanKind INTERNAL
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "JpaCustomerRepository.findByLastName"
             "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
+          operationName ~/^select /
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -225,20 +221,19 @@ class SpringJpaTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          operationName "repository.operation"
+          operationName "CrudRepository/delete"
           spanKind INTERNAL
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "CrudRepository.delete"
             "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
+          operationName ~/^select /
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/^select /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"
@@ -249,11 +244,11 @@ class SpringJpaTest extends AgentTestRunner {
           }
         }
         span(2) { // delete
+          operationName ~/^delete /
           spanKind CLIENT
           childOf(span(0))
           tags {
             "$MoreTags.SERVICE_NAME" "hsqldb"
-            "$MoreTags.RESOURCE_NAME" ~/^delete /
             "$MoreTags.SPAN_TYPE" "sql"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "hsqldb"

--- a/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingDecorator.java
+++ b/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingDecorator.java
@@ -17,8 +17,6 @@ package io.opentelemetry.auto.instrumentation.springscheduling;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
-import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.support.ScheduledMethodRunnable;
@@ -42,19 +40,14 @@ public class SpringSchedulingDecorator extends BaseDecorator {
     return "spring-scheduling";
   }
 
-  public Span onRun(final Span span, final Runnable runnable) {
-    if (runnable != null) {
-      String resourceName = "";
-      if (runnable instanceof ScheduledMethodRunnable) {
-        final ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
-        resourceName = spanNameForMethod(scheduledMethodRunnable.getMethod());
-      } else {
-        final String className = spanNameForClass(runnable.getClass());
-        final String methodName = "run";
-        resourceName = className + "." + methodName;
-      }
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+  public String spanNameOnRun(final Runnable runnable) {
+    if (runnable instanceof ScheduledMethodRunnable) {
+      final ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
+      return spanNameForMethod(scheduledMethodRunnable.getMethod());
+    } else {
+      final String className = spanNameForClass(runnable.getClass());
+      final String methodName = "run";
+      return className + "." + methodName;
     }
-    return span;
   }
 }

--- a/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -32,11 +31,10 @@ class SpringSchedulingTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "scheduled.call"
+          operationName "TriggerTask/run"
           parent()
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "TriggerTask.run"
             "$Tags.COMPONENT" "spring-scheduling"
           }
         }
@@ -56,11 +54,10 @@ class SpringSchedulingTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "scheduled.call"
+          operationName "IntervalTask/run"
           parent()
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "IntervalTask.run"
             "$Tags.COMPONENT" "spring-scheduling"
           }
         }

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/AdviceUtils.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/AdviceUtils.java
@@ -38,9 +38,9 @@ public class AdviceUtils {
     final int lambdaIdx = className.indexOf("$$Lambda$");
 
     if (lambdaIdx > -1) {
-      operationName = className.substring(0, lambdaIdx) + ".lambda";
+      operationName = className.substring(0, lambdaIdx) + "/lambda";
     } else {
-      operationName = className + ".handle";
+      operationName = className + "/handle";
     }
     return operationName;
   }

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -45,7 +45,7 @@ public class DispatcherHandlerAdvice {
     }
 
     final Span span =
-        TRACER.spanBuilder("DispatcherHandler.handle").setSpanKind(SERVER).startSpan();
+        TRACER.spanBuilder("DispatcherHandler/handle").setSpanKind(SERVER).startSpan();
     DECORATE.afterStart(span);
     exchange.getAttributes().put(AdviceUtils.SPAN_ATTRIBUTE, span);
 

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -18,7 +18,6 @@ package io.opentelemetry.auto.instrumentation.springwebflux.server;
 import static io.opentelemetry.auto.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.DECORATE;
 import static io.opentelemetry.auto.instrumentation.springwebflux.server.SpringWebfluxHttpServerDecorator.TRACER;
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.trace.Span;
 import net.bytebuddy.asm.Advice;
@@ -60,10 +59,9 @@ public class HandlerAdapterAdvice {
     final PathPattern bestPattern =
         exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
     if (parentSpan != null && bestPattern != null) {
-      String resourceName =
+      final String resourceName =
           exchange.getRequest().getMethodValue() + " " + bestPattern.getPatternString();
       parentSpan.updateName(resourceName);
-      parentSpan.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
     }
 
     return spanWithScope;

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
@@ -15,7 +15,6 @@
  */
 package io.opentelemetry.auto.instrumentation.springwebflux.server;
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
@@ -49,9 +48,8 @@ public class RouteOnSuccessOrError implements BiConsumer<HandlerFunction<?>, Thr
         final Span parentSpan =
             (Span) serverRequest.attributes().get(AdviceUtils.PARENT_SPAN_ATTRIBUTE);
         if (parentSpan != null) {
-          String resourceName = parseResourceName(predicateString);
+          final String resourceName = parseResourceName(predicateString);
           parentSpan.updateName(resourceName);
-          parentSpan.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
         }
       }
     }

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/SpringWebfluxTest.groovy
@@ -71,7 +71,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET $urlPathWithVariables"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -84,10 +83,10 @@ class SpringWebfluxTest extends AgentTestRunner {
         span(1) {
           if (annotatedMethod == null) {
             // Functional API
-            operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
+            operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, "/handle")
           } else {
             // Annotation API
-            operationName TestController.getSimpleName() + "." + annotatedMethod
+            operationName TestController.getSimpleName() + "/" + annotatedMethod
           }
           spanKind SERVER
           childOf(span(0))
@@ -140,7 +139,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET $urlPathWithVariables"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -153,10 +151,10 @@ class SpringWebfluxTest extends AgentTestRunner {
         span(1) {
           if (annotatedMethod == null) {
             // Functional API
-            operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
+            operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, "/handle")
           } else {
             // Annotation API
-            operationName TestController.getSimpleName() + "." + annotatedMethod
+            operationName TestController.getSimpleName() + "/" + annotatedMethod
           }
           spanKind SERVER
           childOf(span(0))
@@ -213,7 +211,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET /**"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -224,7 +221,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "ResourceWebHandler.handle"
+          operationName "ResourceWebHandler/handle"
           spanKind SERVER
           childOf(span(0))
           errored true
@@ -259,7 +256,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "POST /echo"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -270,7 +266,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName EchoHandlerFunction.getSimpleName() + ".handle"
+          operationName EchoHandlerFunction.getSimpleName() + "/handle"
           spanKind SERVER
           childOf(span(0))
           tags {
@@ -310,7 +306,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET $urlPathWithVariables"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -323,10 +318,10 @@ class SpringWebfluxTest extends AgentTestRunner {
         span(1) {
           if (annotatedMethod == null) {
             // Functional API
-            operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
+            operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, "/handle")
           } else {
             // Annotation API
-            operationName TestController.getSimpleName() + "." + annotatedMethod
+            operationName TestController.getSimpleName() + "/" + annotatedMethod
           }
           spanKind SERVER
           childOf(span(0))
@@ -378,7 +373,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET /double-greet-redirect"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -389,7 +383,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "RedirectComponent.lambda"
+          operationName "RedirectComponent/lambda"
           spanKind SERVER
           childOf(span(0))
           tags {
@@ -409,7 +403,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" "GET /double-greet"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
             "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -420,7 +413,7 @@ class SpringWebfluxTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationNameContains(SpringWebFluxTestApplication.getSimpleName() + "\$", ".handle")
+          operationNameContains(SpringWebFluxTestApplication.getSimpleName() + "\$", "/handle")
           spanKind SERVER
           childOf(span(0))
           tags {
@@ -455,7 +448,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             spanKind SERVER
             parent()
             tags {
-              "$MoreTags.RESOURCE_NAME" "GET $urlPathWithVariables"
               "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
               "$Tags.COMPONENT" "netty"
               "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -468,10 +460,10 @@ class SpringWebfluxTest extends AgentTestRunner {
           span(1) {
             if (annotatedMethod == null) {
               // Functional API
-              operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, ".handle")
+              operationNameContains(SPRING_APP_CLASS_ANON_NESTED_CLASS_PREFIX, "/handle")
             } else {
               // Annotation API
-              operationName TestController.getSimpleName() + "." + annotatedMethod
+              operationName TestController.getSimpleName() + "/" + annotatedMethod
             }
             spanKind SERVER
             childOf(span(0))

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springweb/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springweb/DispatcherServletInstrumentation.java
@@ -79,7 +79,7 @@ public final class DispatcherServletInstrumentation extends Instrumenter.Default
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope onEnter(@Advice.Argument(0) final ModelAndView mv) {
-      final Span span = TRACER.spanBuilder("response.render").startSpan();
+      final Span span = TRACER.spanBuilder(DECORATE_RENDER.spanNameOnRender(mv)).startSpan();
       DECORATE_RENDER.afterStart(span);
       DECORATE_RENDER.onRender(span, mv);
       return new SpanWithScope(span, TRACER.withSpan(span));

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springweb/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springweb/HandlerAdapterInstrumentation.java
@@ -93,9 +93,8 @@ public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
 
       // Now create a span for handler/controller execution.
 
-      final Span span = TRACER.spanBuilder("spring.handler").startSpan();
+      final Span span = TRACER.spanBuilder(DECORATE.spanNameOnHandle(handler)).startSpan();
       DECORATE.afterStart(span);
-      DECORATE.onHandle(span, handler);
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -81,7 +81,7 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   @Override
   void renderSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      operationName "response.render"
+      operationName "render"
       spanKind INTERNAL
       errored false
       tags {
@@ -95,12 +95,11 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   @Override
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      operationName "spring.handler"
+      operationName "TestController/${endpoint.name().toLowerCase()}"
       spanKind INTERNAL
       errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$MoreTags.RESOURCE_NAME" "TestController.${endpoint.name().toLowerCase()}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.getComponentName()
         if (endpoint == EXCEPTION) {
@@ -123,7 +122,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         parent()
       }
       tags {
-        "$MoreTags.RESOURCE_NAME" "$method ${endpoint == PATH_PARAM ? "/path/{id}/param" : endpoint.resolvePath(address).path}"
         "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_SERVER
         "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/CompletionListener.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/CompletionListener.java
@@ -29,27 +29,22 @@ import net.spy.memcached.MemcachedConnection;
 @Slf4j
 public abstract class CompletionListener<T> {
 
-  // Note: it looks like this value is being ignored and DBTypeDecorator overwrites it.
-  static final String OPERATION_NAME = "memcached.query";
-
-  static final String SERVICE_NAME = "memcached";
-  static final String COMPONENT_NAME = "java-spymemcached";
-  static final String DB_TYPE = "memcached";
   static final String DB_COMMAND_CANCELLED = "db.command.cancelled";
   static final String MEMCACHED_RESULT = "memcaced.result";
   static final String HIT = "hit";
   static final String MISS = "miss";
 
-  private final MemcachedConnection connection;
   private final Span span;
 
   public CompletionListener(final MemcachedConnection connection, final String methodName) {
-    this.connection = connection;
-    span = TRACER.spanBuilder(OPERATION_NAME).setSpanKind(CLIENT).startSpan();
+    span =
+        TRACER
+            .spanBuilder(DECORATE.spanNameOnOperation(methodName))
+            .setSpanKind(CLIENT)
+            .startSpan();
     try (final Scope scope = TRACER.withSpan(span)) {
       DECORATE.afterStart(span);
       DECORATE.onConnection(span, connection);
-      DECORATE.onOperation(span, methodName);
     }
   }
 

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -17,9 +17,7 @@ package io.opentelemetry.auto.instrumentation.spymemcached;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanTypes;
-import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import net.spy.memcached.MemcachedConnection;
 
@@ -59,7 +57,7 @@ public class MemcacheClientDecorator extends DatabaseClientDecorator<MemcachedCo
     return null;
   }
 
-  public Span onOperation(final Span span, final String methodName) {
+  public String spanNameOnOperation(final String methodName) {
 
     final char[] chars =
         methodName
@@ -71,7 +69,6 @@ public class MemcacheClientDecorator extends DatabaseClientDecorator<MemcachedCo
     // Lowercase first letter
     chars[0] = Character.toLowerCase(chars[0]);
 
-    span.setAttribute(MoreTags.RESOURCE_NAME, new String(chars));
-    return span;
+    return "memcached/" + new String(chars);
   }
 }

--- a/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
@@ -642,16 +642,15 @@ class SpymemcachedTest extends AgentTestRunner {
         childOf(trace.span(0))
       }
 
-      operationName CompletionListener.OPERATION_NAME
+      operationName "memcached/" + operation
       spanKind CLIENT
       errored(error != null && error != "canceled")
 
       tags {
-        "$MoreTags.SERVICE_NAME" CompletionListener.SERVICE_NAME
-        "$MoreTags.RESOURCE_NAME" operation
+        "$MoreTags.SERVICE_NAME" "memcached"
         "$MoreTags.SPAN_TYPE" SpanTypes.MEMCACHED
-        "$Tags.COMPONENT" CompletionListener.COMPONENT_NAME
-        "$Tags.DB_TYPE" CompletionListener.DB_TYPE
+        "$Tags.COMPONENT" "java-spymemcached"
+        "$Tags.DB_TYPE" "memcached"
 
         if (error == "canceled") {
           "${CompletionListener.DB_COMMAND_CANCELLED}" true

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/trace_annotation/TraceAdvice.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/trace_annotation/TraceAdvice.java
@@ -18,7 +18,6 @@ package io.opentelemetry.auto.instrumentation.trace_annotation;
 import static io.opentelemetry.auto.instrumentation.trace_annotation.TraceDecorator.DECORATE;
 import static io.opentelemetry.auto.instrumentation.trace_annotation.TraceDecorator.TRACER;
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.trace.Span;
 import java.lang.reflect.Method;
@@ -28,9 +27,7 @@ public class TraceAdvice {
 
   @Advice.OnMethodEnter(suppress = Throwable.class)
   public static SpanWithScope onEnter(@Advice.Origin final Method method) {
-    final Span span = TRACER.spanBuilder("trace.annotation").startSpan();
-    final String resourceName = DECORATE.spanNameForMethod(method);
-    span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+    final Span span = TRACER.spanBuilder(DECORATE.spanNameForMethod(method)).startSpan();
     DECORATE.afterStart(span);
     return new SpanWithScope(span, TRACER.withSpan(span));
   }

--- a/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.trace_annotation.TraceAnnotationsInstrumentation
 import io.opentelemetry.auto.test.AgentTestRunner
@@ -52,9 +51,8 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "trace.annotation"
+          operationName "AnnotationTracedCallable/call"
           tags {
-            "$MoreTags.RESOURCE_NAME" "AnnotationTracedCallable.call"
             "$Tags.COMPONENT" "trace"
           }
         }

--- a/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -39,12 +39,11 @@ class TraceAnnotationsTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "trace.annotation"
+          operationName "SayTracedHello/sayHello"
           parent()
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "test"
-            "$MoreTags.RESOURCE_NAME" "SayTracedHello.sayHello"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -61,32 +60,29 @@ class TraceAnnotationsTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 3) {
         span(0) {
-          operationName "trace.annotation"
+          operationName "SayTracedHello/sayHELLOsayHA"
           parent()
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "test2"
-            "$MoreTags.RESOURCE_NAME" "SayTracedHello.sayHELLOsayHA"
             "$Tags.COMPONENT" "trace"
           }
         }
         span(1) {
-          operationName "trace.annotation"
+          operationName "SayTracedHello/sayHello"
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "test"
-            "$MoreTags.RESOURCE_NAME" "SayTracedHello.sayHello"
             "$Tags.COMPONENT" "trace"
           }
         }
         span(2) {
-          operationName "trace.annotation"
+          operationName "SayTracedHello/sayHello"
           childOf span(0)
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "test"
-            "$MoreTags.RESOURCE_NAME" "SayTracedHello.sayHello"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -108,10 +104,9 @@ class TraceAnnotationsTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "trace.annotation"
+          operationName "SayTracedHello/sayERROR"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "SayTracedHello.sayERROR"
             "$Tags.COMPONENT" "trace"
             errorTags(error.class)
           }
@@ -129,9 +124,8 @@ class TraceAnnotationsTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "trace.annotation"
+          operationName "SayTracedHello\$1/call"
           tags {
-            "$MoreTags.RESOURCE_NAME" "SayTracedHello\$1.call"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -152,17 +146,15 @@ class TraceAnnotationsTest extends AgentTestRunner {
     assertTraces(2) {
       trace(0, 1) {
         span(0) {
-          operationName "trace.annotation"
+          operationName "SayTracedHello\$1/call"
           tags {
-            "$MoreTags.RESOURCE_NAME" "SayTracedHello\$1.call"
             "$Tags.COMPONENT" "trace"
           }
         }
         trace(1, 1) {
           span(0) {
-            operationName "trace.annotation"
+            operationName "TraceAnnotationsTest\$1/call"
             tags {
-              "$MoreTags.RESOURCE_NAME" "TraceAnnotationsTest\$1.call"
               "$Tags.COMPONENT" "trace"
             }
           }

--- a/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.trace_annotation.TraceConfigInstrumentation
 import io.opentelemetry.auto.test.AgentTestRunner
@@ -50,9 +49,8 @@ class TraceConfigTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "trace.annotation"
+          operationName "ConfigTracedCallable/call"
           tags {
-            "$MoreTags.RESOURCE_NAME" "ConfigTracedCallable.call"
             "$Tags.COMPONENT" "trace"
           }
         }

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -119,10 +119,13 @@ public class TwilioAsyncInstrumentation extends Instrumenter.Default {
       }
 
       // Don't automatically close the span with the scope if we're executing an async method
-      final Span span = TRACER.spanBuilder("twilio.sdk").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(DECORATE.spanNameOnServiceExecution(that, methodName))
+              .setSpanKind(CLIENT)
+              .startSpan();
 
       DECORATE.afterStart(span);
-      DECORATE.onServiceExecution(span, that, methodName);
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioClientDecorator.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioClientDecorator.java
@@ -20,7 +20,6 @@ import com.twilio.rest.api.v2010.account.Call;
 import com.twilio.rest.api.v2010.account.Message;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.ClientDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanTypes;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -55,16 +54,13 @@ public class TwilioClientDecorator extends ClientDecorator {
   }
 
   /** Decorate trace based on service execution metadata. */
-  public Span onServiceExecution(
-      final Span span, final Object serviceExecutor, final String methodName) {
+  public String spanNameOnServiceExecution(final Object serviceExecutor, final String methodName) {
 
     // Drop common package prefix (com.twilio.rest)
     final String simpleClassName =
         serviceExecutor.getClass().getCanonicalName().replaceFirst("^com\\.twilio\\.rest\\.", "");
 
-    span.setAttribute(MoreTags.RESOURCE_NAME, String.format("%s.%s", simpleClassName, methodName));
-
-    return span;
+    return String.format("%s/%s", simpleClassName, methodName);
   }
 
   /** Annotate the span with the results of the operation. */

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -114,9 +114,12 @@ public class TwilioSyncInstrumentation extends Instrumenter.Default {
         return null;
       }
 
-      final Span span = TRACER.spanBuilder("twilio.sdk").setSpanKind(CLIENT).startSpan();
+      final Span span =
+          TRACER
+              .spanBuilder(DECORATE.spanNameOnServiceExecution(that, methodName))
+              .setSpanKind(CLIENT)
+              .startSpan();
       DECORATE.afterStart(span);
-      DECORATE.onServiceExecution(span, that, methodName);
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
@@ -150,12 +150,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -198,12 +197,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.CallCreator/create"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.CallCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Call"
@@ -268,12 +266,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -367,12 +364,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -487,12 +483,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/createAsync"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.createAsync"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -502,12 +497,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -586,12 +580,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
@@ -620,13 +613,12 @@ class TwilioClientTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           parent()
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -678,12 +670,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/createAsync"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.createAsync"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -693,12 +684,11 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           errored false
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
@@ -763,24 +753,22 @@ class TwilioClientTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/createAsync"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.createAsync"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
           }
         }
         span(2) {
-          operationName "twilio.sdk"
+          operationName "api.v2010.account.MessageCreator/create"
           spanKind CLIENT
           errored true
           tags {
             "$MoreTags.SERVICE_NAME" "twilio-sdk"
-            "$MoreTags.RESOURCE_NAME" "api.v2010.account.MessageCreator.create"
             "$MoreTags.SPAN_TYPE" SpanTypes.HTTP_CLIENT
             "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")

--- a/smoke-tests/springboot/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/springboot/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -19,7 +19,7 @@ import okhttp3.Request
 
 class SpringBootSmokeTest extends AbstractServerSmokeTest {
 
-  static final HANDLER_SPAN = "LOGGED_SPAN spring.handler"
+  static final HANDLER_SPAN = "LOGGED_SPAN WebController/greeting"
   static final SERVLET_SPAN = "LOGGED_SPAN GET /greeting"
 
   @Override

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/SpanAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/SpanAssert.groovy
@@ -21,6 +21,8 @@ import io.opentelemetry.sdk.trace.SpanData
 import io.opentelemetry.trace.Span
 import io.opentelemetry.trace.Status
 
+import java.util.regex.Pattern
+
 import static TagsAssert.assertTags
 import static io.opentelemetry.auto.test.asserts.EventAssert.assertEvent
 
@@ -68,6 +70,16 @@ class SpanAssert {
 
   def operationName(String name) {
     assert span.name == name
+    checked.name = true
+  }
+
+  def operationName(Pattern pattern) {
+    assert span.name =~ pattern
+    checked.name = true
+  }
+
+  def operationName(Closure spec) {
+    assert ((Closure) spec).call(span.name)
     checked.name = true
   }
 

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
@@ -197,7 +197,7 @@ abstract class HttpClientTest extends AgentTestRunner {
       trace(0, 3 + extraClientSpans()) {
         basicSpan(it, 0, "parent")
         clientSpan(it, 1, span(0), method, false)
-        basicSpan(it, 2 + extraClientSpans(), "child", null, span(0))
+        basicSpan(it, 2 + extraClientSpans(), "child", span(0))
       }
     }
 
@@ -319,7 +319,7 @@ abstract class HttpClientTest extends AgentTestRunner {
     and:
     assertTraces(1) {
       trace(0, 2 + extraClientSpans()) {
-        basicSpan(it, 0, "parent", null, null, thrownException)
+        basicSpan(it, 0, "parent", null, thrownException)
         clientSpan(it, 1, span(0), method, false, false, uri, null, thrownException)
       }
     }

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
@@ -362,7 +362,7 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     assertTraces(size * 2) {
       (0..size - 1).each {
         trace(it * 2, 1) {
-          basicSpan(it, 0, "TEST_SPAN", "ServerEntry")
+          basicSpan(it, 0, "TEST_SPAN")
         }
         trace(it * 2 + 1, spanCount) {
           def spanIndex = 0

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTestAdvice.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTestAdvice.java
@@ -16,7 +16,6 @@
 package io.opentelemetry.auto.test.base;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -41,7 +40,6 @@ public abstract class HttpServerTestAdvice {
         return null;
       } else {
         final Span span = TRACER.spanBuilder("TEST_SPAN").startSpan();
-        span.setAttribute(MoreTags.RESOURCE_NAME, "ServerEntry");
         return new SpanWithScope(span, TRACER.withSpan(span));
       }
     }

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.test.utils
 
 import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.context.Scope
 import io.opentelemetry.sdk.trace.SpanData
@@ -61,7 +60,7 @@ class TraceUtils {
     }
   }
 
-  static basicSpan(TraceAssert trace, int index, String operation, String resource = null, Object parentSpan = null, Throwable exception = null) {
+  static basicSpan(TraceAssert trace, int index, String operation, Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
       if (parentSpan == null) {
         parent()
@@ -71,7 +70,6 @@ class TraceUtils {
       operationName operation
       errored exception != null
       tags {
-        "$MoreTags.RESOURCE_NAME" resource
         if (exception) {
           errorTags(exception.class, exception.message)
         }


### PR DESCRIPTION
This PR does two things:

* Promote `resource.name` attribute to span name (and remove `resource.name` attribute)
* Use `/` to separate class name/method name in span name, as this appears to be more consistent with OpenTelemetry semantic conventions, e.g. from [data-rpc](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-rpc.md#grpc)

   > Examples of span name: grpc.test.EchoService/Echo.

This is just a first pass. I also opened #233 to more thoroughly document and review all span names.