### PR TITLE
Better span names for hystrix, finatra and dropwizard-views

### DIFF
--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizard/view/DropwizardViewInstrumentation.java
@@ -27,7 +27,6 @@ import com.google.auto.service.AutoService;
 import io.dropwizard.views.View;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
@@ -83,8 +82,7 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Default {
       if (!TRACER.getCurrentSpan().getContext().isValid()) {
         return null;
       }
-      final Span span = TRACER.spanBuilder("view.render").startSpan();
-      span.setAttribute(MoreTags.RESOURCE_NAME, "View " + view.getTemplateName());
+      final Span span = TRACER.spanBuilder("Render " + view.getTemplateName()).startSpan();
       span.setAttribute(Tags.COMPONENT, "dropwizard-view");
       span.setAttribute("span.origin.type", obj.getClass().getSimpleName());
       return new SpanWithScope(span, TRACER.withSpan(span));

--- a/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
+++ b/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
@@ -16,7 +16,6 @@
 import io.dropwizard.views.View
 import io.dropwizard.views.freemarker.FreemarkerViewRenderer
 import io.dropwizard.views.mustache.MustacheViewRenderer
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
@@ -42,10 +41,9 @@ class ViewRenderTest extends AgentTestRunner {
       trace(0, 2) {
         basicSpan(it, 0, "parent")
         span(1) {
-          operationName "view.render"
+          operationName "Render $template"
           childOf span(0)
           tags {
-            "$MoreTags.RESOURCE_NAME" "View $template"
             "$Tags.COMPONENT" "dropwizard-view"
             "span.origin.type" renderer.class.simpleName
           }

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
@@ -33,7 +33,6 @@ import com.twitter.finatra.http.contexts.RouteInfo;
 import com.twitter.util.Future;
 import com.twitter.util.FutureEventListener;
 import io.opentelemetry.auto.config.Config;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
@@ -91,16 +90,13 @@ public class FinatraInstrumentation extends Instrumenter.Default {
         @Advice.FieldValue("clazz") final Class clazz,
         @Advice.Origin final Method method) {
 
-      // Update the parent "netty.request"
       final Span parent = TRACER.getCurrentSpan();
       final String resourceName = request.method().name() + " " + routeInfo.path();
-      parent.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
       parent.setAttribute(Tags.COMPONENT, "finatra");
       parent.updateName(resourceName);
 
-      final Span span = TRACER.spanBuilder("finatra.controller").startSpan();
+      final Span span = TRACER.spanBuilder(DECORATE.spanNameForClass(clazz)).startSpan();
       DECORATE.afterStart(span);
-      span.setAttribute(MoreTags.RESOURCE_NAME, DECORATE.spanNameForClass(clazz));
 
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
@@ -27,7 +27,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 import com.google.auto.service.AutoService;
-import com.twitter.finagle.http.Request;
 import com.twitter.finagle.http.Response;
 import com.twitter.finatra.http.contexts.RouteInfo;
 import com.twitter.util.Future;
@@ -38,7 +37,6 @@ import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
-import java.lang.reflect.Method;
 import java.util.Map;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -85,15 +83,12 @@ public class FinatraInstrumentation extends Instrumenter.Default {
   public static class RouteAdvice {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope nameSpan(
-        @Advice.Argument(0) final Request request,
         @Advice.FieldValue("routeInfo") final RouteInfo routeInfo,
-        @Advice.FieldValue("clazz") final Class clazz,
-        @Advice.Origin final Method method) {
+        @Advice.FieldValue("clazz") final Class clazz) {
 
       final Span parent = TRACER.getCurrentSpan();
-      final String resourceName = request.method().name() + " " + routeInfo.path();
       parent.setAttribute(Tags.COMPONENT, "finatra");
-      parent.updateName(resourceName);
+      parent.updateName(routeInfo.path());
 
       final Span span = TRACER.spanBuilder(DECORATE.spanNameForClass(clazz)).startSpan();
       DECORATE.afterStart(span);

--- a/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -88,12 +88,11 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
   void handlerSpan(TraceAssert trace, int index, Object parent, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     def errorEndpoint = endpoint == EXCEPTION || endpoint == ERROR
     trace.span(index) {
-      operationName "finatra.controller"
+      operationName "FinatraController"
       spanKind INTERNAL
       errored errorEndpoint
       childOf(parent as SpanData)
       tags {
-        "$MoreTags.RESOURCE_NAME" "FinatraController"
         "$Tags.COMPONENT" FinatraDecorator.DECORATE.getComponentName()
 
         // Finatra doesn't propagate the stack trace or exception to the instrumentation
@@ -102,7 +101,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
     }
   }
 
-  // need to override in order to add RESOURCE_NAME
   @Override
   void serverSpan(TraceAssert trace, int index, String traceID = null, String parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
@@ -116,7 +114,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
         parent()
       }
       tags {
-        "$MoreTags.RESOURCE_NAME" "$method ${endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.resolvePath(address).path}"
         "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_PORT" Long
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -104,7 +104,11 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
   @Override
   void serverSpan(TraceAssert trace, int index, String traceID = null, String parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      operationName "$method ${endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.resolvePath(address).path}"
+      if (endpoint == PATH_PARAM) {
+        operationName "/path/:id/param"
+      } else {
+        operationName endpoint.resolvePath(address).path
+      }
       spanKind SERVER
       errored endpoint.errored
       if (parentID != null) {

--- a/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -104,11 +104,7 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
   @Override
   void serverSpan(TraceAssert trace, int index, String traceID = null, String parentID = null, String method = "GET", ServerEndpoint endpoint = SUCCESS) {
     trace.span(index) {
-      if (endpoint == PATH_PARAM) {
-        operationName "/path/:id/param"
-      } else {
-        operationName endpoint.resolvePath(address).path
-      }
+      operationName endpoint == PATH_PARAM ? "/path/:id/param" : endpoint.resolvePath(address).path
       spanKind SERVER
       errored endpoint.errored
       if (parentID != null) {

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.hystrix;
 
 import com.netflix.hystrix.HystrixInvokableInfo;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 
 public class HystrixDecorator extends BaseDecorator {
@@ -37,7 +36,7 @@ public class HystrixDecorator extends BaseDecorator {
 
       final String resourceName = groupName + "." + commandName + "." + methodName;
 
-      span.setAttribute(MoreTags.RESOURCE_NAME, resourceName);
+      span.updateName(resourceName);
       span.setAttribute("hystrix.command", commandName);
       span.setAttribute("hystrix.group", groupName);
       span.setAttribute("hystrix.circuit-open", circuitOpen);

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.netflix.hystrix.HystrixObservableCommand
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import rx.Observable
@@ -86,11 +85,10 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup.HystrixObservableChainTest\$1.execute"
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableChainTest\$1.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -105,11 +103,10 @@ class HystrixObservableChainTest extends AgentTestRunner {
           }
         }
         span(3) {
-          operationName "hystrix.cmd"
+          operationName "OtherGroup.HystrixObservableChainTest\$2.execute"
           childOf span(1)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "OtherGroup.HystrixObservableChainTest\$2.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$2"
             "hystrix.group" "OtherGroup"

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -16,7 +16,6 @@
 import com.netflix.hystrix.HystrixObservable
 import com.netflix.hystrix.HystrixObservableCommand
 import com.netflix.hystrix.exception.HystrixRuntimeException
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import rx.Observable
@@ -79,11 +78,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup.HystrixObservableTest\$1.execute"
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableTest\$1.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -176,11 +174,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup.HystrixObservableTest\$2.execute"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableTest\$2.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
@@ -189,11 +186,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup.HystrixObservableTest\$2.fallback"
           childOf span(1)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixObservableTest\$2.fallback"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
@@ -279,11 +275,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "FailingGroup.HystrixObservableTest\$3.execute"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "FailingGroup.HystrixObservableTest\$3.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"
@@ -292,11 +287,10 @@ class HystrixObservableTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "hystrix.cmd"
+          operationName "FailingGroup.HystrixObservableTest\$3.fallback"
           childOf span(1)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "FailingGroup.HystrixObservableTest\$3.fallback"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.netflix.hystrix.HystrixCommand
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import spock.lang.Timeout
@@ -65,11 +64,10 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup.HystrixTest\$1.execute"
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixTest\$1.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$1"
             "hystrix.group" "ExampleGroup"
@@ -130,11 +128,10 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(1) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup.HystrixTest\$2.execute"
           childOf span(0)
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixTest\$2.execute"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"
@@ -143,11 +140,10 @@ class HystrixTest extends AgentTestRunner {
           }
         }
         span(2) {
-          operationName "hystrix.cmd"
+          operationName "ExampleGroup.HystrixTest\$2.fallback"
           childOf span(1)
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "ExampleGroup.HystrixTest\$2.fallback"
             "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"


### PR DESCRIPTION
Two things in this PR:

* Promote `resource.name` to span name for internal spans, and remove `resource.name`
* Don't prefix route with `GET/POST/etc` when route is used as span name
* Use `Render <view name>` instead of `View <view name>`, let's revisit this convention in #233 (same applies to spring-webmvc and jsp instrumentation)