### PR TITLE
Fix confusing log message about exporters.

### DIFF
--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/TracerInstaller.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/TracerInstaller.java
@@ -45,6 +45,7 @@ public class TracerInstaller {
         } else {
           log.warn("No valid exporter found. Tracing will run but spans are dropped");
         }
+      } else {
         log.warn("No exporter is specified. Tracing will run but spans are dropped");
       }
     } else {


### PR DESCRIPTION
When you properly configure an exporter the log first gives a message about that and then warns you that no exporter is specified.  A simple logic change fixes that.