### PR TITLE
Better span names for jsp

### DIFF
--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
@@ -75,7 +75,7 @@ public final class JSPInstrumentation extends Instrumenter.Default {
     @Advice.OnMethodEnter(suppress = Throwable.class)
     public static SpanWithScope onEnter(
         @Advice.This final Object obj, @Advice.Argument(0) final HttpServletRequest req) {
-      final Span span = TRACER.spanBuilder("jsp.render").startSpan();
+      final Span span = TRACER.spanBuilder(DECORATE.spanNameOnRender(req)).startSpan();
       span.setAttribute("span.origin.type", obj.getClass().getSimpleName());
       span.setAttribute("servlet.context", req.getContextPath());
       DECORATE.afterStart(span);

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -63,8 +63,10 @@ public final class JasperJSPCompilationContextInstrumentation extends Instrument
   public static class JasperJspCompilationContext {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static SpanWithScope onEnter() {
-      final Span span = TRACER.spanBuilder("jsp.compile").startSpan();
+    public static SpanWithScope onEnter(
+        @Advice.This final JspCompilationContext jspCompilationContext) {
+      final Span span =
+          TRACER.spanBuilder(DECORATE.spanNameOnCompile(jspCompilationContext)).startSpan();
       DECORATE.afterStart(span);
       return new SpanWithScope(span, TRACER.withSpan(span));
     }

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -123,10 +123,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$jspFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
@@ -135,10 +134,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /$jspFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
@@ -190,10 +188,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /getQuery.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/getQuery.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
@@ -202,10 +199,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /getQuery.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/getQuery.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "getQuery_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -254,10 +250,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /post.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/post.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
@@ -266,10 +261,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /post.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/post.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "post_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -322,10 +316,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$jspFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
@@ -334,10 +327,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /$jspFileName"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
@@ -395,10 +387,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /includes/includeHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
@@ -407,10 +398,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /includes/includeHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeHtml_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -455,10 +445,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
@@ -467,10 +456,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -479,10 +467,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -491,10 +478,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -503,10 +489,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(5) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -515,10 +500,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(6) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -564,10 +548,9 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$jspFileName"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$jspFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -122,10 +122,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /$forwardFromFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardFromFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
@@ -134,10 +133,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /$forwardFromFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardFromFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardFromClassName
             "servlet.context" "/$jspWebappContext"
@@ -146,10 +144,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /$forwardDestFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardDestFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
@@ -158,10 +155,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /$forwardDestFileName"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/$forwardDestFileName"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
@@ -212,10 +208,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
@@ -224,10 +219,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToHtml.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToHtml_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -272,10 +266,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToIncludeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
@@ -284,10 +277,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToIncludeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToIncludeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -296,10 +288,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
@@ -308,10 +299,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /includes/includeMulti.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/includes/includeMulti.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -321,10 +311,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(5) {
           childOf span(4)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -333,10 +322,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(6) {
           childOf span(4)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -346,10 +334,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(7) {
           childOf span(4)
-          operationName "jsp.compile"
+          operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
@@ -358,10 +345,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(8) {
           childOf span(4)
-          operationName "jsp.render"
+          operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/javaLoopH2.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -407,10 +393,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToJspForward.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
@@ -419,10 +404,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToJspForward.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToJspForward_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -431,10 +415,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToSimpleJava.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
@@ -443,10 +426,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(4) {
           childOf span(2)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToSimpleJava.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToSimpleJava_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -456,10 +438,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(5) {
           childOf span(4)
-          operationName "jsp.compile"
+          operationName "Compile /common/loop.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/loop.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
@@ -468,10 +449,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(6) {
           childOf span(4)
-          operationName "jsp.render"
+          operationName "Render /common/loop.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/common/loop.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -518,10 +498,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToCompileError.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToCompileError.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
@@ -530,10 +509,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToCompileError.jsp"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToCompileError.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToCompileError_jsp"
             "servlet.context" "/$jspWebappContext"
@@ -543,10 +521,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(3) {
           childOf span(2)
-          operationName "jsp.compile"
+          operationName "Compile /compileError.jsp"
           errored true
           tags {
-            "$MoreTags.RESOURCE_NAME" "/compileError.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
@@ -592,10 +569,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(1) {
           childOf span(0)
-          operationName "jsp.compile"
+          operationName "Compile /forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToNonExistent.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
@@ -604,10 +580,9 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
         }
         span(2) {
           childOf span(0)
-          operationName "jsp.render"
+          operationName "Render /forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "$MoreTags.RESOURCE_NAME" "/forwards/forwardToNonExistent.jsp"
             "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToNonExistent_jsp"
             "servlet.context" "/$jspWebappContext"


### PR DESCRIPTION
Two things in this PR:

* Promote `resource.name` to span name for internal spans, and remove `resource.name`
* Use `Render <jsp file>` and `Compile <jsp file>` for span names, let's revisit this convention in #233 (same applies to spring-webmvc and dropwizard-views instrumentation)