### PR TITLE
Better span names couchbase

### DIFF
--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseBucketInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseBucketInstrumentation.java
@@ -88,7 +88,7 @@ public class CouchbaseBucketInstrumentation extends Instrumenter.Default {
         return;
       }
       CallDepthThreadLocalMap.reset(CouchbaseCluster.class);
-      result = Observable.create(new CouchbaseOnSubscribe(result, method, bucket, null));
+      result = Observable.create(CouchbaseOnSubscribe.create(result, bucket, method));
     }
   }
 
@@ -111,12 +111,15 @@ public class CouchbaseBucketInstrumentation extends Instrumenter.Default {
       }
       CallDepthThreadLocalMap.reset(CouchbaseCluster.class);
 
-      // A query can be of many different types. We could track the creation of them and try to
-      // rewind back to when they were created from a string, but for now we rely on toString()
-      // returning something useful. That seems to be the case. If we're starting to see strange
-      // query texts, this is the place to look!
-      final String queryText = query != null ? query.toString() : null;
-      result = Observable.create(new CouchbaseOnSubscribe(result, method, bucket, queryText));
+      if (query != null) {
+        // A query can be of many different types. We could track the creation of them and try to
+        // rewind back to when they were created from a string, but for now we rely on toString()
+        // returning something useful. That seems to be the case. If we're starting to see strange
+        // query texts, this is the place to look!
+        result = Observable.create(CouchbaseOnSubscribe.create(result, bucket, query.toString()));
+      } else {
+        result = Observable.create(CouchbaseOnSubscribe.create(result, bucket, method));
+      }
     }
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseClusterInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseClusterInstrumentation.java
@@ -83,7 +83,7 @@ public class CouchbaseClusterInstrumentation extends Instrumenter.Default {
       }
       CallDepthThreadLocalMap.reset(CouchbaseCluster.class);
 
-      result = Observable.create(new CouchbaseOnSubscribe(result, method, null, null));
+      result = Observable.create(CouchbaseOnSubscribe.create(result, null, method));
     }
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/client/CouchbaseOnSubscribe.java
@@ -28,12 +28,22 @@ public class CouchbaseOnSubscribe extends TracedOnSubscribe {
   private final String bucket;
   private final String query;
 
-  public CouchbaseOnSubscribe(
-      final Observable originalObservable,
-      final Method method,
-      final String bucket,
-      final String query) {
-    super(originalObservable, operationName(method, query), DECORATE, CLIENT);
+  public static CouchbaseOnSubscribe create(
+      final Observable originalObservable, final String bucket, final Method method) {
+    final Class<?> declaringClass = method.getDeclaringClass();
+    final String className =
+        declaringClass.getSimpleName().replace("CouchbaseAsync", "").replace("DefaultAsync", "");
+    return new CouchbaseOnSubscribe(originalObservable, bucket, className + "." + method.getName());
+  }
+
+  public static CouchbaseOnSubscribe create(
+      final Observable originalObservable, final String bucket, final String query) {
+    return new CouchbaseOnSubscribe(originalObservable, bucket, query);
+  }
+
+  private CouchbaseOnSubscribe(
+      final Observable originalObservable, final String bucket, final String query) {
+    super(originalObservable, query, DECORATE, CLIENT);
 
     this.bucket = bucket;
     this.query = query;
@@ -45,15 +55,5 @@ public class CouchbaseOnSubscribe extends TracedOnSubscribe {
 
     span.setAttribute(Tags.DB_INSTANCE, bucket);
     span.setAttribute(Tags.DB_STATEMENT, query);
-  }
-
-  private static String operationName(final Method method, final String query) {
-    if (query != null) {
-      return query;
-    }
-    final Class<?> declaringClass = method.getDeclaringClass();
-    final String className =
-        declaringClass.getSimpleName().replace("CouchbaseAsync", "").replace("DefaultAsync", "");
-    return className + "." + method.getName();
   }
 }

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -48,7 +48,7 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
     assertTraces(1) {
       trace(0, 2) {
         assertCouchbaseCall(it, 0, "Cluster.openBucket", null)
-        assertCouchbaseCall(it, 1, "ClusterManager.hasBucket", null, null, span(0))
+        assertCouchbaseCall(it, 1, "ClusterManager.hasBucket", null, span(0))
       }
     }
 
@@ -85,8 +85,8 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
 
-        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), null, span(1))
+        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(1))
       }
     }
 
@@ -130,9 +130,9 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
       trace(0, 4) {
         basicSpan(it, 0, "someTrace")
 
-        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), null, span(1))
-        assertCouchbaseCall(it, 3, "Bucket.get", bucketSettings.name(), null, span(2))
+        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketSettings.name(), span(1))
+        assertCouchbaseCall(it, 3, "Bucket.get", bucketSettings.name(), span(2))
       }
     }
 
