### PR TITLE
Remove component attribute

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.trace.TracingContextUtils.getSpan;
 
 import io.grpc.Context;
 import io.opentelemetry.auto.instrumentation.api.MoreTags;
-import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.context.propagation.HttpTextFormat;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.SpanContext;
@@ -40,7 +39,6 @@ public abstract class BaseDecorator {
 
   public Span afterStart(final Span span) {
     assert span != null;
-    span.setAttribute(Tags.COMPONENT, getComponentName());
     return span;
   }
 

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -16,7 +16,6 @@
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.util.test.AgentSpecification
 import io.opentelemetry.trace.Span
 import io.opentelemetry.trace.Status
@@ -34,7 +33,6 @@ class BaseDecoratorTest extends AgentSpecification {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     _ * span.setAttribute(_, _) // Want to allow other calls from child implementations.
     0 * _
   }

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
@@ -15,7 +15,6 @@
  */
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator
 
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.trace.Span
 
 class ClientDecoratorTest extends BaseDecoratorTest {
@@ -30,7 +29,6 @@ class ClientDecoratorTest extends BaseDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     _ * span.setAttribute(_, _) // Want to allow other calls from child implementations.
     0 * _
 

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -30,7 +30,6 @@ class DatabaseClientDecoratorTest extends ClientDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     1 * span.setAttribute(Tags.DB_TYPE, "test-db")
     0 * _
 

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
@@ -16,7 +16,6 @@
 package io.opentelemetry.auto.bootstrap.instrumentation.decorator
 
 
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.trace.Span
 
 class ServerDecoratorTest extends BaseDecoratorTest {
@@ -29,7 +28,6 @@ class ServerDecoratorTest extends BaseDecoratorTest {
     decorator.afterStart(span)
 
     then:
-    1 * span.setAttribute(Tags.COMPONENT, "test-component")
     0 * _
   }
 

--- a/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -79,7 +79,6 @@ class LagomTest extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "akka-http-server"
             "$Tags.HTTP_URL" "ws://localhost:${server.port()}/echo"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 101
@@ -115,7 +114,6 @@ class LagomTest extends AgentTestRunner {
           spanKind SERVER
           errored true
           tags {
-            "$Tags.COMPONENT" "akka-http-server"
             "$Tags.HTTP_URL" "ws://localhost:${server.port()}/error"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 500

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -20,7 +20,6 @@ import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.headers.RawHeader
 import akka.stream.ActorMaterializer
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
-import io.opentelemetry.auto.instrumentation.akkahttp.AkkaHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import spock.lang.Shared
 
@@ -49,11 +48,6 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
       .get()
     callback?.call()
     return response.status().intValue()
-  }
-
-  @Override
-  String component() {
-    return AkkaHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -21,7 +21,6 @@ import akka.http.javadsl.model.headers.RawHeader
 import akka.stream.ActorMaterializer
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.instrumentation.akkahttp.AkkaHttpClientDecorator
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.base.HttpClientTest
 import spock.lang.Shared
 
@@ -77,7 +76,6 @@ class AkkaHttpClientInstrumentationTest extends HttpClientTest {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "akka-http-client"
             errorTags(NullPointerException)
           }
         }

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.akkahttp.AkkaHttpServerDecorator
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.asserts.TraceAssert
@@ -25,11 +24,6 @@ import static io.opentelemetry.auto.test.base.HttpServerTest.ServerEndpoint.SUCC
 import static io.opentelemetry.trace.Span.Kind.SERVER
 
 abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> {
-
-  @Override
-  String component() {
-    return AkkaHttpServerDecorator.DECORATE.getComponentName()
-  }
 
   @Override
   boolean testExceptionBody() {

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -53,7 +53,6 @@ abstract class AkkaHttpServerInstrumentationTest extends HttpServerTest<Object> 
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }
         "$Tags.HTTP_METHOD" method
         "$Tags.HTTP_STATUS" endpoint.status

--- a/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.http.HttpResponse
 import org.apache.http.concurrent.FutureCallback
@@ -63,11 +62,6 @@ class ApacheHttpAsyncClientCallbackTest extends HttpClientTest {
     })
 
     return responseFuture.get()
-  }
-
-  @Override
-  String component() {
-    return ApacheHttpAsyncClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.http.impl.nio.client.HttpAsyncClients
 import org.apache.http.message.BasicHeader
@@ -48,11 +47,6 @@ class ApacheHttpAsyncClientNullCallbackTest extends HttpClientTest {
       callback()
     }
     return 200
-  }
-
-  @Override
-  String component() {
-    return ApacheHttpAsyncClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.apachehttpasyncclient.ApacheHttpAsyncClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.http.HttpResponse
 import org.apache.http.concurrent.FutureCallback
@@ -69,11 +68,6 @@ class ApacheHttpAsyncClientTest extends HttpClientTest {
       latch.await()
     }
     response.statusLine.statusCode
-  }
-
-  @Override
-  String component() {
-    return ApacheHttpAsyncClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/test/groovy/CommonsHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/test/groovy/CommonsHttpClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.apachehttpclient.v2_0.CommonsHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.commons.httpclient.HttpClient
 import org.apache.commons.httpclient.HttpMethod
@@ -69,11 +68,6 @@ class CommonsHttpClientTest extends HttpClientTest {
     } finally {
       httpMethod.releaseConnection()
     }
-  }
-
-  @Override
-  String component() {
-    return CommonsHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.ApacheHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.http.HttpResponse
 import org.apache.http.client.ResponseHandler
@@ -47,10 +46,5 @@ class ApacheHttpClientResponseHandlerTest extends HttpClientTest {
     callback?.call()
 
     return status
-  }
-
-  @Override
-  String component() {
-    return ApacheHttpClientDecorator.DECORATE.getComponentName()
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.apachehttpclient.v4_0.ApacheHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.http.HttpHost
 import org.apache.http.HttpRequest
@@ -27,11 +26,6 @@ import spock.lang.Shared
 abstract class ApacheHttpClientTest<T extends HttpRequest> extends HttpClientTest {
   @Shared
   def client = new DefaultHttpClient()
-
-  @Override
-  String component() {
-    return ApacheHttpClientDecorator.DECORATE.getComponentName()
-  }
 
   @Override
   int doRequest(String method, URI uri, Map<String, String> headers, Closure callback) {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
@@ -155,7 +155,6 @@ class AWSClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.HTTP_STATUS" 200
@@ -174,7 +173,6 @@ class AWSClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
@@ -242,7 +240,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
             "aws.service" { it.contains(service) }
@@ -261,7 +258,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" UNUSABLE_PORT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
@@ -301,7 +297,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "HEAD"
             "aws.service" "Amazon S3"
@@ -343,7 +338,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
             "aws.service" "Amazon S3"
@@ -365,7 +359,6 @@ class AWSClientTest extends AgentTestRunner {
             errored true
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "apache-httpclient"
               "$MoreTags.NET_PEER_NAME" "localhost"
               "$MoreTags.NET_PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/someBucket/someKey"

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -118,7 +118,6 @@ class AWSClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "$method"
             "$Tags.HTTP_STATUS" 200
@@ -137,7 +136,6 @@ class AWSClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "${server.address}${path}"
@@ -187,7 +185,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/"
             "$Tags.HTTP_METHOD" "$method"
             "aws.service" { it.contains(service) }
@@ -206,7 +203,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" UNUSABLE_PORT
             "$Tags.HTTP_URL" "http://localhost:${UNUSABLE_PORT}/$url"
@@ -246,7 +242,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "https://s3.amazonaws.com/"
             "$Tags.HTTP_METHOD" "GET"
             "aws.service" "Amazon S3"
@@ -289,7 +284,6 @@ class AWSClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$Tags.HTTP_URL" "$server.address/"
             "$Tags.HTTP_METHOD" "GET"
             "aws.service" "Amazon S3"
@@ -307,7 +301,6 @@ class AWSClientTest extends AgentTestRunner {
             errored true
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "apache-httpclient"
               "$MoreTags.NET_PEER_NAME" "localhost"
               "$MoreTags.NET_PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/someBucket/someKey"

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -96,7 +96,6 @@ class AwsClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" { it.startsWith("${server.address}${path}") }
@@ -125,7 +124,6 @@ class AwsClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" { it.startsWith("${server.address}${path}") }
@@ -198,7 +196,6 @@ class AwsClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" { it.startsWith("${server.address}${path}") }
@@ -230,7 +227,6 @@ class AwsClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "netty-client"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" server.address.port
@@ -311,7 +307,6 @@ class AwsClientTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "java-aws-sdk"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$server.address/somebucket/somekey"
@@ -330,7 +325,6 @@ class AwsClientTest extends AgentTestRunner {
             errored true
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "apache-httpclient"
               "$MoreTags.NET_PEER_NAME" "localhost"
               "$MoreTags.NET_PEER_PORT" server.address.port
               "$Tags.HTTP_URL" "$server.address/somebucket/somekey"

--- a/instrumentation/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
@@ -126,7 +126,6 @@ class CassandraClientTest extends AgentTestRunner {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$Tags.COMPONENT" "java-cassandra"
         "$MoreTags.NET_PEER_NAME" "localhost"
         "$MoreTags.NET_PEER_IP" "127.0.0.1"
         "$MoreTags.NET_PEER_PORT" EmbeddedCassandraServerHelper.getNativeTransportPort()

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -125,7 +125,6 @@ abstract class AbstractCouchbaseTest extends AgentTestRunner {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$Tags.COMPONENT" "couchbase-client"
         "$Tags.DB_TYPE" "couchbase"
         if (bucketName != null) {
           "$Tags.DB_INSTANCE" bucketName

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -34,7 +34,6 @@ class CouchbaseSpanUtil {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$Tags.COMPONENT" "couchbase-client"
 
         // Because of caching, not all requests hit the server so these tags may be absent
         "$MoreTags.NET_PEER_NAME" { it == "localhost" || it == "127.0.0.1" || it == null }

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -73,11 +73,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
   }
 
   @Override
-  String component() {
-    return "jax-rs"
-  }
-
-  @Override
   boolean hasHandlerSpan() {
     true
   }

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -21,7 +21,6 @@ import io.dropwizard.testing.ConfigOverride
 import io.dropwizard.testing.DropwizardTestSupport
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.jaxrs.v2_0.JaxRsAnnotationsDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.auto.test.utils.PortUtils
@@ -99,7 +98,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
       errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$Tags.COMPONENT" JaxRsAnnotationsDecorator.DECORATE.getComponentName()
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
@@ -120,7 +118,6 @@ class DropwizardTest extends HttpServerTest<DropwizardTestSupport> {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" Long
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }

--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizardviews/DropwizardViewInstrumentation.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizardviews/DropwizardViewInstrumentation.java
@@ -29,7 +29,6 @@ import io.dropwizard.views.View;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
-import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
@@ -84,7 +83,6 @@ public final class DropwizardViewInstrumentation extends Instrumenter.Default {
         return null;
       }
       final Span span = TRACER.spanBuilder("Render " + view.getTemplateName()).startSpan();
-      span.setAttribute(Tags.COMPONENT, "dropwizard-view");
       span.setAttribute("span.origin.type", obj.getClass().getSimpleName());
       return new SpanWithScope(span, currentContextWith(span));
     }

--- a/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
+++ b/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
@@ -16,7 +16,6 @@
 import io.dropwizard.views.View
 import io.dropwizard.views.freemarker.FreemarkerViewRenderer
 import io.dropwizard.views.mustache.MustacheViewRenderer
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
 import java.nio.charset.StandardCharsets
@@ -44,7 +43,6 @@ class ViewRenderTest extends AgentTestRunner {
           operationName "Render $template"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "dropwizard-view"
             "span.origin.type" renderer.class.simpleName
           }
         }

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -101,7 +101,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort
             "$Tags.HTTP_URL" "_cluster/health"
@@ -114,7 +113,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -105,7 +105,6 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort
             "$Tags.HTTP_URL" "_cluster/health"
@@ -118,7 +117,6 @@ class Elasticsearch5RestClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -105,7 +105,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort
             "$Tags.HTTP_URL" "_cluster/health"
@@ -118,7 +117,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -101,7 +101,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" httpPort
             "$Tags.HTTP_URL" "_cluster/health"
@@ -114,7 +113,6 @@ class Elasticsearch6RestClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "apache-httpasyncclient"
             "$Tags.HTTP_URL" "_cluster/health"
             "$Tags.HTTP_METHOD" "GET"
             "$Tags.HTTP_STATUS" 200

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -89,7 +89,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -114,7 +113,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -175,7 +173,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -188,7 +185,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -200,7 +196,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -216,7 +211,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -229,7 +223,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -242,7 +235,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -101,7 +101,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -129,7 +128,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -198,7 +196,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -214,7 +211,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -229,7 +225,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -248,7 +243,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -261,7 +255,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -278,7 +271,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -55,7 +55,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -84,7 +83,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -97,7 +95,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -110,7 +107,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -134,7 +130,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -162,7 +157,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -176,7 +170,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -192,7 +185,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -219,7 +211,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "DeleteAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
@@ -233,7 +224,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -249,7 +239,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -96,7 +96,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -146,7 +145,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -159,7 +157,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -171,7 +168,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -185,7 +181,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -198,7 +193,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -211,7 +205,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -227,7 +220,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -305,7 +297,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -90,7 +90,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -115,7 +114,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -176,7 +174,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -189,7 +186,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -201,7 +197,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -220,7 +215,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -236,7 +230,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -249,7 +242,6 @@ class Elasticsearch2NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -102,7 +102,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -131,7 +130,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
         span(0) {
           operationName "ClusterStatsAction"
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -160,7 +158,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -229,7 +226,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -245,7 +241,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -260,7 +255,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -279,7 +273,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -292,7 +285,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -309,7 +301,6 @@ class Elasticsearch2TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "127.0.0.1"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -56,7 +56,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -85,7 +84,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -101,7 +99,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -114,7 +111,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -138,7 +134,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -169,7 +164,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -186,7 +180,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -202,7 +195,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -232,7 +224,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "DeleteAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -249,7 +240,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -265,7 +255,6 @@ class Elasticsearch2SpringRepositoryTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -97,7 +97,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -147,7 +146,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -160,7 +158,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -172,7 +169,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -186,7 +182,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "local"
             "$MoreTags.NET_PEER_IP" "0.0.0.0"
             "$MoreTags.NET_PEER_PORT" 0
@@ -202,7 +197,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -215,7 +209,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -231,7 +224,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -308,7 +300,6 @@ class Elasticsearch2SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -95,7 +95,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -120,7 +119,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           errored true
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -182,7 +180,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -195,7 +192,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -207,7 +203,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -223,7 +218,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -240,7 +234,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -252,7 +245,6 @@ class Elasticsearch5NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -108,7 +108,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -136,7 +135,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -205,7 +203,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -221,7 +218,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -240,7 +236,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -252,7 +247,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -273,7 +267,6 @@ class Elasticsearch5TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" String
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -95,7 +95,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -120,7 +119,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -182,7 +180,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -195,7 +192,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -207,7 +203,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -223,7 +218,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -241,7 +235,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -253,7 +246,6 @@ class Elasticsearch53NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -108,7 +108,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -136,7 +135,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -205,7 +203,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -221,7 +218,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -240,7 +236,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -252,7 +247,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -274,7 +268,6 @@ class Elasticsearch53TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -83,7 +83,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           operationName "CrudRepository.findAll"
           spanKind INTERNAL
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
@@ -92,7 +91,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -121,7 +119,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           operationName "ElasticsearchRepository.index"
           spanKind INTERNAL
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
@@ -129,7 +126,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -147,7 +143,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -158,7 +153,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -182,7 +176,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           operationName "CrudRepository.findById"
           spanKind INTERNAL
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
@@ -190,7 +183,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -218,7 +210,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           operationName "ElasticsearchRepository.index"
           spanKind INTERNAL
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
@@ -226,7 +217,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -244,7 +234,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -260,7 +249,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           operationName "CrudRepository.findById"
           spanKind INTERNAL
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
@@ -268,7 +256,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -295,7 +282,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           operationName "CrudRepository.deleteById"
           spanKind INTERNAL
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
@@ -303,7 +289,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "DeleteAction"
             "elasticsearch.request" "DeleteRequest"
@@ -320,7 +305,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -337,7 +321,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           operationName "CrudRepository.findAll"
           spanKind INTERNAL
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) {
@@ -345,7 +328,6 @@ class Elasticsearch53SpringRepositoryTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -115,7 +115,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -165,7 +164,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -178,7 +176,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -190,7 +187,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -204,7 +200,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -222,7 +217,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -234,7 +228,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "RefreshAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "RefreshAction"
             "elasticsearch.request" "RefreshRequest"
@@ -250,7 +243,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"
@@ -328,7 +320,6 @@ class Elasticsearch53SpringTemplateTest extends AgentTestRunner {
           operationName "SearchAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "SearchAction"
             "elasticsearch.request" "SearchRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -92,7 +92,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "ClusterHealthAction"
             "elasticsearch.request" "ClusterHealthRequest"
@@ -117,7 +116,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -178,7 +176,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "CreateIndexAction"
             "elasticsearch.request" "CreateIndexRequest"
@@ -191,7 +188,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -207,7 +203,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "IndexAction"
             "elasticsearch.request" "IndexRequest"
@@ -225,7 +220,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -237,7 +231,6 @@ class Elasticsearch6NodeClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -105,7 +105,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "ClusterHealthAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -133,7 +132,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "GetAction"
             "elasticsearch.request" "GetRequest"
@@ -202,7 +200,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "CreateIndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -218,7 +215,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -237,7 +233,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "PutMappingAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$Tags.DB_TYPE" "elasticsearch"
             "elasticsearch.action" "PutMappingAction"
             "elasticsearch.request" "PutMappingRequest"
@@ -249,7 +244,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "IndexAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort
@@ -271,7 +265,6 @@ class Elasticsearch6TransportClientTest extends AgentTestRunner {
           operationName "GetAction"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "elasticsearch-java"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" tcpPort

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
@@ -34,7 +34,6 @@ import com.twitter.util.Future;
 import com.twitter.util.FutureEventListener;
 import io.opentelemetry.auto.config.Config;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
-import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Status;
@@ -88,7 +87,6 @@ public class FinatraInstrumentation extends Instrumenter.Default {
         @Advice.FieldValue("clazz") final Class clazz) {
 
       final Span parent = TRACER.getCurrentSpan();
-      parent.setAttribute(Tags.COMPONENT, "finatra");
       parent.updateName(routeInfo.path());
 
       final Span span = TRACER.spanBuilder(DECORATE.spanNameForClass(clazz)).startSpan();

--- a/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -75,11 +75,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
   }
 
   @Override
-  String component() {
-    return FinatraDecorator.DECORATE.getComponentName()
-  }
-
-  @Override
   boolean testPathParam() {
     true
   }

--- a/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -19,7 +19,6 @@ import com.twitter.util.Closable
 import com.twitter.util.Duration
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.finatra.FinatraDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -88,8 +87,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
       errored errorEndpoint
       childOf(parent as SpanData)
       tags {
-        "$Tags.COMPONENT" FinatraDecorator.DECORATE.getComponentName()
-
         // Finatra doesn't propagate the stack trace or exception to the instrumentation
         // so the normal errorTags() method can't be used
       }
@@ -109,7 +106,6 @@ class FinatraServerTest extends HttpServerTest<HttpServer> {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_PORT" Long
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }

--- a/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
@@ -131,7 +131,6 @@ class PutGetTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "apache-geode-client"
             "$Tags.DB_TYPE" "geode"
             "$Tags.DB_INSTANCE" "test-region"
           }
@@ -141,7 +140,6 @@ class PutGetTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "apache-geode-client"
             "$Tags.DB_TYPE" "geode"
             "$Tags.DB_INSTANCE" "test-region"
           }
@@ -151,7 +149,6 @@ class PutGetTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "apache-geode-client"
             "$Tags.DB_TYPE" "geode"
             "$Tags.DB_INSTANCE" "test-region"
             if (query != null) {

--- a/instrumentation/google-http-client-1.19/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -19,7 +19,6 @@ import com.google.api.client.http.HttpResponse
 import com.google.api.client.http.javanet.NetHttpTransport
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.googlehttpclient.GoogleHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import spock.lang.Shared
 
@@ -49,11 +48,6 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
   }
 
   abstract HttpResponse executeRequest(HttpRequest request)
-
-  @Override
-  String component() {
-    return GoogleHttpClientDecorator.DECORATE.getComponentName()
-  }
 
   @Override
   boolean testCircularRedirects() {

--- a/instrumentation/google-http-client-1.19/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -76,7 +76,6 @@ abstract class AbstractGoogleHttpClientTest extends HttpClientTest {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "google-http-client"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "${uri}"

--- a/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyTest.groovy
+++ b/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.grizzly.GrizzlyDecorator
 import io.opentelemetry.auto.test.base.HttpServerTest
 import org.glassfish.grizzly.http.server.HttpServer
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory
@@ -49,11 +48,6 @@ class GrizzlyTest extends HttpServerTest<HttpServer> {
   @Override
   void stopServer(HttpServer server) {
     server.stop()
-  }
-
-  @Override
-  String component() {
-    return GrizzlyDecorator.DECORATE.getComponentName()
   }
 
   static class SimpleExceptionMapper implements ExceptionMapper<Throwable> {

--- a/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -22,7 +22,6 @@ import io.grpc.Server
 import io.grpc.ServerBuilder
 import io.grpc.stub.StreamObserver
 import io.opentelemetry.auto.instrumentation.api.MoreTags
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 
@@ -121,7 +120,6 @@ class GrpcStreamingTest extends AgentTestRunner {
           errored false
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
-            "$Tags.COMPONENT" "grpc-client"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" port
             "status.code" "OK"
@@ -144,7 +142,6 @@ class GrpcStreamingTest extends AgentTestRunner {
           errored false
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
-            "$Tags.COMPONENT" "grpc-server"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "status.code" "OK"

--- a/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -25,7 +25,6 @@ import io.grpc.StatusRuntimeException
 import io.grpc.stub.StreamObserver
 import io.opentelemetry.auto.common.exec.CommonTaskExecutor
 import io.opentelemetry.auto.instrumentation.api.MoreTags
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 
@@ -98,7 +97,6 @@ class GrpcTest extends AgentTestRunner {
           }
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
-            "$Tags.COMPONENT" "grpc-client"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" port
             "status.code" "OK"
@@ -118,7 +116,6 @@ class GrpcTest extends AgentTestRunner {
           }
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
-            "$Tags.COMPONENT" "grpc-server"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "status.code" "OK"
@@ -173,7 +170,6 @@ class GrpcTest extends AgentTestRunner {
           errored true
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
-            "$Tags.COMPONENT" "grpc-client"
             "status.code" "${status.code.name()}"
             "status.description" description
             "$MoreTags.NET_PEER_NAME" "localhost"
@@ -193,7 +189,6 @@ class GrpcTest extends AgentTestRunner {
             }
           }
           tags {
-            "$Tags.COMPONENT" "grpc-server"
             "$MoreTags.RPC_SERVICE" "Greeter"
             "status.code" "${status.code.name()}"
             "status.description" description
@@ -259,7 +254,6 @@ class GrpcTest extends AgentTestRunner {
           errored true
           tags {
             "$MoreTags.RPC_SERVICE" "Greeter"
-            "$Tags.COMPONENT" "grpc-client"
             "status.code" "UNKNOWN"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" Long
@@ -278,7 +272,6 @@ class GrpcTest extends AgentTestRunner {
             }
           }
           tags {
-            "$Tags.COMPONENT" "grpc-server"
             "$MoreTags.RPC_SERVICE" "Greeter"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
@@ -43,7 +43,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -51,7 +50,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -59,7 +57,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -73,7 +70,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
@@ -48,7 +48,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -56,14 +55,12 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -77,7 +74,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }
@@ -89,7 +85,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(1) {
@@ -97,7 +92,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(2) {
@@ -105,7 +99,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             tags {
-              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
@@ -165,7 +158,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -173,7 +165,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -181,7 +172,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -195,7 +185,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
@@ -60,7 +60,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(1) {
@@ -68,7 +67,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(2) {
@@ -76,7 +74,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             tags {
-              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
@@ -90,7 +87,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
         }
@@ -134,7 +130,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -142,7 +137,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -150,14 +144,12 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(3) {
           spanKind CLIENT
           childOf span(2)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -211,7 +203,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -219,7 +210,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -227,7 +217,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -241,14 +230,12 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(4) {
           spanKind CLIENT
           childOf span(3)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -299,7 +286,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -308,7 +294,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(0)
           errored(true)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
             errorTags(MappingException, "Unknown entity: java.lang.Long")
           }
         }
@@ -317,7 +302,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }
@@ -349,7 +333,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -357,7 +340,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -365,14 +347,12 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(3) {
           spanKind CLIENT
           childOf span(2)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -433,7 +413,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -441,14 +420,12 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -462,7 +439,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }
@@ -510,7 +486,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -518,7 +493,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(3) {
@@ -526,7 +500,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(4) {
@@ -534,7 +507,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(5) {
@@ -542,7 +514,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -556,7 +527,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -570,7 +540,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(8) {
@@ -578,7 +547,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(7)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(9) {
@@ -586,7 +554,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(10) {
@@ -594,7 +561,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(9)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
@@ -43,7 +43,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -51,7 +50,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -59,7 +57,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -73,7 +70,6 @@ class CriteriaTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
@@ -48,7 +48,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -56,14 +55,12 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -77,7 +74,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }
@@ -89,7 +85,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(1) {
@@ -97,7 +92,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(2) {
@@ -105,7 +99,6 @@ class QueryTest extends AbstractHibernateTest {
             spanKind CLIENT
             childOf span(1)
             tags {
-              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
@@ -165,7 +158,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -173,7 +165,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -181,7 +172,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -195,7 +185,6 @@ class QueryTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
@@ -60,7 +60,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             parent()
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(1) {
@@ -68,14 +67,12 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
           span(2) {
             childOf span(1)
             spanKind CLIENT
             tags {
-              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "db1"
               "$Tags.DB_USER" "sa"
@@ -89,7 +86,6 @@ class SessionTest extends AbstractHibernateTest {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "java-hibernate"
             }
           }
         }
@@ -147,7 +143,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -155,7 +150,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -163,7 +157,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -177,14 +170,12 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(4) {
           spanKind CLIENT
           childOf span(3)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -235,7 +226,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -244,7 +234,6 @@ class SessionTest extends AbstractHibernateTest {
           childOf span(0)
           errored(true)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
             errorTags(MappingException, "Unknown entity: java.lang.Long")
           }
         }
@@ -253,7 +242,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }
@@ -285,7 +273,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -293,7 +280,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -301,14 +287,12 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(3) {
           spanKind CLIENT
           childOf span(2)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -369,7 +353,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -377,14 +360,12 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -398,7 +379,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }
@@ -446,7 +426,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -454,7 +433,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(3) {
@@ -462,7 +440,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(4) {
@@ -470,7 +447,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(5) {
@@ -478,7 +454,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -492,7 +467,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(4)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -506,7 +480,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(8) {
@@ -514,7 +487,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(7)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(9) {
@@ -522,7 +494,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind CLIENT
           childOf span(8)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "db1"
             "$Tags.DB_USER" "sa"
@@ -536,7 +507,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(11) {
@@ -544,7 +514,6 @@ class SessionTest extends AbstractHibernateTest {
           spanKind INTERNAL
           childOf span(10)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -86,7 +86,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -94,7 +93,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(2) {
@@ -102,7 +100,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -116,7 +113,6 @@ class ProcedureCallTest extends AgentTestRunner {
           operationName "Transaction.commit"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }
@@ -149,7 +145,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           parent()
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
         span(1) {
@@ -158,7 +153,6 @@ class ProcedureCallTest extends AgentTestRunner {
           childOf span(0)
           errored(true)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
             errorTags(SQLGrammarException, "could not prepare statement")
           }
         }
@@ -167,7 +161,6 @@ class ProcedureCallTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-hibernate"
           }
         }
       }

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -48,7 +48,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -76,7 +75,6 @@ class SpringJpaTest extends AgentTestRunner {
             operationName "call next value for hibernate_sequence"
             spanKind CLIENT
             tags {
-              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" "test"
               "$Tags.DB_USER" "sa"
@@ -92,7 +90,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName ~/insert into Customer \(.*\) values \(.*, \?, \?\)/
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -117,7 +114,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -132,7 +128,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "update Customer set firstName=?, lastName=? where id=?"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -157,7 +152,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_, customer0_.firstName as firstNam2_0_, customer0_.lastName as lastName3_0_ from Customer customer0_ where customer0_.lastName=?"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -180,7 +174,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "select customer0_.id as id1_0_0_, customer0_.firstName as firstNam2_0_0_, customer0_.lastName as lastName3_0_0_ from Customer customer0_ where customer0_.id=?"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -195,7 +188,6 @@ class SpringJpaTest extends AgentTestRunner {
           operationName "delete from Customer where id=?"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
@@ -43,8 +43,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public class UrlInstrumentation extends Instrumenter.Default {
 
-  public static final String COMPONENT = "UrlConnection";
-
   public UrlInstrumentation() {
     super("urlconnection", "httpurlconnection");
   }
@@ -87,7 +85,6 @@ public class UrlInstrumentation extends Instrumenter.Default {
         protocol = protocol != null ? protocol : "url";
 
         final Span span = TRACER.spanBuilder(protocol + ".request").setSpanKind(CLIENT).startSpan();
-        span.setAttribute(Tags.COMPONENT, COMPONENT);
 
         try (final Scope scope = currentContextWith(span)) {
           span.setAttribute(Tags.HTTP_URL, url.toString());

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 
 class HttpUrlConnectionResponseCodeOnlyTest extends HttpClientTest {
@@ -30,11 +29,6 @@ class HttpUrlConnectionResponseCodeOnlyTest extends HttpClientTest {
       callback?.call()
       connection.disconnect()
     }
-  }
-
-  @Override
-  String component() {
-    return HttpUrlConnectionDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -15,7 +15,6 @@
  */
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import spock.lang.Ignore
 import spock.lang.Requires
@@ -47,11 +46,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
     } finally {
       connection.disconnect()
     }
-  }
-
-  @Override
-  String component() {
-    return HttpUrlConnectionDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -103,7 +103,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
@@ -117,7 +116,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
@@ -176,7 +174,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
@@ -190,7 +187,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
@@ -234,7 +230,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"
@@ -294,7 +289,6 @@ class HttpUrlConnectionTest extends HttpClientTest {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" server.address.port
             "$Tags.HTTP_URL" "$url"

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 
 class HttpUrlConnectionUseCachesFalseTest extends HttpClientTest {
@@ -36,11 +35,6 @@ class HttpUrlConnectionUseCachesFalseTest extends HttpClientTest {
     } finally {
       connection.disconnect()
     }
-  }
-
-  @Override
-  String component() {
-    return HttpUrlConnectionDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.httpurlconnection.HttpUrlConnectionDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -35,11 +34,6 @@ class SpringRestTemplateTest extends HttpClientTest {
     ResponseEntity<String> response = restTemplate.exchange(uri, HttpMethod.resolve(method), request, String)
     callback?.call()
     return response.statusCode.value()
-  }
-
-  @Override
-  String component() {
-    return HttpUrlConnectionDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -56,7 +56,6 @@ class UrlConnectionTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "http-url-connection"
             "$MoreTags.NET_PEER_NAME" "localhost"
             "$MoreTags.NET_PEER_PORT" UNUSABLE_PORT
             "$Tags.HTTP_URL" "$url/"

--- a/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -17,7 +17,6 @@ import io.opentelemetry.auto.bootstrap.AgentClassLoader
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.HttpClientDecorator
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.httpurlconnection.UrlInstrumentation
 import io.opentelemetry.auto.test.AgentTestRunner
 
 import static io.opentelemetry.auto.test.utils.PortUtils.UNUSABLE_PORT
@@ -101,7 +100,6 @@ class UrlConnectionTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" UrlInstrumentation.COMPONENT
             "$MoreTags.NET_PEER_PORT" 80
             // FIXME: These tags really make no sense for non-http connections, why do we set them?
             "$Tags.HTTP_URL" "$url"

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.netflix.hystrix.HystrixObservableCommand
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import rx.Observable
 import rx.schedulers.Schedulers
@@ -89,7 +88,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$1"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
@@ -107,7 +105,6 @@ class HystrixObservableChainTest extends AgentTestRunner {
           childOf span(1)
           errored false
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableChainTest\$2"
             "hystrix.group" "OtherGroup"
             "hystrix.circuit-open" false

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -16,7 +16,6 @@
 import com.netflix.hystrix.HystrixObservable
 import com.netflix.hystrix.HystrixObservableCommand
 import com.netflix.hystrix.exception.HystrixRuntimeException
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import rx.Observable
 import rx.schedulers.Schedulers
@@ -82,7 +81,6 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$1"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
@@ -178,7 +176,6 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
@@ -190,7 +187,6 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(1)
           errored false
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
@@ -279,7 +275,6 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"
             "hystrix.circuit-open" false
@@ -291,7 +286,6 @@ class HystrixObservableTest extends AgentTestRunner {
           childOf span(1)
           errored true
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixObservableTest\$3"
             "hystrix.group" "FailingGroup"
             "hystrix.circuit-open" false

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.netflix.hystrix.HystrixCommand
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import spock.lang.Timeout
 
@@ -68,7 +67,6 @@ class HystrixTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$1"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
@@ -132,7 +130,6 @@ class HystrixTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false
@@ -144,7 +141,6 @@ class HystrixTest extends AgentTestRunner {
           childOf span(1)
           errored false
           tags {
-            "$Tags.COMPONENT" "hystrix"
             "hystrix.command" "HystrixTest\$2"
             "hystrix.group" "ExampleGroup"
             "hystrix.circuit-open" false

--- a/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -46,7 +46,6 @@ class SlickTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" SlickUtils.Db()
             "$Tags.DB_USER" SlickUtils.Username()

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
@@ -17,7 +17,6 @@ import com.sun.jersey.api.client.Client
 import com.sun.jersey.api.client.ClientResponse
 import com.sun.jersey.api.client.filter.GZIPContentEncodingFilter
 import com.sun.jersey.api.client.filter.LoggingFilter
-import io.opentelemetry.auto.instrumentation.jaxrsclient.v1_1.JaxRsClientV1Decorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import spock.lang.Shared
 
@@ -41,11 +40,6 @@ class JaxRsClientV1Test extends HttpClientTest {
     callback?.call()
 
     return response.status
-  }
-
-  @Override
-  String component() {
-    return JaxRsClientV1Decorator.DECORATE.getComponentName()
   }
 
   boolean testCircularRedirects() {

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.jaxrsclient.v2_0.JaxRsClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
 import org.glassfish.jersey.client.JerseyClientBuilder
@@ -57,11 +56,6 @@ abstract class JaxRsClientAsyncTest extends HttpClientTest {
     // need to wait for callback to complete in case test is expecting span from it
     latch.await()
     return response.status
-  }
-
-  @Override
-  String component() {
-    return JaxRsClientDecorator.DECORATE.getComponentName()
   }
 
   abstract ClientBuilder builder()

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.jaxrsclient.v2_0.JaxRsClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl
 import org.glassfish.jersey.client.JerseyClientBuilder
@@ -41,11 +40,6 @@ abstract class JaxRsClientTest extends HttpClientTest {
     callback?.call()
 
     return response.status
-  }
-
-  @Override
-  String component() {
-    return JaxRsClientDecorator.DECORATE.getComponentName()
   }
 
   abstract ClientBuilder builder()

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsDecorator.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.auto.bootstrap.WeakMap.Provider.newWeakMap;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.WeakMap;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.ClassHierarchyIterable;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -62,8 +61,6 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     if (span == null) {
       return;
     }
-    span.setAttribute(Tags.COMPONENT, "jax-rs");
-
     if (!resourceName.isEmpty()) {
       span.updateName(resourceName);
     }

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.opentelemetry.auto.bootstrap.WeakMap
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.jaxrs.v1_0.JaxRsAnnotationsDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
 
@@ -46,7 +45,6 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
         span(0) {
           operationName "POST /a"
           tags {
-            "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
       }
@@ -67,14 +65,12 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
           operationName name
           parent()
           tags {
-            "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
           operationName "${className}.call"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
       }

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.dropwizard.testing.junit.ResourceTestRule
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.junit.ClassRule
 import spock.lang.Shared
@@ -46,7 +45,6 @@ class JerseyTest extends AgentTestRunner {
         span(0) {
           operationName expectedResourceName
           tags {
-            "$Tags.COMPONENT" "jax-rs"
           }
         }
 
@@ -54,7 +52,6 @@ class JerseyTest extends AgentTestRunner {
           childOf span(0)
           operationName controllerName
           tags {
-            "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
       }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsDecorator.java
@@ -20,7 +20,6 @@ import static io.opentelemetry.auto.bootstrap.WeakMap.Provider.newWeakMap;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.auto.bootstrap.WeakMap;
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator;
-import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.tooling.ClassHierarchyIterable;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Tracer;
@@ -73,8 +72,6 @@ public class JaxRsAnnotationsDecorator extends BaseDecorator {
     if (span == null) {
       return;
     }
-    span.setAttribute(Tags.COMPONENT, "jax-rs");
-
     if (!resourceName.isEmpty()) {
       span.updateName(resourceName);
     }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.opentelemetry.auto.bootstrap.WeakMap
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.jaxrs.v2_0.JaxRsAnnotationsDecorator
 import io.opentelemetry.auto.test.AgentTestRunner
 
@@ -46,7 +45,6 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
         span(0) {
           operationName "POST /a"
           tags {
-            "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
       }
@@ -67,14 +65,12 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
           operationName name
           parent()
           tags {
-            "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
           operationName "${className}.call"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
       }

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.dropwizard.testing.junit.ResourceTestRule
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.jboss.resteasy.core.Dispatcher
 import org.jboss.resteasy.mock.MockDispatcherFactory
@@ -74,14 +73,12 @@ abstract class JaxRsFilterTest extends AgentTestRunner {
         span(0) {
           operationName parentResourceName != null ? parentResourceName : "test.span"
           tags {
-            "$Tags.COMPONENT" "jax-rs"
           }
         }
         span(1) {
           childOf span(0)
           operationName controllerName
           tags {
-            "$Tags.COMPONENT" "jax-rs-controller"
           }
         }
       }

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
@@ -113,15 +113,8 @@ public class JDBCDecorator extends DatabaseClientDecorator<DBInfo> {
     return sql == null ? DB_QUERY : sql;
   }
 
-  @Override
-  public Span onStatement(final Span span, final String statement) {
-    span.setAttribute(Tags.COMPONENT, "java-jdbc-statement");
-    return super.onStatement(span, statement);
-  }
-
   public Span onPreparedStatement(final Span span, final PreparedStatement statement) {
     final String sql = JDBCMaps.preparedStatements.get(statement);
-    span.setAttribute(Tags.COMPONENT, "java-jdbc-prepared_statement");
     return super.onStatement(span, sql);
   }
 }

--- a/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -192,7 +192,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
@@ -250,7 +249,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
@@ -300,7 +298,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
@@ -350,7 +347,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
@@ -400,7 +396,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
@@ -453,7 +448,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             if (username != null) {
@@ -519,9 +513,7 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           errored false
           tags {
             if (prepareStatement) {
-              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             } else {
-              "$Tags.COMPONENT" "java-jdbc-statement"
             }
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
@@ -578,7 +570,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           operationName "${datasource.class.simpleName}.getConnection"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-connection"
           }
         }
         if (recursive) {
@@ -586,7 +577,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             operationName "${datasource.class.simpleName}.getConnection"
             childOf span(1)
             tags {
-              "$Tags.COMPONENT" "java-jdbc-connection"
             }
           }
         }
@@ -629,7 +619,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_STATEMENT" query
             "$Tags.DB_URL" "testdb://localhost"
@@ -691,7 +680,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" dbName.toLowerCase()
             "$Tags.DB_USER" "SA"
@@ -708,7 +696,6 @@ class JDBCInstrumentationTest extends AgentTestRunner {
             spanKind CLIENT
             errored false
             tags {
-              "$Tags.COMPONENT" "java-jdbc-prepared_statement"
               "$Tags.DB_TYPE" "sql"
               "$Tags.DB_INSTANCE" dbName.toLowerCase()
               "$Tags.DB_USER" "SA"

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -63,7 +63,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
           }
@@ -86,7 +85,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
           }
@@ -97,7 +95,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "GET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "GET"
           }
@@ -120,7 +117,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
           }
@@ -131,7 +127,6 @@ class JedisClientTest extends AgentTestRunner {
           operationName "RANDOMKEY"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "RANDOMKEY"
           }

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -63,7 +63,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
           }
@@ -86,7 +85,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
           }
@@ -97,7 +95,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "GET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "GET"
           }
@@ -120,7 +117,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "SET"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "SET"
           }
@@ -131,7 +127,6 @@ class Jedis30ClientTest extends AgentTestRunner {
           operationName "RANDOMKEY"
           spanKind CLIENT
           tags {
-            "$Tags.COMPONENT" "redis-command"
             "$Tags.DB_TYPE" "redis"
             "$Tags.DB_STATEMENT" "RANDOMKEY"
           }

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
@@ -132,7 +132,6 @@ class JettyHandlerTest extends HttpServerTest<Server> {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" Long
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
@@ -15,7 +15,6 @@
  */
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.jetty.JettyDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import org.eclipse.jetty.server.Request
@@ -69,11 +68,6 @@ class JettyHandlerTest extends HttpServerTest<Server> {
   @Override
   void stopServer(Server server) {
     server.stop()
-  }
-
-  @Override
-  String component() {
-    return JettyDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import com.google.common.io.Files
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -184,7 +183,6 @@ class JMS2Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "jms"
             "span.origin.type" HornetQMessageConsumer.name
           }
         }
@@ -217,7 +215,6 @@ class JMS2Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "jms"
             "span.origin.type" HornetQMessageConsumer.name
           }
         }
@@ -240,7 +237,6 @@ class JMS2Test extends AgentTestRunner {
       spanKind PRODUCER
       errored false
       tags {
-        "$Tags.COMPONENT" "jms"
         "span.origin.type" HornetQMessageProducer.name
       }
     }
@@ -260,7 +256,6 @@ class JMS2Test extends AgentTestRunner {
       errored false
 
       tags {
-        "$Tags.COMPONENT" "jms"
         "span.origin.type" origin.name
       }
     }

--- a/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -147,7 +146,6 @@ class JMS1Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
           }
         }
@@ -180,7 +178,6 @@ class JMS1Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
           }
         }
@@ -228,7 +225,6 @@ class JMS1Test extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "jms"
             "span.origin.type" ActiveMQMessageConsumer.name
           }
         }
@@ -254,7 +250,6 @@ class JMS1Test extends AgentTestRunner {
       errored false
       parent()
       tags {
-        "$Tags.COMPONENT" "jms"
         "span.origin.type" ActiveMQMessageProducer.name
       }
     }
@@ -273,7 +268,6 @@ class JMS1Test extends AgentTestRunner {
       }
       errored false
       tags {
-        "$Tags.COMPONENT" "jms"
         "span.origin.type" origin.name
       }
     }

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -110,7 +110,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
@@ -126,7 +125,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /$jspFileName"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -137,7 +135,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /$jspFileName"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -175,7 +172,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/getQuery.jsp?$queryString"
@@ -191,7 +187,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /getQuery.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.getQuery_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -202,7 +197,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /getQuery.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "getQuery_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -237,7 +231,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/post.jsp"
@@ -253,7 +246,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /post.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.post_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -264,7 +256,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /post.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "post_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -296,7 +287,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanKind SERVER
           errored true
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
@@ -319,7 +309,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /$jspFileName"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -330,7 +319,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /$jspFileName"
           errored true
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -374,7 +362,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeHtml.jsp"
@@ -390,7 +377,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /includes/includeHtml.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -401,7 +387,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /includes/includeHtml.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -432,7 +417,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/includes/includeMulti.jsp"
@@ -448,7 +432,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /includes/includeMulti.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -459,7 +442,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /includes/includeMulti.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -470,7 +452,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -481,7 +462,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -492,7 +472,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -503,7 +482,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -534,7 +512,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           spanKind SERVER
           errored true
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$jspFileName"
@@ -551,7 +528,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           operationName "Compile /$jspFileName"
           errored true
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspClassNamePrefix$jspClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -592,7 +568,6 @@ class JSPInstrumentationBasicTests extends AgentTestRunner {
           // resourceName "GET /$jspWebappContext/$staticFile"
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$staticFile"

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -109,7 +109,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/$forwardFromFileName"
@@ -125,7 +124,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /$forwardFromFileName"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardFromClassPrefix$jspForwardFromClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -136,7 +134,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /$forwardFromFileName"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardFromClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -147,7 +144,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /$forwardDestFileName"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.$jspForwardDestClassPrefix$jspForwardDestClassName"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -158,7 +154,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /$forwardDestFileName"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" jspForwardDestClassName
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/$forwardFromFileName"
@@ -195,7 +190,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToHtml.jsp"
@@ -211,7 +205,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToHtml_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -222,7 +215,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /forwards/forwardToHtml.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToHtml_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -253,7 +245,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToIncludeMulti.jsp"
@@ -269,7 +260,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToIncludeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -280,7 +270,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /forwards/forwardToIncludeMulti.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToIncludeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -291,7 +280,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /includes/includeMulti.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.includes.includeMulti_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -302,7 +290,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /includes/includeMulti.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "includeMulti_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -314,7 +301,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -325,7 +311,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -337,7 +322,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.javaLoopH2_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -348,7 +332,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /common/javaLoopH2.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "javaLoopH2_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToIncludeMulti.jsp"
@@ -380,7 +363,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToJspForward.jsp"
@@ -396,7 +378,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToJspForward_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -407,7 +388,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /forwards/forwardToJspForward.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToJspForward_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -418,7 +398,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToSimpleJava_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -429,7 +408,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /forwards/forwardToSimpleJava.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToSimpleJava_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
@@ -441,7 +419,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /common/loop.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.common.loop_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -452,7 +429,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /common/loop.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "loop_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.forwardOrigin" "/forwards/forwardToJspForward.jsp"
@@ -484,7 +460,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanKind SERVER
           errored true
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToCompileError.jsp"
@@ -501,7 +476,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /forwards/forwardToCompileError.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToCompileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -512,7 +486,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /forwards/forwardToCompileError.jsp"
           errored true
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToCompileError_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl
@@ -524,7 +497,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /compileError.jsp"
           errored true
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.compileError_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -556,7 +528,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           spanKind SERVER
           errored false
           tags {
-            "$Tags.COMPONENT" "java-web-servlet"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/$jspWebappContext/forwards/forwardToNonExistent.jsp"
@@ -572,7 +543,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Compile /forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "servlet.context" "/$jspWebappContext"
             "jsp.classFQCN" "org.apache.jsp.forwards.forwardToNonExistent_jsp"
             "jsp.compiler" "org.apache.jasper.compiler.JDTCompiler"
@@ -583,7 +553,6 @@ class JSPInstrumentationForwardTests extends AgentTestRunner {
           operationName "Render /forwards/forwardToNonExistent.jsp"
           errored false
           tags {
-            "$Tags.COMPONENT" "jsp-http-servlet"
             "span.origin.type" "forwardToNonExistent_jsp"
             "servlet.context" "/$jspWebappContext"
             "jsp.requestURL" reqUrl

--- a/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -103,7 +102,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "java-kafka"
           }
         }
         span(1) {
@@ -112,7 +110,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
           }
@@ -168,7 +165,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "java-kafka"
             "kafka.partition" { it >= 0 }
           }
         }
@@ -178,7 +174,6 @@ class KafkaClientTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
           }

--- a/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import io.grpc.Context
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.context.propagation.HttpTextFormat
 import io.opentelemetry.trace.propagation.HttpTraceContext
@@ -143,7 +142,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "java-kafka"
           }
         }
         // CONSUMER span 0
@@ -153,7 +151,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
           }
@@ -165,7 +162,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
             "asdf" "testing"
@@ -178,7 +174,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(2)
           tags {
-            "$Tags.COMPONENT" "java-kafka"
           }
         }
         // CONSUMER span 0
@@ -188,7 +183,6 @@ class KafkaStreamsTest extends AgentTestRunner {
           errored false
           childOf span(3)
           tags {
-            "$Tags.COMPONENT" "java-kafka"
             "partition" { it >= 0 }
             "offset" 0
             "testing" 123

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -134,7 +134,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
@@ -168,7 +167,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" incorrectPort
             "$Tags.DB_TYPE" "redis"
@@ -194,7 +192,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -227,7 +224,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -274,7 +270,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -307,7 +302,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -358,7 +352,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -369,7 +362,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -410,7 +402,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             errorTags(IllegalStateException, "TestException")
           }
@@ -446,7 +437,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             "db.command.cancelled" true
           }
@@ -467,7 +457,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -488,7 +477,6 @@ class LettuceAsyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -106,7 +106,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -130,7 +129,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -162,7 +160,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -192,7 +189,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -212,7 +208,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             "db.command.results.count" 157
           }
@@ -233,7 +228,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
             "db.command.cancelled" true
             "db.command.results.count" 2
@@ -267,7 +261,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -287,7 +280,6 @@ class LettuceReactiveClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -114,7 +114,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" port
             "$Tags.DB_TYPE" "redis"
@@ -145,7 +144,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$MoreTags.NET_PEER_NAME" HOST
             "$MoreTags.NET_PEER_PORT" incorrectPort
             "$Tags.DB_TYPE" "redis"
@@ -170,7 +168,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -191,7 +188,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -212,7 +208,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -233,7 +228,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -254,7 +248,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -275,7 +268,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -296,7 +288,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -316,7 +307,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }
@@ -336,7 +326,6 @@ class LettuceSyncClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "redis-client"
             "$Tags.DB_TYPE" "redis"
           }
         }

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -254,7 +254,6 @@ class MongoClientTest extends MongoBaseTest {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"
         "$MoreTags.NET_PEER_IP" "127.0.0.1"
         "$MoreTags.NET_PEER_PORT" port

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -257,7 +257,6 @@ class MongoClientTest extends MongoBaseTest {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"
         "$MoreTags.NET_PEER_IP" "127.0.0.1"
         "$MoreTags.NET_PEER_PORT" port

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -297,7 +297,6 @@ class MongoAsyncClientTest extends MongoBaseTest {
         childOf((SpanData) parentSpan)
       }
       tags {
-        "$Tags.COMPONENT" "java-mongo"
         "$MoreTags.NET_PEER_NAME" "localhost"
         "$MoreTags.NET_PEER_IP" "127.0.0.1"
         "$MoreTags.NET_PEER_PORT" port

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
@@ -26,7 +26,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import io.netty.channel.ChannelFuture;
-import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.instrumentation.netty.v4_0.server.NettyHttpServerDecorator;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.context.Scope;
@@ -107,7 +106,6 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
 
       final Span errorSpan =
           NettyHttpServerDecorator.TRACER.spanBuilder("CONNECT").setSpanKind(CLIENT).startSpan();
-      errorSpan.setAttribute(Tags.COMPONENT, "netty");
       try (final Scope scope = currentContextWith(errorSpan)) {
         NettyHttpServerDecorator.DECORATE.onError(errorSpan, cause);
         NettyHttpServerDecorator.DECORATE.beforeFinish(errorSpan);

--- a/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.netty.v4_0.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.asynchttpclient.AsyncCompletionHandler
 import org.asynchttpclient.AsyncHttpClient
@@ -51,11 +50,6 @@ class Netty40ClientTest extends HttpClientTest {
       }
     }).get()
     return response.statusCode
-  }
-
-  @Override
-  String component() {
-    return NettyHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.netty.v4_0.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.asynchttpclient.AsyncCompletionHandler
@@ -96,7 +95,6 @@ class Netty40ClientTest extends HttpClientTest {
             childOf span(0)
             errored true
             tags {
-              "$Tags.COMPONENT" "netty"
               Class errorClass = ConnectException
               try {
                 errorClass = Class.forName('io.netty.channel.AbstractChannel$AnnotatedConnectException')

--- a/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -33,7 +33,6 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
-import io.opentelemetry.auto.instrumentation.netty.v4_0.server.NettyHttpServerDecorator
 import io.opentelemetry.auto.test.base.HttpServerTest
 
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_LENGTH
@@ -117,10 +116,5 @@ class Netty40ServerTest extends HttpServerTest<EventLoopGroup> {
   @Override
   void stopServer(EventLoopGroup server) {
     server?.shutdownGracefully()
-  }
-
-  @Override
-  String component() {
-    NettyHttpServerDecorator.DECORATE.getComponentName()
   }
 }

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
@@ -26,7 +26,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 import com.google.auto.service.AutoService;
 import io.netty.channel.ChannelFuture;
-import io.opentelemetry.auto.instrumentation.api.Tags;
 import io.opentelemetry.auto.instrumentation.netty.v4_1.server.NettyHttpServerDecorator;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.context.Scope;
@@ -107,7 +106,6 @@ public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
 
       final Span errorSpan =
           NettyHttpServerDecorator.TRACER.spanBuilder("CONNECT").setSpanKind(CLIENT).startSpan();
-      errorSpan.setAttribute(Tags.COMPONENT, "netty");
       try (final Scope scope = currentContextWith(errorSpan)) {
         NettyHttpServerDecorator.DECORATE.onError(errorSpan, cause);
         NettyHttpServerDecorator.DECORATE.beforeFinish(errorSpan);

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInitializer
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http.HttpClientCodec
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.netty.v4_1.client.HttpClientTracingHandler
 import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
@@ -106,7 +105,6 @@ class Netty41ClientTest extends HttpClientTest {
             childOf span(0)
             errored true
             tags {
-              "$Tags.COMPONENT" "netty"
               "error.type" AbstractChannel.AnnotatedConnectException.name
               "error.stack" String
               // slightly different message on windows

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -21,7 +21,6 @@ import io.netty.channel.ChannelInitializer
 import io.netty.channel.embedded.EmbeddedChannel
 import io.netty.handler.codec.http.HttpClientCodec
 import io.opentelemetry.auto.instrumentation.netty.v4_1.client.HttpClientTracingHandler
-import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.asynchttpclient.AsyncCompletionHandler
 import org.asynchttpclient.AsyncHttpClient
@@ -60,11 +59,6 @@ class Netty41ClientTest extends HttpClientTest {
       }
     }).get()
     return response.statusCode
-  }
-
-  @Override
-  String component() {
-    return NettyHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -32,7 +32,6 @@ import io.netty.handler.codec.http.HttpServerCodec
 import io.netty.handler.logging.LogLevel
 import io.netty.handler.logging.LoggingHandler
 import io.netty.util.CharsetUtil
-import io.opentelemetry.auto.instrumentation.netty.v4_1.server.NettyHttpServerDecorator
 import io.opentelemetry.auto.test.base.HttpServerTest
 
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH
@@ -116,10 +115,5 @@ class Netty41ServerTest extends HttpServerTest<EventLoopGroup> {
   @Override
   void stopServer(EventLoopGroup server) {
     server?.shutdownGracefully()
-  }
-
-  @Override
-  String component() {
-    NettyHttpServerDecorator.DECORATE.getComponentName()
   }
 }

--- a/instrumentation/okhttp-3.0/src/test/groovy/OkHttp3Test.groovy
+++ b/instrumentation/okhttp-3.0/src/test/groovy/OkHttp3Test.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.okhttp.OkHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import okhttp3.Headers
 import okhttp3.MediaType
@@ -36,11 +35,6 @@ class OkHttp3Test extends HttpClientTest {
     def response = client.newCall(request).execute()
     callback?.call()
     return response.code()
-  }
-
-  @Override
-  String component() {
-    return OkHttpClientDecorator.DECORATE.getComponentName()
   }
 
   boolean testRedirects() {

--- a/instrumentation/play-ws/play-ws-common/src/test/groovy/PlayWSClientTestBase.groovy
+++ b/instrumentation/play-ws/play-ws-common/src/test/groovy/PlayWSClientTestBase.groovy
@@ -53,11 +53,6 @@ abstract class PlayWSClientTestBase extends HttpClientTest {
     system?.terminate()
   }
 
-  @Override
-  String component() {
-    return PlayWSClientDecorator.DECORATE.getComponentName()
-  }
-
   String expectedOperationName() {
     return "play-ws.request"
   }

--- a/instrumentation/play/play-2.4/src/test/groovy/client/PlayWSClientTest.groovy
+++ b/instrumentation/play/play-2.4/src/test/groovy/client/PlayWSClientTest.groovy
@@ -15,7 +15,6 @@
  */
 package client
 
-import io.opentelemetry.auto.instrumentation.netty.v4_0.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import play.libs.ws.WS
 import spock.lang.AutoCleanup
@@ -44,11 +43,6 @@ class PlayWSClientTest extends HttpClientTest {
       it.status
     }
     return status.toCompletableFuture().get()
-  }
-
-  @Override
-  String component() {
-    return NettyHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/play/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -17,7 +17,6 @@ package server
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.netty.v4_0.server.NettyHttpServerDecorator
 import io.opentelemetry.auto.instrumentation.play.v2_4.PlayHttpServerDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
@@ -72,11 +71,6 @@ class PlayServerTest extends HttpServerTest<Server> {
   @Override
   void stopServer(Server server) {
     server.stop()
-  }
-
-  @Override
-  String component() {
-    return NettyHttpServerDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/play/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -17,7 +17,6 @@ package server
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.play.v2_4.PlayHttpServerDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -91,7 +90,6 @@ class PlayServerTest extends HttpServerTest<Server> {
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.getComponentName()
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String

--- a/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -15,7 +15,6 @@
  */
 package server
 
-import io.opentelemetry.auto.instrumentation.akkahttp.AkkaHttpServerDecorator
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.play.v2_6.PlayHttpServerDecorator
@@ -77,11 +76,6 @@ class PlayServerTest extends HttpServerTest<Server> {
   @Override
   void stopServer(Server server) {
     server.stop()
-  }
-
-  @Override
-  String component() {
-    return AkkaHttpServerDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -17,7 +17,6 @@ package server
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.play.v2_6.PlayHttpServerDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -96,7 +95,6 @@ class PlayServerTest extends HttpServerTest<Server> {
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$Tags.COMPONENT" PlayHttpServerDecorator.DECORATE.getComponentName()
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" String
         "$Tags.HTTP_METHOD" String
@@ -123,7 +121,6 @@ class PlayServerTest extends HttpServerTest<Server> {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$Tags.HTTP_STATUS" endpoint.status
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }
         "$Tags.HTTP_METHOD" method

--- a/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -24,7 +24,6 @@ import com.rabbitmq.client.Envelope
 import com.rabbitmq.client.GetResponse
 import com.rabbitmq.client.ShutdownSignalException
 import io.opentelemetry.auto.instrumentation.api.MoreTags
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -364,7 +363,6 @@ class RabbitMQTest extends AgentTestRunner {
       errored exception != null
 
       tags {
-        "$Tags.COMPONENT" "rabbitmq-amqp"
         "$MoreTags.NET_PEER_NAME" { it == null || it instanceof String }
         "$MoreTags.NET_PEER_IP" { "127.0.0.1" }
         "$MoreTags.NET_PEER_PORT" { it == null || it instanceof Long }

--- a/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
@@ -86,7 +86,6 @@ class RatpackOtherTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"
@@ -100,7 +99,6 @@ class RatpackOtherTest extends AgentTestRunner {
           childOf span(0)
           errored false
           tags {
-            "$Tags.COMPONENT" "ratpack"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "${app.address.resolve(path)}"

--- a/instrumentation/ratpack-1.4/src/test/groovy/client/RatpackHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/client/RatpackHttpClientTest.groovy
@@ -15,7 +15,6 @@
  */
 package client
 
-import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import ratpack.exec.ExecResult
 import ratpack.http.client.HttpClient
@@ -49,11 +48,6 @@ class RatpackHttpClientTest extends HttpClientTest {
       }
     }
     return result.value
-  }
-
-  @Override
-  String component() {
-    return NettyHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -17,7 +17,6 @@ package server
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.netty.v4_1.server.NettyHttpServerDecorator
 import io.opentelemetry.auto.instrumentation.ratpack.RatpackServerDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
@@ -108,11 +107,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
   @Override
   void stopServer(EmbeddedApp server) {
     server.close()
-  }
-
-  @Override
-  String component() {
-    return NettyHttpServerDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -17,7 +17,6 @@ package server
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.ratpack.RatpackServerDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -127,7 +126,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
       errored endpoint == ERROR || endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$Tags.COMPONENT" RatpackServerDecorator.DECORATE.getComponentName()
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" Long
         "$Tags.HTTP_URL" String
@@ -155,7 +153,6 @@ class RatpackHttpServerTest extends HttpServerTest<EmbeddedApp> {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_PORT" Long
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }

--- a/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.PortUtils
 import rmi.app.Greeter
@@ -58,7 +57,6 @@ class RmiTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "rmi-client"
             "span.origin.type" Greeter.canonicalName
           }
         }
@@ -66,7 +64,6 @@ class RmiTest extends AgentTestRunner {
           operationName "Server.hello"
           spanKind SERVER
           tags {
-            "$Tags.COMPONENT" "rmi-server"
             "span.origin.type" server.class.canonicalName
           }
         }
@@ -118,7 +115,6 @@ class RmiTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "rmi-client"
             "span.origin.type" Greeter.canonicalName
             errorTags(RuntimeException, String)
           }
@@ -128,7 +124,6 @@ class RmiTest extends AgentTestRunner {
           spanKind SERVER
           errored true
           tags {
-            "$Tags.COMPONENT" "rmi-server"
             "span.origin.type" server.class.canonicalName
             errorTags(RuntimeException, String)
           }
@@ -161,7 +156,6 @@ class RmiTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "rmi-client"
             "span.origin.type" Greeter.canonicalName
           }
         }
@@ -170,7 +164,6 @@ class RmiTest extends AgentTestRunner {
           operationName "ServerLegacy.hello"
           spanKind SERVER
           tags {
-            "$Tags.COMPONENT" "rmi-server"
             "span.origin.type" server.class.canonicalName
           }
         }

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
@@ -98,7 +98,6 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" Long
         "$Tags.HTTP_STATUS" endpoint.status

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
@@ -15,7 +15,6 @@
  */
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.servlet.v3_0.Servlet3Decorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import org.apache.catalina.servlets.DefaultServlet
@@ -79,11 +78,6 @@ class GlassFishServerTest extends HttpServerTest<GlassFish> {
   @Override
   void stopServer(GlassFish server) {
     server.stop()
-  }
-
-  @Override
-  String component() {
-    return Servlet3Decorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/servlet/request-2.3/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/request-2.3/src/test/groovy/JettyServlet2Test.groovy
@@ -15,7 +15,6 @@
  */
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.servlet.v2_3.Servlet2Decorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import org.eclipse.jetty.server.Server
@@ -74,11 +73,6 @@ class JettyServlet2Test extends HttpServerTest<Server> {
   @Override
   URI buildAddress() {
     return new URI("http://localhost:$port/$CONTEXT/")
-  }
-
-  @Override
-  String component() {
-    return Servlet2Decorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/servlet/request-2.3/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/request-2.3/src/test/groovy/JettyServlet2Test.groovy
@@ -93,7 +93,6 @@ class JettyServlet2Test extends HttpServerTest<Server> {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" "127.0.0.1"
         // No peer port
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }

--- a/instrumentation/servlet/request-3.0/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/AbstractServlet3Test.groovy
@@ -15,7 +15,6 @@
  */
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.servlet.v3_0.Servlet3Decorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.trace.Span
@@ -34,11 +33,6 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
   @Override
   URI buildAddress() {
     return new URI("http://localhost:$port/$context/")
-  }
-
-  @Override
-  String component() {
-    return Servlet3Decorator.DECORATE.getComponentName()
   }
 
   // FIXME: Add authentication tests back in...

--- a/instrumentation/servlet/request-3.0/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/AbstractServlet3Test.groovy
@@ -81,7 +81,6 @@ abstract class AbstractServlet3Test<SERVER, CONTEXT> extends HttpServerTest<SERV
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" Long
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }

--- a/instrumentation/servlet/src/test/groovy/FilterTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/FilterTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
 import javax.servlet.Filter
@@ -56,7 +55,6 @@ class FilterTest extends AgentTestRunner {
           operationName "${filter.class.simpleName}.doFilter"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-filter"
           }
         }
       }
@@ -93,7 +91,6 @@ class FilterTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-filter"
             errorTags(ex.class, ex.message)
           }
         }

--- a/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import spock.lang.Subject
 
@@ -74,21 +73,18 @@ class HttpServletResponseTest extends AgentTestRunner {
           operationName "HttpServletResponse.sendError"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-response"
           }
         }
         span(2) {
           operationName "HttpServletResponse.sendError"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-response"
           }
         }
         span(3) {
           operationName "HttpServletResponse.sendRedirect"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-response"
           }
         }
       }
@@ -127,7 +123,6 @@ class HttpServletResponseTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-response"
             errorTags(ex.class, ex.message)
           }
         }

--- a/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import groovy.servlet.AbstractHttpServlet
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 
 import javax.servlet.http.HttpServletRequest
@@ -59,14 +58,12 @@ class HttpServletTest extends AgentTestRunner {
           operationName "HttpServlet.service"
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-service"
           }
         }
         span(2) {
           operationName "${expectedResourceName}.doGet"
           childOf span(1)
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-service"
           }
         }
       }
@@ -109,7 +106,6 @@ class HttpServletTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-service"
             errorTags(ex.class, ex.message)
           }
         }
@@ -118,7 +114,6 @@ class HttpServletTest extends AgentTestRunner {
           childOf span(1)
           errored true
           tags {
-            "$Tags.COMPONENT" "java-web-servlet-service"
             errorTags(ex.class, ex.message)
           }
         }

--- a/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.trace.Span
 
@@ -66,7 +65,6 @@ class RequestDispatcherTest extends AgentTestRunner {
           childOf span(0)
           tags {
             "dispatcher.target" target
-            "$Tags.COMPONENT" "java-web-servlet-dispatcher"
           }
         }
         basicSpan(it, 2, "$operation-child", span(1))
@@ -114,7 +112,6 @@ class RequestDispatcherTest extends AgentTestRunner {
           errored true
           tags {
             "dispatcher.target" target
-            "$Tags.COMPONENT" "java-web-servlet-dispatcher"
             errorTags(ex.class, ex.message)
           }
         }

--- a/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -66,7 +66,6 @@ class SparkJavaBasedTest extends AgentTestRunner {
           errored false
           parent()
           tags {
-            "$Tags.COMPONENT" "jetty-handler"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" "http://localhost:$port/param/asdf1234"

--- a/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -73,7 +73,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind INTERNAL
           errored false
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
@@ -81,7 +80,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -107,7 +105,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind INTERNAL
           errored false
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // insert
@@ -115,7 +112,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -141,7 +137,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind INTERNAL
           errored false
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
@@ -149,7 +144,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -163,7 +157,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -187,7 +180,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind INTERNAL
           errored false
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
@@ -195,7 +187,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -219,7 +210,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind INTERNAL
           errored false
           tags {
-            "$Tags.COMPONENT" "spring-data"
           }
         }
         span(1) { // select
@@ -227,7 +217,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"
@@ -241,7 +230,6 @@ class SpringJpaTest extends AgentTestRunner {
           spanKind CLIENT
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "java-jdbc-prepared_statement"
             "$Tags.DB_TYPE" "sql"
             "$Tags.DB_INSTANCE" "test"
             "$Tags.DB_USER" "sa"

--- a/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
@@ -35,7 +34,6 @@ class SpringSchedulingTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$Tags.COMPONENT" "spring-scheduling"
           }
         }
       }
@@ -58,7 +56,6 @@ class SpringSchedulingTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$Tags.COMPONENT" "spring-scheduling"
           }
         }
       }

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/SpringWebfluxTest.groovy
@@ -71,7 +71,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" url
@@ -90,7 +89,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "spring-webflux-controller"
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -137,7 +135,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" url
@@ -156,7 +153,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "spring-webflux-controller"
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -207,7 +203,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" url
@@ -221,7 +216,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "spring-webflux-controller"
             "handler.type" "org.springframework.web.reactive.resource.ResourceWebHandler"
             errorTags(ResponseStatusException, String)
           }
@@ -250,7 +244,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" url
@@ -263,7 +256,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "spring-webflux-controller"
             "request.predicate" "(POST && /echo)"
             "handler.type" { String tagVal ->
               return tagVal.contains(EchoHandlerFunction.getName())
@@ -298,7 +290,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           errored true
           parent()
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" url
@@ -318,7 +309,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           childOf span(0)
           errored true
           tags {
-            "$Tags.COMPONENT" "spring-webflux-controller"
             if (annotatedMethod == null) {
               // Functional API
               "request.predicate" "(GET && $urlPathWithVariables)"
@@ -363,7 +353,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" url
@@ -376,7 +365,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "spring-webflux-controller"
             "request.predicate" "(GET && /double-greet-redirect)"
             "handler.type" { String tagVal ->
               return (tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
@@ -391,7 +379,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind SERVER
           parent()
           tags {
-            "$Tags.COMPONENT" "netty"
             "$MoreTags.NET_PEER_IP" "127.0.0.1"
             "$MoreTags.NET_PEER_PORT" Long
             "$Tags.HTTP_URL" finalUrl
@@ -404,7 +391,6 @@ class SpringWebfluxTest extends AgentTestRunner {
           spanKind INTERNAL
           childOf span(0)
           tags {
-            "$Tags.COMPONENT" "spring-webflux-controller"
             "request.predicate" "(GET && /double-greet)"
             "handler.type" { String tagVal ->
               return tagVal.contains(INNER_HANDLER_FUNCTION_CLASS_TAG_PREFIX)
@@ -434,7 +420,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             spanKind SERVER
             parent()
             tags {
-              "$Tags.COMPONENT" "netty"
               "$MoreTags.NET_PEER_IP" "127.0.0.1"
               "$MoreTags.NET_PEER_PORT" Long
               "$Tags.HTTP_URL" url
@@ -453,7 +438,6 @@ class SpringWebfluxTest extends AgentTestRunner {
             spanKind INTERNAL
             childOf span(0)
             tags {
-              "$Tags.COMPONENT" "spring-webflux-controller"
               if (annotatedMethod == null) {
                 // Functional API
                 "request.predicate" "(GET && $urlPathWithVariables)"

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
@@ -17,7 +17,6 @@ package client
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.springframework.http.HttpMethod
@@ -61,7 +60,6 @@ class SpringWebfluxHttpClientTest extends HttpClientTest {
         spanKind CLIENT
         errored exception != null
         tags {
-          "$Tags.COMPONENT" NettyHttpClientDecorator.DECORATE.getComponentName()
           "$MoreTags.NET_PEER_NAME" "localhost"
           "$MoreTags.NET_PEER_PORT" uri.port
           "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
@@ -18,7 +18,6 @@ package client
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
-import io.opentelemetry.auto.instrumentation.springwebflux.client.SpringWebfluxHttpClientDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpClientTest
 import org.springframework.http.HttpMethod
@@ -50,12 +49,6 @@ class SpringWebfluxHttpClientTest extends HttpClientTest {
 
     response.statusCode().value()
   }
-
-  @Override
-  String component() {
-    return SpringWebfluxHttpClientDecorator.DECORATE.getComponentName()
-  }
-
 
   @Override
   // parent spanRef must be cast otherwise it breaks debugging classloading (junit loads it early)

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -17,7 +17,6 @@ package test
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebHttpServerDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -91,7 +90,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
       errored endpoint == EXCEPTION
       childOf((SpanData) parent)
       tags {
-        "$Tags.COMPONENT" SpringWebHttpServerDecorator.DECORATE.getComponentName()
         if (endpoint == EXCEPTION) {
           errorTags(Exception, EXCEPTION.body)
         }
@@ -112,7 +110,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" Long
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -17,7 +17,6 @@ package test
 
 import io.opentelemetry.auto.instrumentation.api.MoreTags
 import io.opentelemetry.auto.instrumentation.api.Tags
-import io.opentelemetry.auto.instrumentation.servlet.v3_0.Servlet3Decorator
 import io.opentelemetry.auto.instrumentation.springwebmvc.SpringWebHttpServerDecorator
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.auto.test.base.HttpServerTest
@@ -48,11 +47,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
   @Override
   void stopServer(ConfigurableApplicationContext ctx) {
     ctx.close()
-  }
-
-  @Override
-  String component() {
-    return Servlet3Decorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -84,7 +84,6 @@ class SpringBootBasedTest extends HttpServerTest<ConfigurableApplicationContext>
       spanKind INTERNAL
       errored false
       tags {
-        "$Tags.COMPONENT" "spring-webmvc"
         "view.type" RedirectView.name
       }
     }

--- a/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
@@ -639,7 +639,6 @@ class SpymemcachedTest extends AgentTestRunner {
       errored(error != null && error != "canceled")
 
       tags {
-        "$Tags.COMPONENT" CompletionListener.COMPONENT_NAME
         "$Tags.DB_TYPE" CompletionListener.DB_TYPE
 
         if (error == "canceled") {

--- a/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.traceannotation.TraceAnnotationsInstrumentation
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.ConfigUtils
@@ -53,7 +52,6 @@ class ConfiguredTraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           operationName "AnnotationTracedCallable.call"
           tags {
-            "$Tags.COMPONENT" "trace"
           }
         }
       }

--- a/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.ConfigUtils
 import io.opentelemetry.test.annotation.SayTracedHello
@@ -43,7 +42,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored false
           tags {
             "myattr" "test"
-            "$Tags.COMPONENT" "trace"
           }
         }
       }
@@ -64,7 +62,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored false
           tags {
             "myattr" "test2"
-            "$Tags.COMPONENT" "trace"
           }
         }
         span(1) {
@@ -73,7 +70,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored false
           tags {
             "myattr" "test"
-            "$Tags.COMPONENT" "trace"
           }
         }
         span(2) {
@@ -82,7 +78,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           errored false
           tags {
             "myattr" "test"
-            "$Tags.COMPONENT" "trace"
           }
         }
       }
@@ -106,7 +101,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
           operationName "SayTracedHello.sayERROR"
           errored true
           tags {
-            "$Tags.COMPONENT" "trace"
             errorTags(error.class)
           }
         }
@@ -125,7 +119,6 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           operationName "SayTracedHello\$1.call"
           tags {
-            "$Tags.COMPONENT" "trace"
           }
         }
       }
@@ -147,14 +140,12 @@ class TraceAnnotationsTest extends AgentTestRunner {
         span(0) {
           operationName "SayTracedHello\$1.call"
           tags {
-            "$Tags.COMPONENT" "trace"
           }
         }
         trace(1, 1) {
           span(0) {
             operationName "TraceAnnotationsTest\$1.call"
             tags {
-              "$Tags.COMPONENT" "trace"
             }
           }
         }

--- a/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import io.opentelemetry.auto.instrumentation.api.Tags
 import io.opentelemetry.auto.instrumentation.traceannotation.TraceConfigInstrumentation
 import io.opentelemetry.auto.test.AgentTestRunner
 import io.opentelemetry.auto.test.utils.ConfigUtils
@@ -51,7 +50,6 @@ class TraceConfigTest extends AgentTestRunner {
         span(0) {
           operationName "ConfigTracedCallable.call"
           tags {
-            "$Tags.COMPONENT" "trace"
           }
         }
       }

--- a/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
@@ -154,7 +154,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -199,7 +198,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Call"
             "twilio.account" "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
             "twilio.sid" "CAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -266,7 +264,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -278,7 +275,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
@@ -361,7 +357,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -373,7 +368,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
@@ -385,7 +379,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
@@ -476,7 +469,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -488,7 +480,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -500,7 +491,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
@@ -512,7 +502,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "apache-httpclient"
             "$MoreTags.NET_PEER_NAME" String
             "$Tags.HTTP_URL" String
             "$Tags.HTTP_METHOD" String
@@ -567,7 +556,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
           }
         }
@@ -599,7 +587,6 @@ class TwilioClientTest extends AgentTestRunner {
           parent()
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -653,7 +640,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -665,7 +651,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored false
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             "twilio.type" "com.twilio.rest.api.v2010.account.Message"
             "twilio.account" "AC14984e09e497506cf0d5eb59b1f6ace7"
             "twilio.sid" "MMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
@@ -732,7 +717,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
           }
         }
@@ -741,7 +725,6 @@ class TwilioClientTest extends AgentTestRunner {
           spanKind CLIENT
           errored true
           tags {
-            "$Tags.COMPONENT" "twilio-sdk"
             errorTags(ApiException, "Testing Failure")
           }
         }

--- a/instrumentation/vertx-testing/src/test/groovy/client/VertxHttpClientTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/client/VertxHttpClientTest.groovy
@@ -15,7 +15,6 @@
  */
 package client
 
-import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import io.vertx.core.Vertx
 import io.vertx.core.VertxOptions
@@ -47,11 +46,6 @@ class VertxHttpClientTest extends HttpClientTest {
     request.end()
 
     return future.get().statusCode()
-  }
-
-  @Override
-  String component() {
-    return NettyHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/vertx-testing/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -15,7 +15,6 @@
  */
 package client
 
-import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import io.vertx.circuitbreaker.CircuitBreakerOptions
 import io.vertx.core.VertxOptions
@@ -63,11 +62,6 @@ class VertxRxCircuitBreakerWebClientTest extends HttpClientTest {
       }
     })
     return future.get()
-  }
-
-  @Override
-  String component() {
-    return NettyHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/vertx-testing/src/test/groovy/client/VertxRxWebClientTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/client/VertxRxWebClientTest.groovy
@@ -15,7 +15,6 @@
  */
 package client
 
-import io.opentelemetry.auto.instrumentation.netty.v4_1.client.NettyHttpClientDecorator
 import io.opentelemetry.auto.test.base.HttpClientTest
 import io.vertx.core.VertxOptions
 import io.vertx.core.http.HttpMethod
@@ -42,11 +41,6 @@ class VertxRxWebClientTest extends HttpClientTest {
       .map { it.statusCode() }
       .toObservable()
       .blockingFirst()
-  }
-
-  @Override
-  String component() {
-    return NettyHttpClientDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/instrumentation/vertx-testing/src/test/groovy/server/VertxHttpServerTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/server/VertxHttpServerTest.groovy
@@ -15,7 +15,6 @@
  */
 package server
 
-import io.opentelemetry.auto.instrumentation.netty.v4_1.server.NettyHttpServerDecorator
 import io.opentelemetry.auto.test.base.HttpServerTest
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.DeploymentOptions
@@ -64,11 +63,6 @@ class VertxHttpServerTest extends HttpServerTest<Vertx> {
   @Override
   void stopServer(Vertx server) {
     server.close()
-  }
-
-  @Override
-  String component() {
-    return NettyHttpServerDecorator.DECORATE.getComponentName()
   }
 
   @Override

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
@@ -70,17 +70,12 @@ abstract class HttpClientTest extends AgentTestRunner {
     }
   }
 
-  @Shared
-  String component = component()
-
   /**
    * Make the request and return the status code response
    * @param method
    * @return
    */
   abstract int doRequest(String method, URI uri, Map<String, String> headers = [:], Closure callback = null)
-
-  abstract String component()
 
   Integer statusOnRedirectError() {
     return null
@@ -317,7 +312,6 @@ abstract class HttpClientTest extends AgentTestRunner {
       spanKind CLIENT
       errored exception != null
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_NAME" "localhost"
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$MoreTags.NET_PEER_PORT" uri.port

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
@@ -61,9 +61,6 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
     return new URI("http://localhost:$port/")
   }
 
-  @Shared
-  String component = component()
-
   def setupSpec() {
     server = startServer(port)
     println getClass().name + " http server started at: http://localhost:$port/"
@@ -82,8 +79,6 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
   }
 
   abstract void stopServer(SERVER server)
-
-  abstract String component()
 
   String expectedOperationName(String method) {
     return method != null ? "HTTP $method" : HttpServerDecorator.DEFAULT_SPAN_NAME
@@ -418,7 +413,6 @@ abstract class HttpServerTest<SERVER> extends AgentTestRunner {
         parent()
       }
       tags {
-        "$Tags.COMPONENT" component
         "$MoreTags.NET_PEER_PORT" Long
         "$MoreTags.NET_PEER_IP" { it == null || it == "127.0.0.1" } // Optional
         "$Tags.HTTP_URL" { it == "${endpoint.resolve(address)}" || it == "${endpoint.resolveWithoutFragment(address)}" }


### PR DESCRIPTION
I'd like remove the `service.name` and `component` attributes in the beta release, as I think they are some of the first things people will notice, as they are holdovers from OpenTracing.

(this PR is based on top of #290, so that one needs to be merged first)