### PR TITLE
Better span names jaxrs

### DIFF
--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -99,12 +99,11 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
   @Override
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      operationName "jax-rs.request"
+      operationName "${this.testResource().simpleName}.${endpoint.name().toLowerCase()}"
       spanKind INTERNAL
       errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$MoreTags.RESOURCE_NAME" "${this.testResource().simpleName}.${endpoint.name().toLowerCase()}"
         "$Tags.COMPONENT" JaxRsAnnotationsDecorator.DECORATE.getComponentName()
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
@@ -126,7 +125,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         parent()
       }
       tags {
-        "$MoreTags.RESOURCE_NAME" "$method ${endpoint == PATH_PARAM ? "/path/{id}/param" : endpoint.resolvePath(address).path}"
         "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" Long

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs1/JaxRsAnnotationsDecorator.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.auto.bootstrap.WeakMap.Provider.newWeakMap;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.WeakMap;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.ClassHierarchyIterable;
 import io.opentelemetry.trace.Span;
@@ -53,10 +52,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = !parent.getContext().isValid();
     if (isRootScope && !resourceName.isEmpty()) {
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+      span.updateName(resourceName);
     } else {
-      span.setAttribute(
-          MoreTags.RESOURCE_NAME, DECORATE.spanNameForClass(target) + "." + method.getName());
+      span.updateName(DECORATE.spanNameForClass(target) + "." + method.getName());
     }
   }
 
