### PR TITLE
Better span names for rabbitmq-amqp

### DIFF
--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -135,14 +135,13 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
 
       final Connection connection = channel.getConnection();
 
-      final Span.Builder spanBuilder = TRACER.spanBuilder("amqp.command");
+      final Span.Builder spanBuilder = TRACER.spanBuilder(method);
       if (method.equals("Channel.basicPublish")) {
         spanBuilder.setSpanKind(PRODUCER);
       } else {
         spanBuilder.setSpanKind(CLIENT);
       }
       final Span span = spanBuilder.startSpan();
-      span.setAttribute(MoreTags.RESOURCE_NAME, method);
       span.setAttribute(MoreTags.NET_PEER_PORT, connection.getPort());
       DECORATE.afterStart(span);
       DECORATE.onPeerConnection(span, connection.getAddress());
@@ -242,7 +241,7 @@ public class RabbitChannelInstrumentation extends Instrumenter.Default {
       // span creation
       final Span.Builder spanBuilder =
           TRACER
-              .spanBuilder("amqp.command")
+              .spanBuilder(DECORATE.spanNameOnGet(queue))
               .setSpanKind(CLIENT)
               .setStartTimestamp(TimeUnit.MILLISECONDS.toNanos(startTime));
 

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -81,7 +81,8 @@ public class TracedDelegatingConsumer implements Consumer {
     Scope scope = null;
     try {
       final Map<String, Object> headers = properties.getHeaders();
-      final Span.Builder spanBuilder = TRACER.spanBuilder("amqp.command").setSpanKind(CONSUMER);
+      final Span.Builder spanBuilder =
+          TRACER.spanBuilder(DECORATE.spanNameOnDeliver(queue)).setSpanKind(CONSUMER);
       SpanContext extractedContext = SpanContext.getInvalid();
       if (headers != null) {
         extractedContext = TRACER.getHttpTextFormat().extract(headers, GETTER);
@@ -98,7 +99,7 @@ public class TracedDelegatingConsumer implements Consumer {
       span.setAttribute("message.size", body == null ? 0 : body.length);
       span.setAttribute("span.origin.type", delegate.getClass().getName());
       DECORATE.afterStart(span);
-      DECORATE.onDeliver(span, queue, envelope);
+      DECORATE.onDeliver(span, envelope);
 
       scope = TRACER.withSpan(span);
 


### PR DESCRIPTION
Two things in this PR:

* Promote `resource.name` to span name for internal spans, and remove `resource.name`

* Update span names based on guidance at the almost merged https://github.com/open-telemetry/opentelemetry-specification/pull/418

* Not sure what to do with span name `$exchangeName -> $routingKey`, will revisit in #233
