### PR TITLE
Better span names for spring-scheduling

### DIFF
--- a/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingDecorator.java
+++ b/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingDecorator.java
@@ -17,8 +17,6 @@ package io.opentelemetry.auto.instrumentation.springscheduling;
 
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
-import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.support.ScheduledMethodRunnable;
@@ -42,19 +40,12 @@ public class SpringSchedulingDecorator extends BaseDecorator {
     return "spring-scheduling";
   }
 
-  public Span onRun(final Span span, final Runnable runnable) {
-    if (runnable != null) {
-      String resourceName = "";
-      if (runnable instanceof ScheduledMethodRunnable) {
-        final ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
-        resourceName = spanNameForMethod(scheduledMethodRunnable.getMethod());
-      } else {
-        final String className = spanNameForClass(runnable.getClass());
-        final String methodName = "run";
-        resourceName = className + "." + methodName;
-      }
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+  public String spanNameOnRun(final Runnable runnable) {
+    if (runnable instanceof ScheduledMethodRunnable) {
+      final ScheduledMethodRunnable scheduledMethodRunnable = (ScheduledMethodRunnable) runnable;
+      return spanNameForMethod(scheduledMethodRunnable.getMethod());
+    } else {
+      return spanNameForClass(runnable.getClass()) + "/run";
     }
-    return span;
   }
 }

--- a/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -32,11 +31,10 @@ class SpringSchedulingTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "scheduled.call"
+          operationName "TriggerTask.run"
           parent()
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "TriggerTask.run"
             "$Tags.COMPONENT" "spring-scheduling"
           }
         }
@@ -56,11 +54,10 @@ class SpringSchedulingTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "scheduled.call"
+          operationName "IntervalTask.run"
           parent()
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "IntervalTask.run"
             "$Tags.COMPONENT" "spring-scheduling"
           }
         }


### PR DESCRIPTION
2 things going on in this PR:

* Promote `resource.name` to span name for internal spans, and remove `resource.name`

* Use `ClassName/methodName` for span names instead of `ClassName.methodName`, based on similar pattern specified for gRPC at https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-rpc.md#grpc (this is not applied everywhere in servlet yet because it relies on `BaseDecorator.spanNameForMethod()` and changing that base method will affect other instrumentation, so I will come back and do that change across all instrumentation later)
