### PR TITLE
Do not instrument exporter class loader

### DIFF
--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ClassLoaderMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ClassLoaderMatcher.java
@@ -57,6 +57,8 @@ public final class ClassLoaderMatcher {
         CacheBuilder.newBuilder().weakKeys().concurrencyLevel(CACHE_CONCURRENCY).build();
     private static final String AGENT_CLASSLOADER_NAME =
         "io.opentelemetry.auto.bootstrap.AgentClassLoader";
+    private static final String EXPORTER_CLASSLOADER_NAME =
+        "io.opentelemetry.auto.tooling.ExporterClassLoader";
 
     private SkipClassLoaderMatcher() {}
 
@@ -92,6 +94,7 @@ public final class ClassLoaderMatcher {
         case "org.apache.cxf.common.util.ASMHelper$TypeHelperClassLoader":
         case "sun.misc.Launcher$ExtClassLoader":
         case AGENT_CLASSLOADER_NAME:
+        case EXPORTER_CLASSLOADER_NAME:
           return true;
       }
       return false;

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ClassLoaderMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ClassLoaderMatcherTest.groovy
@@ -17,6 +17,7 @@ package io.opentelemetry.auto.test
 
 import io.opentelemetry.auto.bootstrap.AgentClassLoader
 import io.opentelemetry.auto.tooling.ClassLoaderMatcher
+import io.opentelemetry.auto.tooling.ExporterClassLoader
 import io.opentelemetry.auto.util.test.AgentSpecification
 
 class ClassLoaderMatcherTest extends AgentSpecification {
@@ -27,6 +28,13 @@ class ClassLoaderMatcherTest extends AgentSpecification {
     final URLClassLoader agentLoader = new AgentClassLoader(root, null, null)
     expect:
     ClassLoaderMatcher.skipClassLoader().matches(agentLoader)
+  }
+
+  def "skips exporter classloader"() {
+    setup:
+    final URLClassLoader exporterLoader = new ExporterClassLoader(new URL[0], null)
+    expect:
+    ClassLoaderMatcher.skipClassLoader().matches(exporterLoader)
   }
 
   def "does not skip empty classloader"() {
@@ -44,5 +52,10 @@ class ClassLoaderMatcherTest extends AgentSpecification {
   def "AgentClassLoader class name is hardcoded in ClassLoaderMatcher"() {
     expect:
     AgentClassLoader.name == "io.opentelemetry.auto.bootstrap.AgentClassLoader"
+  }
+
+  def "ExporterClassLoader class name is hardcoded in ClassLoaderMatcher"() {
+    expect:
+    ExporterClassLoader.name == "io.opentelemetry.auto.tooling.ExporterClassLoader"
   }
 }


### PR DESCRIPTION
Once gRPC instrumentation was fixed in #297, it started getting applied to Jaeger gRPC exporter, which caused the exporter to fail. We shouldn't be applying instrumentation to the exporter class loader anyways.