### PR TITLE
Remove service.name attribute

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -15,7 +15,6 @@
  */
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Span;
 
 public abstract class ClientDecorator extends BaseDecorator {
@@ -25,7 +24,6 @@ public abstract class ClientDecorator extends BaseDecorator {
   @Override
   public Span afterStart(final Span span) {
     assert span != null;
-    span.setAttribute(MoreTags.SERVICE_NAME, service());
     return super.afterStart(span);
   }
 }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -15,8 +15,6 @@
  */
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator;
 
-import io.opentelemetry.auto.config.Config;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.trace.Span;
 
@@ -53,10 +51,6 @@ public abstract class DatabaseClientDecorator<CONNECTION> extends ClientDecorato
       span.setAttribute(Tags.DB_USER, dbUser(connection));
       span.setAttribute(Tags.DB_INSTANCE, dbInstance(connection));
       span.setAttribute(Tags.DB_URL, dbUrl(connection));
-
-      if (Config.get().isDbClientSplitByInstance()) {
-        span.setAttribute(MoreTags.SERVICE_NAME, dbInstance(connection));
-      }
     }
     return span;
   }

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -102,9 +102,6 @@ public abstract class HttpClientDecorator<REQUEST, RESPONSE> extends ClientDecor
       final String hostname = hostname(request);
       span.setAttribute(MoreTags.NET_PEER_NAME, hostname);
 