@@ -175,8 +175,8 @@ class CouchbaseAsyncClientTest extends AbstractCouchbaseTest {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
 
-        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.query", bucketCouchbase.name(), 'SimpleN1qlQuery{statement=SELECT mockrow}', span(1))
+        assertCouchbaseCall(it, 1, "Cluster.openBucket", null, span(0))
+        assertCouchbaseCall(it, 2, 'SimpleN1qlQuery{statement=SELECT mockrow}', bucketCouchbase.name(), span(1))
       }
     }
 

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -81,8 +81,8 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
       }
       trace(1, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketSettings.name(), null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.get", bucketSettings.name(), null, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketSettings.name(), span(0))
+        assertCouchbaseCall(it, 2, "Bucket.get", bucketSettings.name(), span(0))
       }
     }
 
@@ -121,7 +121,7 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
         assertCouchbaseCall(it, 0, "Cluster.openBucket")
       }
       trace(1, 1) {
-        assertCouchbaseCall(it, 0, 'SimpleN1qlQuery{statement=SELECT mockrow}', bucketCouchbase.name(), 'SimpleN1qlQuery{statement=SELECT mockrow}')
+        assertCouchbaseCall(it, 0, 'SimpleN1qlQuery{statement=SELECT mockrow}', bucketCouchbase.name())
       }
     }
 

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -121,7 +121,7 @@ class CouchbaseClientTest extends AbstractCouchbaseTest {
         assertCouchbaseCall(it, 0, "Cluster.openBucket")
       }
       trace(1, 1) {
-        assertCouchbaseCall(it, 0, "Bucket.query", bucketCouchbase.name(), 'SimpleN1qlQuery{statement=SELECT mockrow}')
+        assertCouchbaseCall(it, 0, 'SimpleN1qlQuery{statement=SELECT mockrow}', bucketCouchbase.name(), 'SimpleN1qlQuery{statement=SELECT mockrow}')
       }
     }
 

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -92,7 +92,7 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     and:
     assertTraces(1) {
       trace(0, 1) {
-        assertCouchbaseCall(it, 0, ~/^ViewQuery\(doc\/all\).*/, bucketCouchbase.name(), ~/^ViewQuery\(doc\/all\).*/)
+        assertCouchbaseCall(it, 0, ~/^ViewQuery\(doc\/all\).*/, bucketCouchbase.name())
       }
     }
   }
@@ -134,8 +134,8 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.get", bucketCouchbase.name(), null, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 2, "Bucket.get", bucketCouchbase.name(), span(0))
       }
     }
 
@@ -161,8 +161,8 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketCouchbase.name(), null, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 2, "Bucket.upsert", bucketCouchbase.name(), span(0))
       }
     }
 
@@ -189,9 +189,9 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     assertTraces(1) {
       trace(0, 4) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.remove", bucketCouchbase.name(), null, span(0))
-        assertCouchbaseCall(it, 3, ~/^ViewQuery\(doc\/all\).*/, bucketCouchbase.name(), ~/^ViewQuery\(doc\/all\).*/, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 2, "Bucket.remove", bucketCouchbase.name(), span(0))
+        assertCouchbaseCall(it, 3, ~/^ViewQuery\(doc\/all\).*/, bucketCouchbase.name(), span(0))
       }
     }
   }

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -92,7 +92,7 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
     and:
     assertTraces(1) {
       trace(0, 1) {
-        assertCouchbaseCall(it, 0, "Bucket.query", bucketCouchbase.name(), ~/^ViewQuery\(doc\/all\).*/)
+        assertCouchbaseCall(it, 0, ~/^ViewQuery\(doc\/all\).*/, bucketCouchbase.name(), ~/^ViewQuery\(doc\/all\).*/)
       }
     }
   }
@@ -191,7 +191,7 @@ class CouchbaseSpringRepositoryTest extends AbstractCouchbaseTest {
         basicSpan(it, 0, "someTrace")
         assertCouchbaseCall(it, 1, "Bucket.upsert", bucketCouchbase.name(), null, span(0))
         assertCouchbaseCall(it, 2, "Bucket.remove", bucketCouchbase.name(), null, span(0))
-        assertCouchbaseCall(it, 3, "Bucket.query", bucketCouchbase.name(), ~/^ViewQuery\(doc\/all\).*/, span(0))
+        assertCouchbaseCall(it, 3, ~/^ViewQuery\(doc\/all\).*/, bucketCouchbase.name(), ~/^ViewQuery\(doc\/all\).*/, span(0))
       }
     }
   }

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -90,8 +90,8 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 1, "Bucket.upsert", name, null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.get", name, null, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", name, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.get", name, span(0))
       }
     }
 