@@ -68,7 +66,6 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
 
     if (!resourceName.isEmpty()) {
       span.updateName(resourceName);
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
     }
   }
 

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import io.opentelemetry.auto.bootstrap.WeakMap
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.jaxrs1.JaxRsAnnotationsDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
@@ -45,9 +45,8 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "jax-rs.request"
+          operationName "POST /a"
           tags {
-            "$MoreTags.RESOURCE_NAME" "POST /a"
             "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
@@ -69,15 +68,13 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
           operationName name
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" name
             "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
-          operationName "jax-rs.request"
+          operationName "${className}.call"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "${className}.call"
             "$Tags.COMPONENT" "jax-rs-controller"
           }
         }

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import io.opentelemetry.auto.bootstrap.WeakMap
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.jaxrs1.JaxRsAnnotationsDecorator

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import io.dropwizard.testing.junit.ResourceTestRule
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
@@ -53,7 +52,7 @@ class JerseyTest extends AgentTestRunner {
 
         span(1) {
           childOf span(0)
-          operationName expectedSpanName
+          operationName controllerName
           tags {
             "$Tags.COMPONENT" "jax-rs-controller"
           }
@@ -62,9 +61,9 @@ class JerseyTest extends AgentTestRunner {
     }
 
     where:
-    resource           | expectedResourceName       | expectedSpanName | expectedResponse
-    "/test/hello/bob"  | "POST /test/hello/{name}"  | "Test1/hello"    | "Test1 bob!"
-    "/test2/hello/bob" | "POST /test2/hello/{name}" | "Test2/hello"    | "Test2 bob!"
-    "/test3/hi/bob"    | "POST /test3/hi/{name}"    | "Test3/hello"    | "Test3 bob!"
+    resource           | expectedResourceName       | controllerName | expectedResponse
+    "/test/hello/bob"  | "POST /test/hello/{name}"  | "Test1.hello"  | "Test1 bob!"
+    "/test2/hello/bob" | "POST /test2/hello/{name}" | "Test2.hello"  | "Test2 bob!"
+    "/test3/hi/bob"    | "POST /test3/hi/{name}"    | "Test3.hello"  | "Test3 bob!"
   }
 }

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import io.dropwizard.testing.junit.ResourceTestRule
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.junit.ClassRule
@@ -47,16 +47,14 @@ class JerseyTest extends AgentTestRunner {
         span(0) {
           operationName expectedResourceName
           tags {
-            "$MoreTags.RESOURCE_NAME" expectedResourceName
             "$Tags.COMPONENT" "jax-rs"
           }
         }
 
         span(1) {
           childOf span(0)
-          operationName "jax-rs.request"
+          operationName expectedSpanName
           tags {
-            "$MoreTags.RESOURCE_NAME" controllerName
             "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
@@ -64,9 +62,9 @@ class JerseyTest extends AgentTestRunner {
     }
 
     where:
-    resource           | expectedResourceName       | controllerName | expectedResponse
-    "/test/hello/bob"  | "POST /test/hello/{name}"  | "Test1.hello"  | "Test1 bob!"
-    "/test2/hello/bob" | "POST /test2/hello/{name}" | "Test2.hello"  | "Test2 bob!"
-    "/test3/hi/bob"    | "POST /test3/hi/{name}"    | "Test3.hello"  | "Test3 bob!"
+    resource           | expectedResourceName       | expectedSpanName | expectedResponse
+    "/test/hello/bob"  | "POST /test/hello/{name}"  | "Test1/hello"    | "Test1 bob!"
+    "/test2/hello/bob" | "POST /test2/hello/{name}" | "Test2/hello"    | "Test2 bob!"
+    "/test3/hi/bob"    | "POST /test3/hi/{name}"    | "Test3/hello"    | "Test3 bob!"
   }
 }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs2/JaxRsAnnotationsDecorator.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.auto.bootstrap.WeakMap.Provider.newWeakMap;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.WeakMap;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.ClassHierarchyIterable;
 import io.opentelemetry.trace.Span;
@@ -63,10 +62,9 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     // When jax-rs is the root, we want to name using the path, otherwise use the class/method.
     final boolean isRootScope = !parent.getContext().isValid();
     if (isRootScope && !resourceName.isEmpty()) {
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+      span.updateName(resourceName);
     } else {
-      span.setAttribute(
-          MoreTags.RESOURCE_NAME,
+      span.updateName(
           DECORATE.spanNameForClass(target) + (method == null ? "" : "." + method.getName()));
     }
   }
@@ -79,7 +77,6 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
 
     if (!resourceName.isEmpty()) {
       span.updateName(resourceName);
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
     }
   }
 

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import io.opentelemetry.auto.bootstrap.WeakMap
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.jaxrs2.JaxRsAnnotationsDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
@@ -45,9 +45,8 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
     assertTraces(1) {
       trace(0, 1) {
         span(0) {
-          operationName "jax-rs.request"
+          operationName "POST /a"
           tags {
-            "$MoreTags.RESOURCE_NAME" "POST /a"
             "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
@@ -69,15 +68,13 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
           operationName name
           parent()
           tags {
-            "$MoreTags.RESOURCE_NAME" name
             "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
-          operationName "jax-rs.request"
+          operationName "${className}.call"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "${className}.call"
             "$Tags.COMPONENT" "jax-rs-controller"
           }
         }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import io.opentelemetry.auto.bootstrap.WeakMap
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.jaxrs2.JaxRsAnnotationsDecorator

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import io.dropwizard.testing.junit.ResourceTestRule
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
@@ -80,7 +79,7 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName expectedSpanName
+          operationName controllerName
           tags {
             "$Tags.COMPONENT" "jax-rs-controller"
           }
@@ -89,21 +88,21 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     }
 
     where:
-    resource           | abortNormal | abortPrematch | parentResourceName         | expectedSpanName               | expectedResponse
-    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "Test1/hello"                  | "Test1 bob!"
-    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "Test2/hello"                  | "Test2 bob!"
-    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "Test3/hello"                  | "Test3 bob!"
+    resource           | abortNormal | abortPrematch | parentResourceName         | controllerName                 | expectedResponse
+    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Test1 bob!"
+    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Test2 bob!"
+    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Test3 bob!"
 
     // Resteasy and Jersey give different resource class names for just the below case
     // Resteasy returns "SubResource.class"
     // Jersey returns "Test1.class
-    // "/test/hello/bob"  | true        | false         | "POST /test/hello/{name}"  | "Test1/hello"                  | "Aborted"
+    // "/test/hello/bob"  | true        | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Aborted"
 
-    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "Test2/hello"                  | "Aborted"
-    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "Test3/hello"                  | "Aborted"
-    "/test/hello/bob"  | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
-    "/test2/hello/bob" | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
-    "/test3/hi/bob"    | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
+    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Aborted"
+    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Aborted"
+    "/test/hello/bob"  | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
+    "/test2/hello/bob" | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
+    "/test3/hi/bob"    | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
   }
 
   @Provider

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import io.dropwizard.testing.junit.ResourceTestRule
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.jboss.resteasy.core.Dispatcher
@@ -75,15 +75,13 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
         span(0) {
           operationName parentResourceName != null ? parentResourceName : "test.span"
           tags {
-            "$MoreTags.RESOURCE_NAME" parentResourceName
             "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
           childOf span(0)
-          operationName abort ? "jax-rs.request.abort" : "jax-rs.request"
+          operationName expectedSpanName
           tags {
-            "$MoreTags.RESOURCE_NAME" controllerName
             "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
@@ -91,21 +89,21 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
     }
 
     where:
-    resource           | abortNormal | abortPrematch | parentResourceName         | controllerName                 | expectedResponse
-    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Test1 bob!"
-    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Test2 bob!"
-    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Test3 bob!"
+    resource           | abortNormal | abortPrematch | parentResourceName         | expectedSpanName               | expectedResponse
+    "/test/hello/bob"  | false       | false         | "POST /test/hello/{name}"  | "Test1/hello"                  | "Test1 bob!"
+    "/test2/hello/bob" | false       | false         | "POST /test2/hello/{name}" | "Test2/hello"                  | "Test2 bob!"
+    "/test3/hi/bob"    | false       | false         | "POST /test3/hi/{name}"    | "Test3/hello"                  | "Test3 bob!"
 
     // Resteasy and Jersey give different resource class names for just the below case
     // Resteasy returns "SubResource.class"
     // Jersey returns "Test1.class
-    // "/test/hello/bob"  | true        | false         | "POST /test/hello/{name}"  | "Test1.hello"                  | "Aborted"
+    // "/test/hello/bob"  | true        | false         | "POST /test/hello/{name}"  | "Test1/hello"                  | "Aborted"
 
-    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "Test2.hello"                  | "Aborted"
-    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "Test3.hello"                  | "Aborted"
-    "/test/hello/bob"  | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
-    "/test2/hello/bob" | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
-    "/test3/hi/bob"    | false       | true          | null                       | "PrematchRequestFilter.filter" | "Aborted Prematch"
+    "/test2/hello/bob" | true        | false         | "POST /test2/hello/{name}" | "Test2/hello"                  | "Aborted"
+    "/test3/hi/bob"    | true        | false         | "POST /test3/hi/{name}"    | "Test3/hello"                  | "Aborted"
+    "/test/hello/bob"  | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
+    "/test2/hello/bob" | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
+    "/test3/hi/bob"    | false       | true          | null                       | "PrematchRequestFilter/filter" | "Aborted Prematch"
   }
 
   @Provider


### PR DESCRIPTION
Promote `resource.name` to span name for internal spans, and remove `resource.name`