-      if (Config.get().isHttpClientSplitByDomain()) {
-        span.setAttribute(MoreTags.SERVICE_NAME, hostname);
-      }
       final Integer port = port(request);
       // Negative or Zero ports might represent an unset/null value for an int type.  Skip setting.
       if (port != null && port > 0) {

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/config/Config.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/config/Config.java
@@ -66,8 +66,6 @@ public class Config {
   public static final String HTTP_CLIENT_ERROR_STATUSES = "http.client.error.statuses";
   public static final String HTTP_SERVER_TAG_QUERY_STRING = "http.server.tag.query-string";
   public static final String HTTP_CLIENT_TAG_QUERY_STRING = "http.client.tag.query-string";
-  public static final String HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN = "trace.http.client.split-by-domain";
-  public static final String DB_CLIENT_HOST_SPLIT_BY_INSTANCE = "trace.db.client.split-by-instance";
   public static final String SCOPE_DEPTH_LIMIT = "trace.scope.depth.limit";
   public static final String SPAN_DURATION_ABOVE_AVERAGE_STACKTRACE_MILLIS =
       "trace.span.duration-above-average.stacktrace.millis";
@@ -89,8 +87,6 @@ public class Config {
       parseIntegerRangeSet("400-599", "default");
   private static final boolean DEFAULT_HTTP_SERVER_TAG_QUERY_STRING = false;
   private static final boolean DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING = false;
-  private static final boolean DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN = false;
-  private static final boolean DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE = false;
   private static final int DEFAULT_SCOPE_DEPTH_LIMIT = 100;
   private static final int DEFAULT_SPAN_DURATION_ABOVE_AVERAGE_STACKTRACE_MILLIS =
       (int) TimeUnit.SECONDS.toMillis(1);
@@ -114,8 +110,6 @@ public class Config {
   @Getter private final Set<Integer> httpClientErrorStatuses;
   @Getter private final boolean httpServerTagQueryString;
   @Getter private final boolean httpClientTagQueryString;
-  @Getter private final boolean httpClientSplitByDomain;
-  @Getter private final boolean dbClientSplitByInstance;
   @Getter private final Integer scopeDepthLimit;
   @Getter private final long spanDurationAboveAverageStacktraceNanos;
   @Getter private final boolean runtimeContextFieldInjection;
@@ -177,14 +171,6 @@ public class Config {
         getBooleanSettingFromEnvironment(
             HTTP_CLIENT_TAG_QUERY_STRING, DEFAULT_HTTP_CLIENT_TAG_QUERY_STRING);
 
-    httpClientSplitByDomain =
-        getBooleanSettingFromEnvironment(
-            HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, DEFAULT_HTTP_CLIENT_SPLIT_BY_DOMAIN);
-
-    dbClientSplitByInstance =
-        getBooleanSettingFromEnvironment(
-            DB_CLIENT_HOST_SPLIT_BY_INSTANCE, DEFAULT_DB_CLIENT_HOST_SPLIT_BY_INSTANCE);
-
     scopeDepthLimit =
         getIntegerSettingFromEnvironment(SCOPE_DEPTH_LIMIT, DEFAULT_SCOPE_DEPTH_LIMIT);
 
@@ -245,14 +231,6 @@ public class Config {
     httpClientTagQueryString =
         getPropertyBooleanValue(
             properties, HTTP_CLIENT_TAG_QUERY_STRING, parent.httpClientTagQueryString);
-
-    httpClientSplitByDomain =
-        getPropertyBooleanValue(
-            properties, HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, parent.httpClientSplitByDomain);
-
-    dbClientSplitByInstance =
-        getPropertyBooleanValue(
-            properties, DB_CLIENT_HOST_SPLIT_BY_INSTANCE, parent.dbClientSplitByInstance);
 
     scopeDepthLimit =
         getPropertyIntegerValue(properties, SCOPE_DEPTH_LIMIT, parent.scopeDepthLimit);

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
@@ -15,7 +15,6 @@
  */
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.trace.Span
 
@@ -31,7 +30,6 @@ class ClientDecoratorTest extends BaseDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(MoreTags.SERVICE_NAME, serviceName)
     1 * span.setAttribute(Tags.COMPONENT, "test-component")
     _ * span.setAttribute(_, _) // Want to allow other calls from child implementations.
     0 * _

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -36,9 +36,7 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
     def decorator = newDecorator()
 
     when:
-    withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      decorator.onRequest(span, req)
-    }
+    decorator.onRequest(span, req)
 
     then:
     if (req) {
@@ -46,18 +44,14 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       1 * span.setAttribute(Tags.HTTP_URL, "$req.url")
       1 * span.setAttribute(MoreTags.NET_PEER_NAME, req.host)
       1 * span.setAttribute(MoreTags.NET_PEER_PORT, req.port)
-      if (renameService) {
-        1 * span.setAttribute(MoreTags.SERVICE_NAME, req.host)
-      }
     }
     0 * _
 
     where:
-    renameService | req
-    false         | null
-    true          | null
-    false         | [method: "test-method", url: testUrl, host: "test-host", port: 555]
-    true          | [method: "test-method", url: testUrl, host: "test-host", port: 555]
+    req << [
+      null,
+      [method: "test-method", url: testUrl, host: "test-host", port: 555]
+    ]
   }
 
   def "test url handling for #url"() {
@@ -188,4 +182,5 @@ class HttpClientDecoratorTest extends ClientDecoratorTest {
       }
     }
   }
+
 }

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/config/ConfigTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/config/ConfigTest.groovy
@@ -21,9 +21,7 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 
 import static io.opentelemetry.auto.config.Config.CONFIGURATION_FILE
-import static io.opentelemetry.auto.config.Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE
 import static io.opentelemetry.auto.config.Config.HTTP_CLIENT_ERROR_STATUSES
-import static io.opentelemetry.auto.config.Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN
 import static io.opentelemetry.auto.config.Config.HTTP_SERVER_ERROR_STATUSES
 import static io.opentelemetry.auto.config.Config.PREFIX
 import static io.opentelemetry.auto.config.Config.RUNTIME_CONTEXT_FIELD_INJECTION
@@ -47,8 +45,6 @@ class ConfigTest extends AgentSpecification {
     config.traceEnabled == true
     config.httpServerErrorStatuses == (500..599).toSet()
     config.httpClientErrorStatuses == (400..599).toSet()
-    config.httpClientSplitByDomain == false
-    config.dbClientSplitByInstance == false
     config.runtimeContextFieldInjection == true
     config.toString().contains("traceEnabled=true")
 
@@ -67,8 +63,6 @@ class ConfigTest extends AgentSpecification {
     prop.setProperty(TRACE_METHODS, "mypackage.MyClass[myMethod]")
     prop.setProperty(HTTP_SERVER_ERROR_STATUSES, "123-456,457,124-125,122")
     prop.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
-    prop.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
-    prop.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
     prop.setProperty(RUNTIME_CONTEXT_FIELD_INJECTION, "false")
 
     when:
@@ -79,8 +73,6 @@ class ConfigTest extends AgentSpecification {
     config.traceMethods == "mypackage.MyClass[myMethod]"
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
-    config.httpClientSplitByDomain == true
-    config.dbClientSplitByInstance == true
     config.runtimeContextFieldInjection == false
   }
 
@@ -90,8 +82,6 @@ class ConfigTest extends AgentSpecification {
     System.setProperty(PREFIX + TRACE_METHODS, "mypackage.MyClass[myMethod]")
     System.setProperty(PREFIX + HTTP_SERVER_ERROR_STATUSES, "123-456,457,124-125,122")
     System.setProperty(PREFIX + HTTP_CLIENT_ERROR_STATUSES, "111")
-    System.setProperty(PREFIX + HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
-    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
     System.setProperty(PREFIX + RUNTIME_CONTEXT_FIELD_INJECTION, "false")
 
     when:
@@ -102,8 +92,6 @@ class ConfigTest extends AgentSpecification {
     config.traceMethods == "mypackage.MyClass[myMethod]"
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
-    config.httpClientSplitByDomain == true
-    config.dbClientSplitByInstance == true
     config.runtimeContextFieldInjection == false
   }
 
@@ -139,8 +127,6 @@ class ConfigTest extends AgentSpecification {
     System.setProperty(PREFIX + TRACE_METHODS, " ")
     System.setProperty(PREFIX + HTTP_SERVER_ERROR_STATUSES, "1111")
     System.setProperty(PREFIX + HTTP_CLIENT_ERROR_STATUSES, "1:1")
-    System.setProperty(PREFIX + HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "invalid")
-    System.setProperty(PREFIX + DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "invalid")
 
     when:
     def config = new Config()
@@ -150,8 +136,6 @@ class ConfigTest extends AgentSpecification {
     config.traceMethods == " "
     config.httpServerErrorStatuses == (500..599).toSet()
     config.httpClientErrorStatuses == (400..599).toSet()
-    config.httpClientSplitByDomain == false
-    config.dbClientSplitByInstance == false
   }
 
   def "sys props override properties"() {
@@ -161,8 +145,6 @@ class ConfigTest extends AgentSpecification {
     properties.setProperty(TRACE_METHODS, "mypackage.MyClass[myMethod]")
     properties.setProperty(HTTP_SERVER_ERROR_STATUSES, "123-456,457,124-125,122")
     properties.setProperty(HTTP_CLIENT_ERROR_STATUSES, "111")
-    properties.setProperty(HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "true")
-    properties.setProperty(DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
 
     when:
     def config = Config.get(properties)
@@ -172,8 +154,6 @@ class ConfigTest extends AgentSpecification {
     config.traceMethods == "mypackage.MyClass[myMethod]"
     config.httpServerErrorStatuses == (122..457).toSet()
     config.httpClientErrorStatuses == (111..111).toSet()
-    config.httpClientSplitByDomain == true
-    config.dbClientSplitByInstance == true
   }
 
   def "override null properties"() {

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -83,8 +83,5 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
         }
       }
     }
-
-    where:
-    renameService << [false, true]
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
@@ -155,7 +155,6 @@ class AWSClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
@@ -243,7 +242,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
@@ -303,7 +301,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "HEAD"
@@ -346,7 +343,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -118,7 +118,6 @@ class AWSClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
@@ -188,7 +187,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
@@ -248,7 +246,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "GET"
@@ -292,7 +289,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -96,7 +96,6 @@ class AwsClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -199,7 +198,6 @@ class AwsClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -313,7 +311,6 @@ class AwsClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "java-aws-sdk"
             "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -26,7 +26,6 @@ import com.couchbase.mock.BucketConfiguration
 import com.couchbase.mock.CouchbaseMock
 import com.couchbase.mock.http.query.QueryServer
 import io.opentelemetry.auto.config.Config
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
@@ -132,7 +131,6 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$MoreTags.SERVICE_NAME" "couchbase"
         "$Tags.COMPONENT" "couchbase-client"
         "$Tags.DB_TYPE" "couchbase"
         if (bucketName != null) {

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -25,7 +25,6 @@ import com.couchbase.mock.Bucket
 import com.couchbase.mock.BucketConfiguration
 import com.couchbase.mock.CouchbaseMock
 import com.couchbase.mock.http.query.QueryServer
-import io.opentelemetry.auto.config.Config
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
@@ -77,9 +76,6 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
 
     mock.createBucket(convert(bucketCouchbase))
     mock.createBucket(convert(bucketMemcache))
-
-    // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   private static BucketConfiguration convert(BucketSettings bucketSettings) {
@@ -94,8 +90,6 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
 
   def cleanupSpec() {
     mock?.stop()
-
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   protected DefaultCouchbaseEnvironment.Builder envBuilder(BucketSettings bucketSettings) {

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -34,7 +34,6 @@ class CouchbaseSpanUtil {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$MoreTags.SERVICE_NAME" "couchbase"
         "$Tags.COMPONENT" "couchbase-client"
 
         // Because of caching, not all requests hit the server so these tags may be absent

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -101,7 +101,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -105,7 +105,6 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -105,7 +105,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -101,7 +101,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -90,7 +89,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -116,7 +114,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -178,7 +175,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -192,7 +188,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -205,7 +200,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -222,7 +216,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -236,7 +229,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -250,7 +242,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -101,7 +101,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -130,7 +129,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -200,7 +198,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -217,7 +214,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -233,7 +229,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -253,7 +248,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -267,7 +261,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -285,7 +278,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -15,7 +15,6 @@
  */
 package springdata
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.springframework.context.ApplicationContext
@@ -56,7 +55,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -86,7 +84,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -100,7 +97,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -114,7 +110,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -139,7 +134,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -168,7 +162,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -183,7 +176,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -200,7 +192,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -228,7 +219,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "DeleteAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
@@ -243,7 +233,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -260,7 +249,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -15,7 +15,6 @@
  */
 package springdata
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -97,7 +96,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -148,7 +146,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -162,7 +159,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -175,7 +171,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -190,7 +185,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -204,7 +198,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -218,7 +211,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -235,7 +227,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -314,7 +305,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -90,7 +90,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -116,7 +115,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -178,7 +176,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -192,7 +189,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -205,7 +201,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -225,7 +220,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -242,7 +236,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -256,7 +249,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -102,7 +102,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -132,7 +131,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           operationName "ClusterStatsAction"
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -162,7 +160,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -232,7 +229,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -249,7 +245,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -265,7 +260,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -285,7 +279,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -299,7 +292,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -317,7 +309,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -56,7 +56,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -86,7 +85,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -103,7 +101,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -117,7 +114,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -142,7 +138,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -174,7 +169,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -192,7 +186,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -209,7 +202,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -240,7 +232,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "DeleteAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -258,7 +249,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -275,7 +265,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -97,7 +97,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -148,7 +147,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -162,7 +160,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -175,7 +172,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -190,7 +186,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
@@ -207,7 +202,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -221,7 +215,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -238,7 +231,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -316,7 +308,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -96,7 +95,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -122,7 +120,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           errored true
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -185,7 +182,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -199,7 +195,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -212,7 +207,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -229,7 +223,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -247,7 +240,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -260,7 +252,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -108,7 +108,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -137,7 +136,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -207,7 +205,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -224,7 +221,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -244,7 +240,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -257,7 +252,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -279,7 +273,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -96,7 +95,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -122,7 +120,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -185,7 +182,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -199,7 +195,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -212,7 +207,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -229,7 +223,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -248,7 +241,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -261,7 +253,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -108,7 +108,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -137,7 +136,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -207,7 +205,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -224,7 +221,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -244,7 +240,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -257,7 +252,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -280,7 +274,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -15,7 +15,6 @@
  */
 package springdata
 
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -93,7 +92,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -131,7 +129,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -150,7 +147,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -162,7 +158,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -195,7 +190,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -232,7 +226,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -251,7 +244,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -276,7 +268,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -312,7 +303,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
@@ -330,7 +320,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -356,7 +345,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -16,7 +16,6 @@
 package springdata
 
 import com.google.common.collect.ImmutableSet
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -116,7 +115,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -167,7 +165,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -181,7 +178,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -194,7 +190,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -209,7 +204,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -228,7 +222,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -241,7 +234,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
@@ -258,7 +250,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
@@ -337,7 +328,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -93,7 +92,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
@@ -119,7 +117,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -181,7 +178,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
@@ -195,7 +191,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -212,7 +207,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
@@ -231,7 +225,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -244,7 +237,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -105,7 +105,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -134,7 +133,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
@@ -204,7 +202,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -221,7 +218,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -241,7 +237,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
@@ -254,7 +249,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
@@ -277,7 +271,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "elasticsearch"
             "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.apache.geode.cache.client.ClientCacheFactory
@@ -133,7 +132,6 @@ class PutGetTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT" "apache-geode-client"
-            "$MoreTags.SERVICE_NAME" "apache-geode"
             "$Tags.DB_TYPE" "geode"
             "$Tags.DB_INSTANCE" "test-region"
           }
@@ -144,7 +142,6 @@ class PutGetTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT" "apache-geode-client"
-            "$MoreTags.SERVICE_NAME" "apache-geode"
             "$Tags.DB_TYPE" "geode"
             "$Tags.DB_INSTANCE" "test-region"
           }
@@ -155,7 +152,6 @@ class PutGetTest extends AgentTestRunner {
           errored false
           tags {
             "$Tags.COMPONENT" "apache-geode-client"
-            "$MoreTags.SERVICE_NAME" "apache-geode"
             "$Tags.DB_TYPE" "geode"
             "$Tags.DB_INSTANCE" "test-region"
             if (query != null) {

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import org.hibernate.Criteria
 import org.hibernate.Session
@@ -44,7 +43,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -53,7 +51,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -62,7 +59,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -77,7 +73,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import org.hibernate.Query
 import org.hibernate.Session
@@ -49,7 +48,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -58,7 +56,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -66,7 +63,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -81,7 +77,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -94,7 +89,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -103,7 +97,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -112,7 +105,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             tags {
-              "$MoreTags.SERVICE_NAME" "h2"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
@@ -173,7 +165,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -182,7 +173,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -191,7 +181,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -206,7 +195,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import org.hibernate.LockMode
 import org.hibernate.MappingException
@@ -61,7 +60,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -70,7 +68,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -79,7 +76,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             tags {
-              "$MoreTags.SERVICE_NAME" "h2"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
@@ -94,7 +90,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -139,7 +134,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -148,7 +142,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -157,7 +150,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -165,7 +157,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(2)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -220,7 +211,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -229,7 +219,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -238,7 +227,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -253,7 +241,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -261,7 +248,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(3)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -313,7 +299,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -323,7 +308,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(0)
           errored(true)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
             errorTags(MappingException, "Unknown entity: java.lang.Long")
           }
@@ -333,7 +317,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -366,7 +349,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -375,7 +357,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -384,7 +365,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -392,7 +372,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(2)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -454,7 +433,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -463,7 +441,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -471,7 +448,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -486,7 +462,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -535,7 +510,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -544,7 +518,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -553,7 +526,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -562,7 +534,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -571,7 +542,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -586,7 +556,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -601,7 +570,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -610,7 +578,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(7)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -619,7 +586,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -628,7 +594,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(9)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import org.hibernate.Criteria
 import org.hibernate.Session
@@ -44,7 +43,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -53,7 +51,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -62,7 +59,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -77,7 +73,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import org.hibernate.Query
 import org.hibernate.Session
@@ -49,7 +48,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -58,7 +56,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -66,7 +63,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -81,7 +77,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -94,7 +89,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -103,7 +97,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -112,7 +105,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             tags {
-              "$MoreTags.SERVICE_NAME" "h2"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
@@ -173,7 +165,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -182,7 +173,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -191,7 +181,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -206,7 +195,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import org.hibernate.LockMode
 import org.hibernate.MappingException
@@ -61,7 +60,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -70,7 +68,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -78,7 +75,6 @@ class SessionTest extends AbstractHibernateTest {
             childOf span(1)
             spanKind CLIENT
             tags {
-              "$MoreTags.SERVICE_NAME" "h2"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
@@ -93,7 +89,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$MoreTags.SERVICE_NAME" "hibernate"
               "$Tags.COMPONENT" "java-hibernate"
             }
           }
@@ -152,7 +147,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -161,7 +155,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -170,7 +163,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -185,7 +177,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -193,7 +184,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(3)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -245,7 +235,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -255,7 +244,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(0)
           errored(true)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
             errorTags(MappingException, "Unknown entity: java.lang.Long")
           }
@@ -265,7 +253,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -298,7 +285,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -307,7 +293,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -316,7 +301,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -324,7 +308,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(2)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -386,7 +369,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -395,7 +377,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -403,7 +384,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -418,7 +398,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -467,7 +446,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -476,7 +454,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -485,7 +462,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -494,7 +470,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -503,7 +478,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -518,7 +492,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -533,7 +506,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -542,7 +514,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(7)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -551,7 +522,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(8)
           tags {
-            "$MoreTags.SERVICE_NAME" "h2"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
@@ -566,7 +536,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -575,7 +544,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(10)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.hibernate.Session
@@ -87,7 +86,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -96,7 +94,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -105,7 +102,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -120,7 +116,6 @@ class ProcedureCallTest extends AgentTestRunner {
           operationName "Transaction.commit"
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -154,7 +149,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }
@@ -164,7 +158,6 @@ class ProcedureCallTest extends AgentTestRunner {
           childOf span(0)
           errored(true)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
             errorTags(SQLGrammarException, "could not prepare statement")
           }
@@ -174,7 +167,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hibernate"
             "$Tags.COMPONENT" "java-hibernate"
           }
         }

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -49,7 +48,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -78,7 +76,6 @@ class SpringJpaTest extends AgentTestRunner {
             operationName "call next value for hibernate_sequence"
             spanKind CLIENT
             tags {
-              "$MoreTags.SERVICE_NAME" "hsqldb"
               "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "test"
@@ -95,7 +92,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -121,7 +117,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -137,7 +132,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "update Customer set firstName=?, lastName=? where id=?"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -163,7 +157,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -187,7 +180,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -203,7 +195,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "delete from Customer where id=?"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
@@ -27,7 +27,6 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.auto.bootstrap.InternalJarURLHandler;
-import io.opentelemetry.auto.config.Config;
 import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
@@ -96,9 +95,6 @@ public class UrlInstrumentation extends Instrumenter.Default {
           final String host = url.getHost();
           if (host != null && !host.isEmpty()) {
             span.setAttribute(MoreTags.NET_PEER_NAME, host);
-            if (Config.get().isHttpClientSplitByDomain()) {
-              span.setAttribute(MoreTags.SERVICE_NAME, host);
-            }
           }
 
           DECORATE.onError(span, throwable);

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.config.Config
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
@@ -22,7 +21,6 @@ import spock.lang.Ignore
 import spock.lang.Requires
 import sun.net.www.protocol.https.HttpsURLConnectionImpl
 
-import static io.opentelemetry.auto.test.utils.ConfigUtils.withConfigOverride
 import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
 import static io.opentelemetry.trace.Span.Kind.CLIENT
 
@@ -65,28 +63,26 @@ class HttpUrlConnectionTest extends HttpClientTest {
   def "trace request with propagation (useCaches: #useCaches)"() {
     setup:
     def url = server.address.resolve("/success").toURL()
-    withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      runUnderTrace("someTrace") {
-        HttpURLConnection connection = url.openConnection()
-        connection.useCaches = useCaches
-        assert activeSpan() != null
-        def stream = connection.inputStream
-        def lines = stream.readLines()
-        stream.close()
-        assert connection.getResponseCode() == STATUS
-        assert lines == [RESPONSE]
+    runUnderTrace("someTrace") {
+      HttpURLConnection connection = url.openConnection()
+      connection.useCaches = useCaches
+      assert activeSpan() != null
+      def stream = connection.inputStream
+      def lines = stream.readLines()
+      stream.close()
+      assert connection.getResponseCode() == STATUS
+      assert lines == [RESPONSE]
 
-        // call again to ensure the cycling is ok
-        connection = url.openConnection()
-        connection.useCaches = useCaches
-        assert activeSpan() != null
-        assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
-        connection.inputStream
-        stream = connection.inputStream // one more to ensure state is working
-        lines = stream.readLines()
-        stream.close()
-        assert lines == [RESPONSE]
-      }
+      // call again to ensure the cycling is ok
+      connection = url.openConnection()
+      connection.useCaches = useCaches
+      assert activeSpan() != null
+      assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
+      connection.inputStream
+      stream = connection.inputStream // one more to ensure state is working
+      lines = stream.readLines()
+      stream.close()
+      assert lines == [RESPONSE]
     }
 
     expect:
@@ -107,7 +103,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -122,7 +117,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -136,37 +130,34 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     where:
     useCaches << [false, true]
-    renameService << [true, false]
   }
 
   @Ignore
   def "trace request without propagation (useCaches: #useCaches)"() {
     setup:
     def url = server.address.resolve("/success").toURL()
-    withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      runUnderTrace("someTrace") {
-        HttpURLConnection connection = url.openConnection()
-        connection.useCaches = useCaches
-        connection.addRequestProperty("is-test-server", "false")
-        assert activeSpan() != null
-        def stream = connection.inputStream
-        connection.inputStream // one more to ensure state is working
-        def lines = stream.readLines()
-        stream.close()
-        assert connection.getResponseCode() == STATUS
-        assert lines == [RESPONSE]
+    runUnderTrace("someTrace") {
+      HttpURLConnection connection = url.openConnection()
+      connection.useCaches = useCaches
+      connection.addRequestProperty("is-test-server", "false")
+      assert activeSpan() != null
+      def stream = connection.inputStream
+      connection.inputStream // one more to ensure state is working
+      def lines = stream.readLines()
+      stream.close()
+      assert connection.getResponseCode() == STATUS
+      assert lines == [RESPONSE]
 
-        // call again to ensure the cycling is ok
-        connection = url.openConnection()
-        connection.useCaches = useCaches
-        connection.addRequestProperty("is-test-server", "false")
-        assert activeSpan() != null
-        assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
-        stream = connection.inputStream
-        lines = stream.readLines()
-        stream.close()
-        assert lines == [RESPONSE]
-      }
+      // call again to ensure the cycling is ok
+      connection = url.openConnection()
+      connection.useCaches = useCaches
+      connection.addRequestProperty("is-test-server", "false")
+      assert activeSpan() != null
+      assert connection.getResponseCode() == STATUS // call before input stream to test alternate behavior
+      stream = connection.inputStream
+      lines = stream.readLines()
+      stream.close()
+      assert lines == [RESPONSE]
     }
 
     expect:
@@ -185,7 +176,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -200,7 +190,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -214,22 +203,19 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     where:
     useCaches << [false, true]
-    renameService << [false, true]
   }
 
   @Ignore
   def "test broken API usage"() {
     setup:
     def url = server.address.resolve("/success").toURL()
-    HttpURLConnection conn = withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      runUnderTrace("someTrace") {
-        HttpURLConnection connection = url.openConnection()
-        connection.setRequestProperty("Connection", "close")
-        connection.addRequestProperty("is-test-server", "false")
-        assert activeSpan() != null
-        assert connection.getResponseCode() == STATUS
-        return connection
-      }
+    runUnderTrace("someTrace") {
+      HttpURLConnection connection = url.openConnection()
+      connection.setRequestProperty("Connection", "close")
+      connection.addRequestProperty("is-test-server", "false")
+      assert activeSpan() != null
+      assert connection.getResponseCode() == STATUS
+      return connection
     }
 
     expect:
@@ -248,7 +234,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -265,34 +250,31 @@ class HttpUrlConnectionTest extends HttpClientTest {
 
     where:
     iteration << (1..10)
-    renameService = (iteration % 2 == 0) // alternate even/odd
   }
 
   @Ignore
   def "test post request"() {
     setup:
     def url = server.address.resolve("/success").toURL()
-    withConfigOverride(Config.HTTP_CLIENT_HOST_SPLIT_BY_DOMAIN, "$renameService") {
-      runUnderTrace("someTrace") {
-        HttpURLConnection connection = url.openConnection()
-        connection.setRequestMethod("POST")
+    runUnderTrace("someTrace") {
+      HttpURLConnection connection = url.openConnection()
+      connection.setRequestMethod("POST")
 
-        String urlParameters = "q=ASDF&w=&e=&r=12345&t="
+      String urlParameters = "q=ASDF&w=&e=&r=12345&t="
 
-        // Send post request
-        connection.setDoOutput(true)
-        DataOutputStream wr = new DataOutputStream(connection.getOutputStream())
-        wr.writeBytes(urlParameters)
-        wr.flush()
-        wr.close()
+      // Send post request
+      connection.setDoOutput(true)
+      DataOutputStream wr = new DataOutputStream(connection.getOutputStream())
+      wr.writeBytes(urlParameters)
+      wr.flush()
+      wr.close()
 
-        assert connection.getResponseCode() == STATUS
+      assert connection.getResponseCode() == STATUS
 
-        def stream = connection.inputStream
-        def lines = stream.readLines()
-        stream.close()
-        assert lines == [RESPONSE]
-      }
+      def stream = connection.inputStream
+      def lines = stream.readLines()
+      stream.close()
+      assert lines == [RESPONSE]
     }
 
     expect:
@@ -312,7 +294,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
             "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -323,9 +304,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
         }
       }
     }
-
-    where:
-    renameService << [false, true]
   }
 
   // This test makes no sense on IBM JVM because there is no HttpsURLConnectionImpl class there

--- a/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
@@ -47,7 +46,6 @@ class SlickTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" SlickUtils.Driver()
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" SlickUtils.Db()

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
@@ -19,7 +19,6 @@ import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.DatabaseClientDecorator;
 import io.opentelemetry.auto.bootstrap.instrumentation.jdbc.DBInfo;
 import io.opentelemetry.auto.bootstrap.instrumentation.jdbc.JDBCConnectionUrlParser;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -102,9 +101,6 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     }
 
     span.setAttribute(Tags.DB_TYPE, "sql");
-    if (dbInfo != null) {
-      span.setAttribute(MoreTags.SERVICE_NAME, dbInfo.getType());
-    }
     return super.onConnection(span, dbInfo);
   }
 

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.opentelemetry.auto.config.Config
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -70,7 +69,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
@@ -94,7 +92,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
@@ -106,7 +103,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "GET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "GET"
@@ -130,7 +126,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
@@ -142,7 +137,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "RANDOMKEY"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "RANDOMKEY"

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.config.Config
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -41,16 +40,11 @@ class JedisClientTest extends AgentTestRunner {
   def setupSpec() {
     println "Using redis: $redisServer.args"
     redisServer.start()
-
-    // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   def cleanupSpec() {
     redisServer.stop()
 //    jedis.close()  // not available in the early version we're using.
-
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   def setup() {

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.config.Config
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -41,16 +40,11 @@ class Jedis30ClientTest extends AgentTestRunner {
   def setupSpec() {
     println "Using redis: $redisServer.args"
     redisServer.start()
-
-    // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   def cleanupSpec() {
     redisServer.stop()
     jedis.close()
-
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   def setup() {

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.opentelemetry.auto.config.Config
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -70,7 +69,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
@@ -94,7 +92,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
@@ -106,7 +103,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "GET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "GET"
@@ -130,7 +126,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
@@ -142,7 +137,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "RANDOMKEY"
           spanKind CLIENT
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "RANDOMKEY"

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.google.common.io.Files
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
@@ -185,7 +184,6 @@ class JMS2Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "jms"
             "$Tags.COMPONENT" "jms"
             "span.origin.type" HornetQMessageConsumer.name
           }
@@ -219,7 +217,6 @@ class JMS2Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "jms"
             "$Tags.COMPONENT" "jms"
             "span.origin.type" HornetQMessageConsumer.name
           }
@@ -243,7 +240,6 @@ class JMS2Test extends AgentTestRunner {
       spanKind PRODUCER
       errored false
       tags {
-        "$MoreTags.SERVICE_NAME" "jms"
         "$Tags.COMPONENT" "jms"
         "span.origin.type" HornetQMessageProducer.name
       }
@@ -264,7 +260,6 @@ class JMS2Test extends AgentTestRunner {
       errored false
 
       tags {
-        "$MoreTags.SERVICE_NAME" "jms"
         "$Tags.COMPONENT" "jms"
         "span.origin.type" origin.name
       }

--- a/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
@@ -148,7 +147,6 @@ class JMS1Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "jms"
             "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
           }
@@ -182,7 +180,6 @@ class JMS1Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "jms"
             "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
           }
@@ -231,7 +228,6 @@ class JMS1Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "jms"
             "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
           }
@@ -258,7 +254,6 @@ class JMS1Test extends AgentTestRunner {
       errored false
       parent()
       tags {
-        "$MoreTags.SERVICE_NAME" "jms"
         "$Tags.COMPONENT" "jms"
         "span.origin.type" ActiveMQMessageProducer.name
       }
@@ -278,7 +273,6 @@ class JMS1Test extends AgentTestRunner {
       }
       errored false
       tags {
-        "$MoreTags.SERVICE_NAME" "jms"
         "$Tags.COMPONENT" "jms"
         "span.origin.type" origin.name
       }

--- a/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -104,7 +103,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
           }
         }
@@ -114,7 +112,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
@@ -171,7 +168,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
             "kafka.partition" { it >= 0 }
           }
@@ -182,7 +178,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0

--- a/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.grpc.Context
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.context.propagation.HttpTextFormat
@@ -144,7 +143,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
           }
         }
@@ -155,7 +153,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
@@ -168,7 +165,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
@@ -182,7 +178,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(2)
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
           }
         }
@@ -193,7 +188,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(3)
           tags {
-            "$MoreTags.SERVICE_NAME" "kafka"
             "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -134,7 +134,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" port
@@ -169,7 +168,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" incorrectPort
@@ -196,7 +194,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -230,7 +227,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -278,7 +274,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -312,7 +307,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -364,7 +358,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -376,7 +369,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -418,7 +410,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             errorTags(IllegalStateException, "TestException")
@@ -455,7 +446,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             "db.command.cancelled" true
@@ -477,7 +467,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -499,7 +488,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -18,7 +18,6 @@ import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulConnection
 import io.lettuce.core.api.reactive.RedisReactiveCommands
 import io.lettuce.core.api.sync.RedisCommands
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -107,7 +106,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -132,7 +130,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -165,7 +162,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -196,7 +192,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -217,7 +212,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             "db.command.results.count" 157
@@ -239,7 +233,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             "db.command.cancelled" true
@@ -274,7 +267,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -295,7 +287,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -114,7 +114,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" port
@@ -146,7 +145,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" incorrectPort
@@ -172,7 +170,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -194,7 +191,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -216,7 +212,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -238,7 +233,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -260,7 +254,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -282,7 +275,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -304,7 +296,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -325,7 +316,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
@@ -346,7 +336,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "redis"
             "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -19,7 +19,6 @@ import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
-import io.opentelemetry.auto.config.Config
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.asserts.TraceAssert
@@ -29,7 +28,6 @@ import org.bson.BsonString
 import org.bson.Document
 import spock.lang.Shared
 
-import static io.opentelemetry.auto.test.utils.ConfigUtils.withConfigOverride
 import static io.opentelemetry.auto.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.auto.test.utils.TraceUtils.runUnderTrace
 import static io.opentelemetry.trace.Span.Kind.CLIENT
@@ -56,21 +54,18 @@ class MongoClientTest extends MongoBaseTest {
     MongoDatabase db = client.getDatabase(dbName)
 
     when:
-    withConfigOverride(Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "$renameService") {
-      db.createCollection(collectionName)
-    }
+    db.createCollection(collectionName)
 
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", renameService)
+        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}")
       }
     }
 
     where:
     dbName = "test_db"
     collectionName = "testCollection"
-    renameService << [false, true]
   }
 
   def "test create collection no description"() {
@@ -83,7 +78,7 @@ class MongoClientTest extends MongoBaseTest {
     then:
     assertTraces(1) {
       trace(0, 1) {
-        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", false, dbName)
+        mongoSpan(it, 0, "{\"create\":\"$collectionName\",\"capped\":\"?\"}", dbName)
       }
     }
 
@@ -249,7 +244,7 @@ class MongoClientTest extends MongoBaseTest {
     collectionName = "testCollection"
   }
 
-  def mongoSpan(TraceAssert trace, int index, String statement, boolean renameService = false, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
+  def mongoSpan(TraceAssert trace, int index, String statement, String instance = "some-description", Object parentSpan = null, Throwable exception = null) {
     trace.span(index) {
       operationName { it.replace(" ", "") == statement }
       spanKind CLIENT
@@ -259,7 +254,6 @@ class MongoClientTest extends MongoBaseTest {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$MoreTags.SERVICE_NAME" renameService ? instance : "mongo"
         "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"
         "$MoreTags.NET_PEER_IP" "127.0.0.1"

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -267,7 +267,7 @@ class MongoClientTest extends MongoBaseTest {
         "$Tags.DB_STATEMENT" {
           it.replace(" ", "") == statement
         }
-        "$Tags.DB_URL" "mongodb://localhost:"+port
+        "$Tags.DB_URL" "mongodb://localhost:" + port
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance
       }

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -271,7 +271,7 @@ class MongoClientTest extends MongoBaseTest {
           it.replace(" ", "") == statement
         }
         "$Tags.DB_TYPE" "mongo"
-        "$Tags.DB_URL" "mongodb://localhost:"+port
+        "$Tags.DB_URL" "mongodb://localhost:" + port
         "$Tags.DB_INSTANCE" instance
       }
     }

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -297,12 +297,11 @@ class MongoAsyncClientTest extends MongoBaseTest {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$MoreTags.SERVICE_NAME" "mongo"
         "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"
         "$MoreTags.NET_PEER_IP" "127.0.0.1"
         "$MoreTags.NET_PEER_PORT" port
-        "$Tags.DB_URL" "mongodb://localhost:"+port
+        "$Tags.DB_URL" "mongodb://localhost:" + port
         "$Tags.DB_STATEMENT" statementEval
         "$Tags.DB_TYPE" "mongo"
         "$Tags.DB_INSTANCE" instance

--- a/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -364,7 +364,6 @@ class RabbitMQTest extends AgentTestRunner {
       errored exception != null
 
       tags {
-        "$MoreTags.SERVICE_NAME" "rabbitmq"
         "$Tags.COMPONENT" "rabbitmq-amqp"
         "$MoreTags.NET_PEER_NAME" { it == null || it instanceof String }
         "$MoreTags.NET_PEER_IP" { "127.0.0.1" }

--- a/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
@@ -82,7 +81,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -117,7 +115,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -152,7 +149,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -167,7 +163,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -200,7 +195,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -233,7 +227,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
@@ -248,7 +241,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$MoreTags.SERVICE_NAME" "hsqldb"
             "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
@@ -59,8 +59,8 @@ class SpringWebfluxHttpClientTest extends HttpClientTest {
 
   @Override
   // parent spanRef must be cast otherwise it breaks debugging classloading (junit loads it early)
-  void clientSpan(TraceAssert trace, int index, Object parentSpan, String method = "GET", boolean renameService = false, boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
-    super.clientSpan(trace, index, parentSpan, method, renameService, tagQueryString, uri, status, exception)
+  void clientSpan(TraceAssert trace, int index, Object parentSpan, String method = "GET", boolean tagQueryString = false, URI uri = server.address.resolve("/success"), Integer status = 200, Throwable exception = null) {
+    super.clientSpan(trace, index, parentSpan, method, tagQueryString, uri, status, exception)
     if (!exception) {
       trace.span(index + 1) {
         childOf(trace.span(index))
@@ -68,7 +68,6 @@ class SpringWebfluxHttpClientTest extends HttpClientTest {
         spanKind CLIENT
         errored exception != null
         tags {
-          "$MoreTags.SERVICE_NAME" renameService ? "localhost" : null
           "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.getComponentName()
           "$MoreTags.NET_PEER_NAME" "localhost"
           "$MoreTags.NET_PEER_PORT" uri.port

--- a/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 import com.google.common.util.concurrent.MoreExecutors
-import io.opentelemetry.auto.config.Config
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.spymemcached.CompletionListener
 import io.opentelemetry.auto.test.AgentTestRunner
@@ -84,17 +82,12 @@ class SpymemcachedTest extends AgentTestRunner {
         memcachedContainer.getMappedPort(defaultMemcachedPort)
       )
     }
-
-    // This setting should have no effect since decorator returns null for the instance.
-    System.setProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE, "true")
   }
 
   def cleanupSpec() {
     if (memcachedContainer) {
       memcachedContainer.stop()
     }
-
-    System.clearProperty(Config.PREFIX + Config.DB_CLIENT_HOST_SPLIT_BY_INSTANCE)
   }
 
   ReentrantLock queueLock
@@ -646,7 +639,6 @@ class SpymemcachedTest extends AgentTestRunner {
       errored(error != null && error != "canceled")
 
       tags {
-        "$MoreTags.SERVICE_NAME" CompletionListener.SERVICE_NAME
         "$Tags.COMPONENT" CompletionListener.COMPONENT_NAME
         "$Tags.DB_TYPE" CompletionListener.DB_TYPE
 

--- a/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -42,6 +42,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           parent()
           errored false
           tags {
+            "myattr" "test"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -62,6 +63,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           parent()
           errored false
           tags {
+            "myattr" "test2"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -70,6 +72,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
+            "myattr" "test"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -78,6 +81,7 @@ class TraceAnnotationsTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
+            "myattr" "test"
             "$Tags.COMPONENT" "trace"
           }
         }

--- a/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.ConfigUtils
@@ -43,7 +42,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "test"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -64,7 +62,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "test2"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -73,7 +70,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "test"
             "$Tags.COMPONENT" "trace"
           }
         }
@@ -82,7 +78,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "test"
             "$Tags.COMPONENT" "trace"
           }
         }

--- a/instrumentation/trace-annotation/src/test/java/io/opentelemetry/test/annotation/SayTracedHello.java
+++ b/instrumentation/trace-annotation/src/test/java/io/opentelemetry/test/annotation/SayTracedHello.java
@@ -16,7 +16,6 @@
 package io.opentelemetry.test.annotation;
 
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.instrumentation.api.MoreTags;
 import io.opentelemetry.trace.Tracer;
 import io.opentracing.contrib.dropwizard.Trace;
 import java.util.concurrent.Callable;
@@ -28,13 +27,13 @@ public class SayTracedHello {
 
   @Trace
   public static String sayHello() {
-    TRACER.getCurrentSpan().setAttribute(MoreTags.SERVICE_NAME, "test");
+    TRACER.getCurrentSpan().setAttribute("myattr", "test");
     return "hello!";
   }
 
   @Trace
   public static String sayHELLOsayHA() {
-    TRACER.getCurrentSpan().setAttribute(MoreTags.SERVICE_NAME, "test2");
+    TRACER.getCurrentSpan().setAttribute("myattr", "test2");
     return sayHello() + sayHello();
   }
 

--- a/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
@@ -154,7 +154,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -200,7 +199,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Call"
             "twilio.account" "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -268,7 +266,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -364,7 +361,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -480,7 +476,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -493,7 +488,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -573,7 +567,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
           }
@@ -606,7 +599,6 @@ class TwilioClientTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -661,7 +653,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -674,7 +665,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
@@ -742,7 +732,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
           }
@@ -752,7 +741,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$MoreTags.SERVICE_NAME" "twilio-sdk"
             "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
           }


### PR DESCRIPTION
I'd like remove the `service.name` and `component` attributes in the beta release, as I think they are some of the first things people will notice, as they are holdovers from OpenTracing. This is not the (new) `service.name` that is defined in resource specification.