@@ -115,8 +115,8 @@ class CouchbaseSpringTemplateTest extends AbstractCouchbaseTest {
     assertTraces(1) {
       trace(0, 3) {
         basicSpan(it, 0, "someTrace")
-        assertCouchbaseCall(it, 1, "Bucket.upsert", name, null, span(0))
-        assertCouchbaseCall(it, 2, "Bucket.remove", name, null, span(0))
+        assertCouchbaseCall(it, 1, "Bucket.upsert", name, span(0))
+        assertCouchbaseCall(it, 2, "Bucket.remove", name, span(0))
       }
     }
 

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -121,7 +121,7 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       .socketConnectTimeout(timeout.intValue())
   }
 
-  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object parentSpan = null) {
     trace.span(index) {
       operationName name
       spanKind CLIENT
@@ -138,9 +138,7 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
         if (bucketName != null) {
           "$Tags.DB_INSTANCE" bucketName
         }
-        if (dbStatement != null) {
-          "$Tags.DB_STATEMENT" dbStatement
-        }
+        "$Tags.DB_STATEMENT" name
       }
     }
   }

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -121,9 +121,9 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       .socketConnectTimeout(timeout.intValue())
   }
 
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     trace.span(index) {
-      operationName "couchbase.call"
+      operationName name
       spanKind CLIENT
       errored false
       if (parentSpan == null) {
@@ -133,7 +133,6 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
       }
       tags {
         "$MoreTags.SERVICE_NAME" "couchbase"
-        "$MoreTags.RESOURCE_NAME" name
         "$Tags.COMPONENT" "couchbase-client"
         "$Tags.DB_TYPE" "couchbase"
         if (bucketName != null) {

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
@@ -18,7 +18,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 class CouchbaseAsyncClient26Test extends CouchbaseAsyncClientTest {
 
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
   }
 }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
@@ -18,7 +18,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 class CouchbaseAsyncClient26Test extends CouchbaseAsyncClientTest {
 
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
   }
 }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
@@ -17,7 +17,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 
 class CouchbaseClient26Test extends CouchbaseClientTest {
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
   }
 }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
@@ -17,7 +17,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 
 class CouchbaseClient26Test extends CouchbaseClientTest {
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
   }
 }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -23,7 +23,7 @@ import static io.opentelemetry.trace.Span.Kind.CLIENT
 class CouchbaseSpanUtil {
   // Reusable span assertion method.  Cannot directly override AbstractCouchbaseTest.assertCouchbaseSpan because
   // Of the class hierarchy of these tests
-  static void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  static void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object parentSpan = null) {
     trace.span(index) {
       operationName name
       spanKind CLIENT
@@ -54,9 +54,7 @@ class CouchbaseSpanUtil {
         // that do have operation ids
         "couchbase.operation_id" { it == null || String }
 
-        if (dbStatement != null) {
-          "$Tags.DB_STATEMENT" dbStatement
-        }
+        "$Tags.DB_STATEMENT" name
       }
     }
   }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -23,9 +23,9 @@ import static io.opentelemetry.trace.Span.Kind.CLIENT
 class CouchbaseSpanUtil {
   // Reusable span assertion method.  Cannot directly override AbstractCouchbaseTest.assertCouchbaseSpan because
   // Of the class hierarchy of these tests
-  static void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  static void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     trace.span(index) {
-      operationName "couchbase.call"
+      operationName name
       spanKind CLIENT
       errored false
       if (parentSpan == null) {
@@ -35,7 +35,6 @@ class CouchbaseSpanUtil {
       }
       tags {
         "$MoreTags.SERVICE_NAME" "couchbase"
-        "$MoreTags.RESOURCE_NAME" name
         "$Tags.COMPONENT" "couchbase-client"
 
         // Because of caching, not all requests hit the server so these tags may be absent

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
@@ -20,7 +20,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 class CouchbaseSpringRepository26Test extends CouchbaseSpringRepositoryTest {
 
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
   }
 }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
@@ -20,7 +20,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 class CouchbaseSpringRepository26Test extends CouchbaseSpringRepositoryTest {
 
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
   }
 }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
@@ -19,7 +19,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 
 class CouchbaseSpringTemplate26Test extends CouchbaseSpringTemplateTest {
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
-    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object parentSpan = null) {
+    CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, parentSpan)
   }
 }

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
@@ -19,7 +19,7 @@ import io.opentelemetry.auto.test.asserts.TraceAssert
 
 class CouchbaseSpringTemplate26Test extends CouchbaseSpringTemplateTest {
   @Override
-  void assertCouchbaseCall(TraceAssert trace, int index, String name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
+  void assertCouchbaseCall(TraceAssert trace, int index, Object name, String bucketName = null, Object dbStatement = null, Object parentSpan = null) {
     CouchbaseSpanUtil.assertCouchbaseCall(trace, index, name, bucketName, dbStatement, parentSpan)
   }
 }


### PR DESCRIPTION
A few things:

* Promote `resource.name` to span name for internal spans, and remove `resource.name`
* Use query as span name where available
* Always provide db.statement since it is a required attribute for database spans