### PR TITLE
More consistent instrumentation names

### DIFF
--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
@@ -50,7 +50,7 @@ import scala.util.Try;
 @AutoService(Instrumenter.class)
 public final class AkkaHttpClientInstrumentation extends Instrumenter.Default {
   public AkkaHttpClientInstrumentation() {
-    super("akka-http", "akka-http-client");
+    super("akka-http");
   }
 
   @Override

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
@@ -49,7 +49,7 @@ import scala.runtime.AbstractFunction1;
 @AutoService(Instrumenter.class)
 public final class AkkaHttpServerInstrumentation extends Instrumenter.Default {
   public AkkaHttpServerInstrumentation() {
-    super("akka-http", "akka-http-server");
+    super("akka-http");
   }
 
   @Override

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -55,7 +55,7 @@ import org.apache.http.protocol.HttpContext;
 public class ApacheHttpAsyncClientInstrumentation extends Instrumenter.Default {
 
   public ApacheHttpAsyncClientInstrumentation() {
-    super("httpasyncclient", "apache-httpasyncclient");
+    super("apache-httpasyncclient");
   }
 
   @Override

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
@@ -42,7 +42,7 @@ import org.apache.http.HttpRequest;
 public class ApacheHttpClientRedirectInstrumentation extends Instrumenter.Default {
 
   public ApacheHttpClientRedirectInstrumentation() {
-    super("httpasyncclient", "apache-httpasyncclient");
+    super("apache-httpasyncclient");
   }
 
   @Override

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
@@ -58,7 +58,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 public class ApacheHttpClientInstrumentation extends Instrumenter.Default {
 
   public ApacheHttpClientInstrumentation() {
-    super("httpclient", "apache-httpclient", "apache-http-client");
+    super("apache-httpclient");
   }
 
   @Override

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AbstractAwsClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AbstractAwsClientInstrumentation.java
@@ -18,10 +18,9 @@ package io.opentelemetry.auto.instrumentation.awssdk.v2_2;
 import io.opentelemetry.auto.tooling.Instrumenter;
 
 public abstract class AbstractAwsClientInstrumentation extends Instrumenter.Default {
-  private static final String INSTRUMENTATION_NAME = "aws-sdk";
 
   public AbstractAwsClientInstrumentation() {
-    super(INSTRUMENTATION_NAME);
+    super("aws-sdk");
   }
 
   @Override

--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizardviews/DropwizardViewInstrumentation.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizardviews/DropwizardViewInstrumentation.java
@@ -43,7 +43,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class DropwizardViewInstrumentation extends Instrumenter.Default {
 
   public DropwizardViewInstrumentation() {
-    super("dropwizard", "dropwizard-view");
+    super("dropwizard-views");
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v5_0/Elasticsearch5RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v5_0/Elasticsearch5RestClientInstrumentation.java
@@ -39,7 +39,7 @@ import org.elasticsearch.client.ResponseListener;
 public class Elasticsearch5RestClientInstrumentation extends Instrumenter.Default {
 
   public Elasticsearch5RestClientInstrumentation() {
-    super("elasticsearch", "elasticsearch-rest", "elasticsearch-rest-5");
+    super("elasticsearch-rest-5.0", "elasticsearch-rest", "elasticsearch");
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentation.java
@@ -40,7 +40,7 @@ import org.elasticsearch.client.ResponseListener;
 public class Elasticsearch6RestClientInstrumentation extends Instrumenter.Default {
 
   public Elasticsearch6RestClientInstrumentation() {
-    super("elasticsearch", "elasticsearch-rest", "elasticsearch-rest-6");
+    super("elasticsearch-rest-6.0", "elasticsearch-rest", "elasticsearch");
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v2_0/Elasticsearch2TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v2_0/Elasticsearch2TransportClientInstrumentation.java
@@ -42,7 +42,7 @@ import org.elasticsearch.action.ActionResponse;
 public class Elasticsearch2TransportClientInstrumentation extends Instrumenter.Default {
 
   public Elasticsearch2TransportClientInstrumentation() {
-    super("elasticsearch", "elasticsearch-transport", "elasticsearch-transport-2");
+    super("elasticsearch-transport-2.0", "elasticsearch-transport", "elasticsearch");
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentation.java
@@ -42,7 +42,7 @@ import org.elasticsearch.action.ActionResponse;
 public class Elasticsearch5TransportClientInstrumentation extends Instrumenter.Default {
 
   public Elasticsearch5TransportClientInstrumentation() {
-    super("elasticsearch", "elasticsearch-transport", "elasticsearch-transport-5");
+    super("elasticsearch-transport-5.0", "elasticsearch-transport", "elasticsearch");
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -43,7 +43,7 @@ import org.elasticsearch.action.ActionResponse;
 public class Elasticsearch53TransportClientInstrumentation extends Instrumenter.Default {
 
   public Elasticsearch53TransportClientInstrumentation() {
-    super("elasticsearch", "elasticsearch-transport", "elasticsearch-transport-5");
+    super("elasticsearch-transport-5.0", "elasticsearch-transport", "elasticsearch");
   }
 
   @Override

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentation.java
@@ -46,7 +46,7 @@ import org.elasticsearch.action.ActionResponse;
 public class Elasticsearch6TransportClientInstrumentation extends Instrumenter.Default {
 
   public Elasticsearch6TransportClientInstrumentation() {
-    super("elasticsearch", "elasticsearch-transport", "elasticsearch-transport-6");
+    super("elasticsearch-transport-6.0", "elasticsearch-transport", "elasticsearch");
   }
 
   @Override

--- a/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeInstrumentation.java
+++ b/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeInstrumentation.java
@@ -43,7 +43,7 @@ import org.apache.geode.cache.Region;
 @AutoService(Instrumenter.class)
 public class GeodeInstrumentation extends Instrumenter.Default {
   public GeodeInstrumentation() {
-    super("geode", "geode-client");
+    super("geode");
   }
 
   @Override

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
@@ -40,7 +40,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 public class GrpcClientBuilderInstrumentation extends Instrumenter.Default {
 
   public GrpcClientBuilderInstrumentation() {
-    super("grpc", "grpc-client");
+    super("grpc");
   }
 
   @Override

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -33,7 +33,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class GrpcServerBuilderInstrumentation extends Instrumenter.Default {
 
   public GrpcServerBuilderInstrumentation() {
-    super("grpc", "grpc-server");
+    super("grpc");
   }
 
   @Override

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/AbstractHibernateInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/AbstractHibernateInstrumentation.java
@@ -25,7 +25,7 @@ import org.hibernate.transaction.JBossTransactionManagerLookup;
 public abstract class AbstractHibernateInstrumentation extends Instrumenter.Default {
 
   public AbstractHibernateInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super("hibernate");
   }
 
   @Override

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/AbstractHibernateInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/AbstractHibernateInstrumentation.java
@@ -24,7 +24,7 @@ import org.hibernate.SharedSessionContract;
 public abstract class AbstractHibernateInstrumentation extends Instrumenter.Default {
 
   public AbstractHibernateInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super("hibernate");
   }
 
   @Override

--- a/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
@@ -39,7 +39,7 @@ import org.hibernate.procedure.ProcedureCall;
 public class ProcedureCallInstrumentation extends Instrumenter.Default {
 
   public ProcedureCallInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super("hibernate");
   }
 
   @Override

--- a/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/SessionInstrumentation.java
@@ -43,7 +43,7 @@ import org.hibernate.procedure.ProcedureCall;
 public class SessionInstrumentation extends Instrumenter.Default {
 
   public SessionInstrumentation() {
-    super("hibernate", "hibernate-core");
+    super("hibernate");
   }
 
   @Override

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentation.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentation.java
@@ -50,7 +50,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 public class HttpUrlConnectionInstrumentation extends Instrumenter.Default {
 
   public HttpUrlConnectionInstrumentation() {
-    super("httpurlconnection");
+    super("http-url-connection");
   }
 
   @Override

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
@@ -44,7 +44,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class UrlInstrumentation extends Instrumenter.Default {
 
   public UrlInstrumentation() {
-    super("urlconnection", "httpurlconnection");
+    super("http-url-connection", "url-connection");
   }
 
   @Override

--- a/instrumentation/java-class-loader/src/main/java/io/opentelemetry/auto/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/java-class-loader/src/main/java/io/opentelemetry/auto/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
@@ -49,7 +49,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class ClassLoaderInstrumentation extends Instrumenter.Default {
   public ClassLoaderInstrumentation() {
-    super("class-loader");
+    super("java-class-loader");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -34,8 +34,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 @Slf4j
 public abstract class AbstractExecutorInstrumentation extends Instrumenter.Default {
 
-  public static final String EXEC_NAME = "java_concurrent";
-
   private final boolean TRACE_ALL_EXECUTORS = Config.get().isTraceExecutorsAll();
 
   /**
@@ -52,7 +50,7 @@ public abstract class AbstractExecutorInstrumentation extends Instrumenter.Defau
   private final Collection<String> WHITELISTED_EXECUTORS_PREFIXES;
 
   public AbstractExecutorInstrumentation(final String... additionalNames) {
-    super(EXEC_NAME, additionalNames);
+    super("java-concurrent", additionalNames);
 
     if (TRACE_ALL_EXECUTORS) {
       log.info("Tracing all executors enabled.");

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaExecutorInstrumentation.java
@@ -42,7 +42,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class AkkaExecutorInstrumentation extends AbstractExecutorInstrumentation {
 
   public AkkaExecutorInstrumentation() {
-    super(EXEC_NAME + ".akka_fork_join");
+    super("java-concurrent-akka");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaForkJoinTaskInstrumentation.java
@@ -55,7 +55,7 @@ public final class AkkaForkJoinTaskInstrumentation extends Instrumenter.Default 
   static final String TASK_CLASS_NAME = "akka.dispatch.forkjoin.ForkJoinTask";
 
   public AkkaForkJoinTaskInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super("java-concurrent", "java-concurrent-akka");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/CallableInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/CallableInstrumentation.java
@@ -43,7 +43,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class CallableInstrumentation extends Instrumenter.Default {
 
   public CallableInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super("java-concurrent");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -86,7 +86,7 @@ public final class FutureInstrumentation extends Instrumenter.Default {
   }
 
   public FutureInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super("java-concurrent");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
@@ -52,7 +52,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JavaForkJoinTaskInstrumentation extends Instrumenter.Default {
 
   public JavaForkJoinTaskInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super("java-concurrent");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/NonStandardExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/NonStandardExecutorInstrumentation.java
@@ -32,7 +32,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class NonStandardExecutorInstrumentation extends AbstractExecutorInstrumentation {
 
   public NonStandardExecutorInstrumentation() {
-    super(EXEC_NAME + ".other");
+    super("java-concurrent-other");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/RunnableInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/RunnableInstrumentation.java
@@ -42,7 +42,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class RunnableInstrumentation extends Instrumenter.Default {
 
   public RunnableInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super("java-concurrent");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaExecutorInstrumentation.java
@@ -42,7 +42,7 @@ import scala.concurrent.forkjoin.ForkJoinTask;
 public final class ScalaExecutorInstrumentation extends AbstractExecutorInstrumentation {
 
   public ScalaExecutorInstrumentation() {
-    super(EXEC_NAME + ".scala_fork_join");
+    super("java-concurrent-scala");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaForkJoinTaskInstrumentation.java
@@ -55,7 +55,7 @@ public final class ScalaForkJoinTaskInstrumentation extends Instrumenter.Default
   static final String TASK_CLASS_NAME = "scala.concurrent.forkjoin.ForkJoinTask";
 
   public ScalaForkJoinTaskInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super("java-concurrent", "java-concurrent-scala");
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ThreadPoolExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ThreadPoolExecutorInstrumentation.java
@@ -44,7 +44,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class ThreadPoolExecutorInstrumentation extends Instrumenter.Default {
 
   public ThreadPoolExecutorInstrumentation() {
-    super(AbstractExecutorInstrumentation.EXEC_NAME);
+    super("java-concurrent");
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Instrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Instrumentation.java
@@ -49,7 +49,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JaxRsClientV1Instrumentation extends Instrumenter.Default {
 
   public JaxRsClientV1Instrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-client");
+    super("jaxrs-client");
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JerseyClientConnectionErrorInstrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JerseyClientConnectionErrorInstrumentation.java
@@ -44,7 +44,7 @@ import org.glassfish.jersey.client.ClientRequest;
 public final class JerseyClientConnectionErrorInstrumentation extends Instrumenter.Default {
 
   public JerseyClientConnectionErrorInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-client");
+    super("jaxrs-client");
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ResteasyClientConnectionErrorInstrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ResteasyClientConnectionErrorInstrumentation.java
@@ -44,7 +44,7 @@ import org.jboss.resteasy.client.jaxrs.internal.ClientConfiguration;
 public final class ResteasyClientConnectionErrorInstrumentation extends Instrumenter.Default {
 
   public ResteasyClientConnectionErrorInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-client");
+    super("jaxrs-client");
   }
 
   @Override

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientInstrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientInstrumentation.java
@@ -36,7 +36,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JaxRsClientInstrumentation extends Instrumenter.Default {
 
   public JaxRsClientInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-client");
+    super("jaxrs-client");
   }
 
   @Override

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
@@ -45,7 +45,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
   private static final String JAX_ENDPOINT_OPERATION_NAME = "jax-rs.request";
 
   public JaxRsAnnotationsInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-annotations");
+    super("jaxrs");
   }
 
   // this is required to make sure instrumentation won't apply to jax-rs 2

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/AbstractRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/AbstractRequestContextInstrumentation.java
@@ -38,7 +38,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 public abstract class AbstractRequestContextInstrumentation extends Instrumenter.Default {
   public AbstractRequestContextInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-filter");
+    super("jaxrs");
   }
 
   @Override

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
@@ -41,7 +41,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class ContainerRequestFilterInstrumentation extends Instrumenter.Default {
 
   public ContainerRequestFilterInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-filter");
+    super("jaxrs");
   }
 
   @Override

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsInstrumentation.java
@@ -46,7 +46,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
   private static final String JAX_ENDPOINT_OPERATION_NAME = "jax-rs.request";
 
   public JaxRsAnnotationsInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-annotations");
+    super("jaxrs");
   }
 
   @Override

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
@@ -40,7 +40,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JaxRsAsyncResponseInstrumentation extends Instrumenter.Default {
 
   public JaxRsAsyncResponseInstrumentation() {
-    super("jax-rs", "jaxrs", "jax-rs-annotations");
+    super("jaxrs");
   }
 
   @Override

--- a/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v1_4/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v1_4/JedisInstrumentation.java
@@ -42,7 +42,7 @@ import redis.clients.jedis.Protocol.Command;
 public final class JedisInstrumentation extends Instrumenter.Default {
 
   public JedisInstrumentation() {
-    super("jedis", "redis");
+    super("jedis");
   }
 
   @Override

--- a/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v3_0/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v3_0/JedisInstrumentation.java
@@ -42,7 +42,7 @@ import redis.clients.jedis.commands.ProtocolCommand;
 public final class JedisInstrumentation extends Instrumenter.Default {
 
   public JedisInstrumentation() {
-    super("jedis", "redis");
+    super("jedis");
   }
 
   @Override

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
@@ -34,7 +34,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JettyHandlerInstrumentation extends Instrumenter.Default {
 
   public JettyHandlerInstrumentation() {
-    super("jetty", "jetty-8");
+    super("jetty");
   }
 
   @Override

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -47,7 +47,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JMSMessageConsumerInstrumentation extends Instrumenter.Default {
 
   public JMSMessageConsumerInstrumentation() {
-    super("jms", "jms-1", "jms-2");
+    super("jms");
   }
 
   @Override

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageListenerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageListenerInstrumentation.java
@@ -44,7 +44,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JMSMessageListenerInstrumentation extends Instrumenter.Default {
 
   public JMSMessageListenerInstrumentation() {
-    super("jms", "jms-1", "jms-2");
+    super("jms");
   }
 
   @Override

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -49,7 +49,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JMSMessageProducerInstrumentation extends Instrumenter.Default {
 
   public JMSMessageProducerInstrumentation() {
-    super("jms", "jms-1", "jms-2");
+    super("jms");
   }
 
   @Override

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
@@ -40,7 +40,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class JSPInstrumentation extends Instrumenter.Default {
 
   public JSPInstrumentation() {
-    super("jsp", "jsp-render");
+    super("jsp");
   }
 
   @Override

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -38,7 +38,7 @@ import org.apache.jasper.JspCompilationContext;
 public final class JasperJSPCompilationContextInstrumentation extends Instrumenter.Default {
 
   public JasperJSPCompilationContextInstrumentation() {
-    super("jsp", "jsp-compile");
+    super("jsp");
   }
 
   @Override

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaConsumerInstrumentation.java
@@ -39,7 +39,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 public final class KafkaConsumerInstrumentation extends Instrumenter.Default {
 
   public KafkaConsumerInstrumentation() {
-    super("kafka");
+    super("kafka-clients");
   }
 
   @Override

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaProducerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaProducerInstrumentation.java
@@ -49,7 +49,7 @@ import org.apache.kafka.common.record.RecordBatch;
 public final class KafkaProducerInstrumentation extends Instrumenter.Default {
 
   public KafkaProducerInstrumentation() {
-    super("kafka");
+    super("kafka-clients");
   }
 
   @Override

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsProcessorInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsProcessorInstrumentation.java
@@ -63,7 +63,7 @@ public class KafkaStreamsProcessorInstrumentation {
   public static class StartInstrumentation extends Instrumenter.Default {
 
     public StartInstrumentation() {
-      super("kafka", "kafka-streams");
+      super("kafka-streams");
     }
 
     @Override
@@ -120,7 +120,7 @@ public class KafkaStreamsProcessorInstrumentation {
   public static class StopInstrumentation extends Instrumenter.Default {
 
     public StopInstrumentation() {
-      super("kafka", "kafka-streams");
+      super("kafka-streams");
     }
 
     @Override

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
@@ -37,7 +37,7 @@ import org.apache.kafka.common.record.TimestampType;
 public class KafkaStreamsSourceNodeRecordDeserializerInstrumentation extends Instrumenter.Default {
 
   public KafkaStreamsSourceNodeRecordDeserializerInstrumentation() {
-    super("kafka", "kafka-streams");
+    super("kafka-streams");
   }
 
   @Override

--- a/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsInstrumentation.java
@@ -31,7 +31,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class LettuceAsyncCommandsInstrumentation extends Instrumenter.Default {
 
   public LettuceAsyncCommandsInstrumentation() {
-    super("lettuce", "lettuce-5-async");
+    super("lettuce");
   }
 
   @Override

--- a/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceReactiveCommandsInstrumentation.java
+++ b/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceReactiveCommandsInstrumentation.java
@@ -34,7 +34,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class LettuceReactiveCommandsInstrumentation extends Instrumenter.Default {
 
   public LettuceReactiveCommandsInstrumentation() {
-    super("lettuce", "lettuce-5-rx");
+    super("lettuce");
   }
 
   @Override

--- a/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/ThreadContextInstrumentation.java
+++ b/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/ThreadContextInstrumentation.java
@@ -32,10 +32,9 @@ import net.bytebuddy.matcher.ElementMatcher;
 // FIXME this instrumentation relied on scope listener
 // @AutoService(Instrumenter.class)
 public class ThreadContextInstrumentation extends Instrumenter.Default {
-  public static final String MDC_INSTRUMENTATION_NAME = "log4j";
 
   public ThreadContextInstrumentation() {
-    super(MDC_INSTRUMENTATION_NAME);
+    super("log4j");
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
@@ -43,9 +43,7 @@ import org.jboss.netty.channel.ChannelFuture;
 public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
 
   public ChannelFutureListenerInstrumentation() {
-    super(
-        NettyChannelPipelineInstrumentation.INSTRUMENTATION_NAME,
-        NettyChannelPipelineInstrumentation.ADDITIONAL_INSTRUMENTATION_NAMES);
+    super("netty-3.8", "netty");
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelInstrumentation.java
@@ -39,9 +39,7 @@ import org.jboss.netty.channel.Channel;
 @AutoService(Instrumenter.class)
 public class NettyChannelInstrumentation extends Instrumenter.Default {
   public NettyChannelInstrumentation() {
-    super(
-        NettyChannelPipelineInstrumentation.INSTRUMENTATION_NAME,
-        NettyChannelPipelineInstrumentation.ADDITIONAL_INSTRUMENTATION_NAMES);
+    super("netty-3.8", "netty");
   }
 
   @Override

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelPipelineInstrumentation.java
@@ -53,11 +53,8 @@ import org.jboss.netty.handler.codec.http.HttpServerCodec;
 @AutoService(Instrumenter.class)
 public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
 
-  static final String INSTRUMENTATION_NAME = "netty";
-  static final String[] ADDITIONAL_INSTRUMENTATION_NAMES = {"netty-3.9"};
-
   public NettyChannelPipelineInstrumentation() {
-    super(INSTRUMENTATION_NAME, ADDITIONAL_INSTRUMENTATION_NAMES);
+    super("netty-3.8", "netty");
   }
 
   @Override

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
@@ -40,9 +40,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
 
   public ChannelFutureListenerInstrumentation() {
-    super(
-        NettyChannelPipelineInstrumentation.INSTRUMENTATION_NAME,
-        NettyChannelPipelineInstrumentation.ADDITIONAL_INSTRUMENTATION_NAMES);
+    super("netty-4.0", "netty");
   }
 
   @Override

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
@@ -53,11 +53,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
 
-  static final String INSTRUMENTATION_NAME = "netty";
-  static final String[] ADDITIONAL_INSTRUMENTATION_NAMES = {"netty-4.0"};
-
   public NettyChannelPipelineInstrumentation() {
-    super(INSTRUMENTATION_NAME, ADDITIONAL_INSTRUMENTATION_NAMES);
+    super("netty-4.0", "netty");
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
@@ -40,9 +40,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class ChannelFutureListenerInstrumentation extends Instrumenter.Default {
 
   public ChannelFutureListenerInstrumentation() {
-    super(
-        NettyChannelPipelineInstrumentation.INSTRUMENTATION_NAME,
-        NettyChannelPipelineInstrumentation.ADDITIONAL_INSTRUMENTATION_NAMES);
+    super("netty-4.1", "netty");
   }
 
   @Override

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -53,11 +53,8 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public class NettyChannelPipelineInstrumentation extends Instrumenter.Default {
 
-  static final String INSTRUMENTATION_NAME = "netty";
-  static final String[] ADDITIONAL_INSTRUMENTATION_NAMES = {"netty-4.1"};
-
   public NettyChannelPipelineInstrumentation() {
-    super(INSTRUMENTATION_NAME, ADDITIONAL_INSTRUMENTATION_NAMES);
+    super("netty-4.1", "netty");
   }
 
   @Override

--- a/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/OkHttp3Instrumentation.java
+++ b/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/OkHttp3Instrumentation.java
@@ -34,7 +34,7 @@ import okhttp3.OkHttpClient;
 public class OkHttp3Instrumentation extends Instrumenter.Default {
 
   public OkHttp3Instrumentation() {
-    super("okhttp", "okhttp-3");
+    super("okhttp");
   }
 
   @Override

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -68,7 +68,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class RabbitChannelInstrumentation extends Instrumenter.Default {
 
   public RabbitChannelInstrumentation() {
-    super("amqp", "rabbitmq");
+    super("rabbitmq");
   }
 
   @Override

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
@@ -37,7 +37,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class RabbitCommandInstrumentation extends Instrumenter.Default {
 
   public RabbitCommandInstrumentation() {
-    super("amqp", "rabbitmq");
+    super("rabbitmq");
   }
 
   @Override

--- a/instrumentation/reactor-3.1/src/main/java/io/opentelemetry/auto/instrumentation/reactor/FluxAndMonoInstrumentation.java
+++ b/instrumentation/reactor-3.1/src/main/java/io/opentelemetry/auto/instrumentation/reactor/FluxAndMonoInstrumentation.java
@@ -37,7 +37,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class FluxAndMonoInstrumentation extends Instrumenter.Default {
 
   public FluxAndMonoInstrumentation() {
-    super("reactor-core");
+    super("reactor");
   }
 
   @Override

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -40,7 +40,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class RmiClientInstrumentation extends Instrumenter.Default {
 
   public RmiClientInstrumentation() {
-    super("rmi", "rmi-client");
+    super("rmi");
   }
 
   @Override

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
@@ -61,7 +61,7 @@ import sun.rmi.transport.Connection;
 public class RmiClientContextInstrumentation extends Instrumenter.Default {
 
   public RmiClientContextInstrumentation() {
-    super("rmi", "rmi-context-propagator", "rmi-client-context-propagator");
+    super("rmi", "rmi-context-propagator");
   }
 
   @Override

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
@@ -36,7 +36,7 @@ import sun.rmi.transport.Target;
 public class RmiServerContextInstrumentation extends Instrumenter.Default {
 
   public RmiServerContextInstrumentation() {
-    super("rmi", "rmi-context-propagator", "rmi-server-context-propagator");
+    super("rmi", "rmi-context-propagator");
   }
 
   @Override

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -46,7 +46,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class RmiServerInstrumentation extends Instrumenter.Default {
 
   public RmiServerInstrumentation() {
-    super("rmi", "rmi-server");
+    super("rmi");
   }
 
   @Override

--- a/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Instrumentation.java
+++ b/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Instrumentation.java
@@ -34,7 +34,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class Servlet2Instrumentation extends Instrumenter.Default {
 
   public Servlet2Instrumentation() {
-    super("servlet", "servlet-2");
+    super("servlet-2.3", "servlet");
   }
 
   // this is required to make sure servlet 2 instrumentation won't apply to servlet 3

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/AsyncContextInstrumentation.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/AsyncContextInstrumentation.java
@@ -40,7 +40,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class AsyncContextInstrumentation extends Instrumenter.Default {
 
   public AsyncContextInstrumentation() {
-    super("servlet", "servlet-3");
+    super("servlet-3.0", "servlet");
   }
 
   @Override

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Instrumentation.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Instrumentation.java
@@ -32,7 +32,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class Servlet3Instrumentation extends Instrumenter.Default {
   public Servlet3Instrumentation() {
-    super("servlet", "servlet-3");
+    super("servlet-3.0", "servlet");
   }
 
   @Override

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -43,7 +43,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class RequestDispatcherInstrumentation extends Instrumenter.Default {
   public RequestDispatcherInstrumentation() {
-    super("servlet", "servlet-dispatcher");
+    super("servlet");
   }
 
   @Override

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
@@ -36,7 +36,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class ServletContextInstrumentation extends Instrumenter.Default {
   public ServletContextInstrumentation() {
-    super("servlet", "servlet-dispatcher");
+    super("servlet");
   }
 
   @Override

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -39,7 +39,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class HttpServletResponseInstrumentation extends Instrumenter.Default {
   public HttpServletResponseInstrumentation() {
-    super("servlet", "servlet-response");
+    super("servlet");
   }
 
   @Override

--- a/instrumentation/slf4j-mdc/src/main/java/io/opentelemetry/auto/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
+++ b/instrumentation/slf4j-mdc/src/main/java/io/opentelemetry/auto/instrumentation/slf4j/mdc/MDCInjectionInstrumentation.java
@@ -20,14 +20,13 @@ import net.bytebuddy.utility.JavaModule;
 
 @AutoService(Instrumenter.class)
 public class MDCInjectionInstrumentation extends Instrumenter.Default {
-  public static final String MDC_INSTRUMENTATION_NAME = "mdc";
 
   // Intentionally doing the string replace to bypass gradle shadow rename
   // mdcClassName = org.slf4j.MDC
   private static final String mdcClassName = "org.TMP.MDC".replaceFirst("TMP", "slf4j");
 
   public MDCInjectionInstrumentation() {
-    super(MDC_INSTRUMENTATION_NAME);
+    super("slf4j-mdc");
   }
 
   @Override

--- a/instrumentation/sparkjava-2.3/src/main/java/io/opentelemetry/auto/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/instrumentation/sparkjava-2.3/src/main/java/io/opentelemetry/auto/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -38,7 +38,7 @@ import spark.routematch.RouteMatch;
 public class RoutesInstrumentation extends Instrumenter.Default {
 
   public RoutesInstrumentation() {
-    super("sparkjava", "sparkjava-2.4");
+    super("sparkjava");
   }
 
   @Override

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/client/DefaultWebClientInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/client/DefaultWebClientInstrumentation.java
@@ -34,7 +34,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class DefaultWebClientInstrumentation extends Instrumenter.Default {
 
   public DefaultWebClientInstrumentation() {
-    super("spring-webflux", "spring-webflux-client");
+    super("spring-webflux");
   }
 
   @Override

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/AbstractWebfluxInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/AbstractWebfluxInstrumentation.java
@@ -19,8 +19,8 @@ import io.opentelemetry.auto.tooling.Instrumenter;
 
 public abstract class AbstractWebfluxInstrumentation extends Instrumenter.Default {
 
-  public AbstractWebfluxInstrumentation(final String... additionalNames) {
-    super("spring-webflux", additionalNames);
+  public AbstractWebfluxInstrumentation() {
+    super("spring-webflux");
   }
 
   @Override

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
@@ -36,10 +36,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 @AutoService(Instrumenter.class)
 public final class RouterFunctionInstrumentation extends AbstractWebfluxInstrumentation {
 
-  public RouterFunctionInstrumentation() {
-    super("spring-webflux-functional");
-  }
-
   @Override
   public ElementMatcher<ClassLoader> classLoaderMatcher() {
     // Optimization for expensive typeMatcher.

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
@@ -42,7 +42,7 @@ import org.springframework.web.servlet.ModelAndView;
 public final class DispatcherServletInstrumentation extends Instrumenter.Default {
 
   public DispatcherServletInstrumentation() {
-    super("spring-web");
+    super("spring-webmvc");
   }
 
   @Override

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
@@ -44,7 +44,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public final class HandlerAdapterInstrumentation extends Instrumenter.Default {
 
   public HandlerAdapterInstrumentation() {
-    super("spring-web");
+    super("spring-webmvc");
   }
 
   @Override

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceAnnotationsInstrumentation.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceAnnotationsInstrumentation.java
@@ -61,7 +61,7 @@ public final class TraceAnnotationsInstrumentation extends Instrumenter.Default 
   private final ElementMatcher.Junction<NamedElement> methodTraceMatcher;
 
   public TraceAnnotationsInstrumentation() {
-    super("trace", "trace-annotation");
+    super("trace-annotation");
 
     final String configString = Config.get().getTraceAnnotations();
     if (configString == null) {

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceConfigInstrumentation.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceConfigInstrumentation.java
@@ -135,7 +135,7 @@ public class TraceConfigInstrumentation implements Instrumenter {
     }
 
     public TracerClassInstrumentation(final String className, final Set<String> methodNames) {
-      super("trace", "trace-config");
+      super("trace-annotation");
       this.className = className;
       this.methodNames = methodNames;
     }

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -48,7 +48,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class TwilioAsyncInstrumentation extends Instrumenter.Default {
 
   public TwilioAsyncInstrumentation() {
-    super("twilio-sdk");
+    super("twilio");
   }
 
   @Override

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -44,7 +44,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 public class TwilioSyncInstrumentation extends Instrumenter.Default {
 
   public TwilioSyncInstrumentation() {
-    super("twilio-sdk");
+    super("twilio");
   }
 
   @Override


### PR DESCRIPTION
Instrumentation names are used to enable/disable instrumentation.

In general, they should reflect the module name, in order to turn on/off all instrumentation in a specific module.

In some cases, instrumentation within a module may have different instrumentation names if it's important to be able to disable some instrumentation but not others. I'm not too sure about the use case for this. If it's just for debugging instrumentation issues, maybe we can use the instrumentation class name for this instead? In which case I could simplify the names and improve consistency in this PR further.