### PR TITLE
Remove copyright year from license header

### DIFF
--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/Agent.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/AgentClassLoader.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/AgentClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/CallDepthThreadLocalMap.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/CallDepthThreadLocalMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/ContextStore.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/ContextStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/ExceptionLogger.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/ExceptionLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/FieldBackedContextStoreAppliedMarker.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/FieldBackedContextStoreAppliedMarker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/InstrumentationContext.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/InstrumentationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/InternalJarURLHandler.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/InternalJarURLHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/PatchLogger.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/PatchLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/WeakCache.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/WeakCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/WeakMap.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/WeakMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ServerDecorator.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/AdviceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/CallableWrapper.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/CallableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/ExecutorInstrumentationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/GenericRunnable.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/GenericRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/RunnableWrapper.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/RunnableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/State.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/java/concurrent/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/jdbc/DBInfo.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/jdbc/DBInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/jdbc/JDBCConnectionUrlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/rmi/ThreadLocalContext.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/bootstrap/instrumentation/rmi/ThreadLocalContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/config/Config.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/LogFields.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/LogFields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/MoreTags.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/MoreTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/SpanWithScope.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/SpanWithScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/Tags.java
+++ b/agent-bootstrap/src/main/java/io/opentelemetry/auto/instrumentation/api/Tags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/AgentClassLoaderTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/AgentClassLoaderTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/CallDepthThreadLocalMapTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/CallDepthThreadLocalMapTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/WeakMapTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/WeakMapTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/BaseDecoratorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ClientDecoratorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/DatabaseClientDecoratorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpClientDecoratorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/HttpServerDecoratorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/OrmClientDecoratorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/SampleJavaClass.java
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/SampleJavaClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/bootstrap/instrumentation/decorator/ServerDecoratorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/config/ConfigTest.groovy
+++ b/agent-bootstrap/src/test/groovy/io/opentelemetry/auto/config/ConfigTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/AgentInstaller.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/AgentInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/AgentTooling.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/AgentTooling.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ClassHierarchyIterable.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ClassHierarchyIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ClassLoaderMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ClassLoaderMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Cleaner.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Cleaner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Constants.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/DefaultExporterConfig.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/DefaultExporterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ExporterClassLoader.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ExporterClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/GuavaWeakCache.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/GuavaWeakCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/HelperInjector.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/HelperInjector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Instrumenter.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Instrumenter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ShadingRemapper.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/ShadingRemapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/TracerInstaller.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/TracerInstaller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Utils.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/VersionLogger.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/VersionLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/WeakMapSuppliers.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/WeakMapSuppliers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/AgentCachingPoolStrategy.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/AgentCachingPoolStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/AgentLocationStrategy.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/AgentLocationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/AgentTransformers.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/AgentTransformers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/ExceptionHandlers.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/ExceptionHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/AgentElementMatchers.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/AgentElementMatchers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/HasSuperMethodMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/HasSuperMethodMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/LoggingFailSafeMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/LoggingFailSafeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeErasureMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeErasureMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeExtendsClassMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeExtendsClassMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/context/FieldBackedProvider.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/context/FieldBackedProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/context/InstrumentationContextProvider.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/context/InstrumentationContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/context/NoopContextProvider.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/context/NoopContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/log/LogContextScopeListener.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/log/LogContextScopeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/AdditionalLibraryIgnoresMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/GlobalIgnoresMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/matcher/GlobalIgnoresMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/MuzzleGradlePlugin.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/MuzzleGradlePlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/MuzzleVersionScanPlugin.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/MuzzleVersionScanPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/MuzzleVisitor.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/MuzzleVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/Reference.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/Reference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/ReferenceCreator.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/ReferenceCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/ReferenceMatcher.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/tooling/muzzle/ReferenceMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/base/BaseTypedSpan.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/base/BaseTypedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/base/BaseTypedTracer.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/base/BaseTypedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/base/DelegatingSpan.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/base/DelegatingSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/ClientTypedSpan.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/ClientTypedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/ClientTypedTracer.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/ClientTypedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/http/HttpClientTypedSpan.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/http/HttpClientTypedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/http/HttpClientTypedTracer.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/client/http/HttpClientTypedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/ServerTypedSpan.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/ServerTypedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/ServerTypedTracer.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/ServerTypedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/http/HttpServerTypedSpan.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/http/HttpServerTypedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/http/HttpServerTypedTracer.java
+++ b/agent-tooling/src/main/java/io/opentelemetry/auto/typed/server/http/HttpServerTypedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ClassLoaderMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ClassLoaderMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/DefaultInstrumenterTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/DefaultInstrumenterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ExceptionHandlerTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ExceptionHandlerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/HelperInjectionTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/HelperInjectionTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ResourceLocatingTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/test/ResourceLocatingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/CacheProviderTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/CacheProviderTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/CleanerTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/CleanerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/UtilsTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/UtilsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/WeakCacheTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/WeakCacheTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/WeakConcurrentSupplierTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/WeakConcurrentSupplierTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/ExtendsClassMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/HasInterfaceMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/HasSuperMethodMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/HasSuperMethodMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/ImplementsInterfaceMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeHasSuperTypeMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeMatcherTest.groovy
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/SafeMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/A.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/B.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/C.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/D.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/E.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/E.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/F.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/F.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/G.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/G.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/Trace.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/Trace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/TracedClass.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/TracedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/UntracedClass.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/tooling/bytebuddy/matcher/testclasses/UntracedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/TypedTracerDemonstration.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/TypedTracerDemonstration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/client/SampleHttpClientTypedSpan.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/client/SampleHttpClientTypedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/client/SampleHttpClientTypedTracer.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/client/SampleHttpClientTypedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/server/SampleHttpServerTypedSpan.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/server/SampleHttpServerTypedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/server/SampleHttpServerTypedTracer.java
+++ b/agent-tooling/src/test/groovy/io/opentelemetry/auto/typed/server/SampleHttpServerTypedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/java/io/opentelemetry/auto/test/BadAdvice.java
+++ b/agent-tooling/src/test/java/io/opentelemetry/auto/test/BadAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent-tooling/src/test/java/io/opentelemetry/auto/test/HelperClass.java
+++ b/agent-tooling/src/test/java/io/opentelemetry/auto/test/HelperClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-exporters/jaeger/src/main/java/io/opentelemetry/auto/exporters/jaeger/JaegerExporterFactory.java
+++ b/auto-exporters/jaeger/src/main/java/io/opentelemetry/auto/exporters/jaeger/JaegerExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-exporters/logging/src/main/java/io/opentelemetry/auto/exporters/logging/LoggingExporter.java
+++ b/auto-exporters/logging/src/main/java/io/opentelemetry/auto/exporters/logging/LoggingExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-exporters/logging/src/main/java/io/opentelemetry/auto/exporters/logging/LoggingExporterFactory.java
+++ b/auto-exporters/logging/src/main/java/io/opentelemetry/auto/exporters/logging/LoggingExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-exporters/otlp/src/main/java/io/opentelemetry/auto/exporters/otlp/OtlpMetricExporterFactory.java
+++ b/auto-exporters/otlp/src/main/java/io/opentelemetry/auto/exporters/otlp/OtlpMetricExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-exporters/otlp/src/main/java/io/opentelemetry/auto/exporters/otlp/OtlpSpanExporterFactory.java
+++ b/auto-exporters/otlp/src/main/java/io/opentelemetry/auto/exporters/otlp/OtlpSpanExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/auto-exporters/src/test/groovy/io/opentelemetry/auto/exporteradapters/ExporterAdaptersTest.groovy
+++ b/auto-exporters/src/test/groovy/io/opentelemetry/auto/exporteradapters/ExporterAdaptersTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark-integration/jetty-perftest/src/main/java/io/opentelemetry/perftest/Worker.java
+++ b/benchmark-integration/jetty-perftest/src/main/java/io/opentelemetry/perftest/Worker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark-integration/jetty-perftest/src/main/java/io/opentelemetry/perftest/jetty/JettyPerftest.java
+++ b/benchmark-integration/jetty-perftest/src/main/java/io/opentelemetry/perftest/jetty/JettyPerftest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/ClassRetransformingBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/ClassRetransformingBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/A.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/A.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/B.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/B.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/C.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/C.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/D.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/E.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/E.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/F.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/F.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/TracedClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/TracedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/UntracedClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/UntracedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporter-support/src/main/java/io/opentelemetry/auto/exportersupport/MetricExporterFactory.java
+++ b/exporter-support/src/main/java/io/opentelemetry/auto/exportersupport/MetricExporterFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/enforcement/spotless.license.java
+++ b/gradle/enforcement/spotless.license.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
+++ b/instrumentation/akka-http-10.0/src/lagomTest/groovy/LagomTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/lagomTest/java/EchoService.java
+++ b/instrumentation/akka-http-10.0/src/lagomTest/java/EchoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/lagomTest/java/EchoServiceImpl.java
+++ b/instrumentation/akka-http-10.0/src/lagomTest/java/EchoServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/lagomTest/java/ServiceTestModule.java
+++ b/instrumentation/akka-http-10.0/src/lagomTest/java/ServiceTestModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientDecorator.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerDecorator.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
+++ b/instrumentation/akka-http-10.0/src/main/java/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/main/java8/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerHeaders.java
+++ b/instrumentation/akka-http-10.0/src/main/java8/io/opentelemetry/auto/instrumentation/akkahttp/AkkaHttpServerHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpClientInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpServerInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpTestInstrumentation.java
+++ b/instrumentation/akka-http-10.0/src/test/groovy/AkkaHttpTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestAsyncWebServer.scala
+++ b/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestAsyncWebServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestSyncWebServer.scala
+++ b/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestSyncWebServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
+++ b/instrumentation/akka-http-10.0/src/test/scala/AkkaHttpTestWebServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpAsyncClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/ApacheHttpClientRedirectInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/HttpHeadersInjectAdapter.java
+++ b/instrumentation/apache-httpasyncclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpasyncclient/HttpHeadersInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientCallbackTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientNullCallbackTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientTest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/ApacheHttpAsyncClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/HttpUriRequest.groovy
+++ b/instrumentation/apache-httpasyncclient-4.0/src/test/groovy/HttpUriRequest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientDecorator.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/CommonsHttpClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/HttpHeadersInjectAdapter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v2_0/HttpHeadersInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/src/test/groovy/CommonsHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/src/test/groovy/CommonsHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/ApacheHttpClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/HostAndRequestAsHttpUriRequest.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/HostAndRequestAsHttpUriRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/main/java/io/opentelemetry/auto/instrumentation/apachehttpclient/v4_0/HttpHeadersInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientResponseHandlerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientTest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/ApacheHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/HttpUriRequest.groovy
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/src/test/groovy/HttpUriRequest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AWSClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AWSClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AWSHttpClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AWSHttpClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AwsSdkClientDecorator.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/AwsSdkClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/OnErrorDecorator.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/OnErrorDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/RequestInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/RequestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/RequestMeta.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/RequestMeta.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/TracingRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AbstractAwsClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AbstractAwsClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsHttpClientInstrumentation.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsHttpClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsSdkClientDecorator.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/AwsSdkClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/cassandra/CassandraClientDecorator.java
+++ b/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/cassandra/CassandraClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/cassandra/CassandraClientInstrumentation.java
+++ b/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/cassandra/CassandraClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/cassandra/TracingSession.java
+++ b/instrumentation/cassandra-3.0/src/main/java/io/opentelemetry/auto/instrumentation/cassandra/TracingSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
+++ b/instrumentation/cassandra-3.0/src/test/groovy/CassandraClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/cdi-testing/src/test/groovy/CDIContainerTest.groovy
+++ b/instrumentation/cdi-testing/src/test/groovy/CDIContainerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/cdi-testing/src/test/java/TestBean.java
+++ b/instrumentation/cdi-testing/src/test/java/TestBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseBucketInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseBucketInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseClientDecorator.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseClusterInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseClusterInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseOnSubscribe.java
+++ b/instrumentation/couchbase/couchbase-2.0/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_0/CouchbaseOnSubscribe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseAsyncClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/CouchbaseClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseConfig.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringRepositoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/CouchbaseSpringTemplateTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/Doc.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/Doc.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/DocRepository.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/springdata/DocRepository.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
+++ b/instrumentation/couchbase/couchbase-2.0/src/test/groovy/util/AbstractCouchbaseTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_6/CouchbaseCoreInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
+++ b/instrumentation/couchbase/couchbase-2.6/src/main/java/io/opentelemetry/auto/instrumentation/couchbase/v2_6/CouchbaseNetworkInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseAsyncClient26Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseClient26Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/CouchbaseSpanUtil.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringRepository26Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
+++ b/instrumentation/couchbase/couchbase-2.6/src/test/groovy/springdata/CouchbaseSpringTemplate26Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardAsyncTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardAsyncTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
+++ b/instrumentation/dropwizard-testing/src/test/groovy/DropwizardTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/dropwizard-testing/src/test/groovy/JettyTestInstrumentation.java
+++ b/instrumentation/dropwizard-testing/src/test/groovy/JettyTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizardviews/DropwizardViewInstrumentation.java
+++ b/instrumentation/dropwizard-views-0.7/src/main/java/io/opentelemetry/auto/instrumentation/dropwizardviews/DropwizardViewInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
+++ b/instrumentation/dropwizard-views-0.7/src/test/groovy/ViewRenderTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-common/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
+++ b/instrumentation/elasticsearch/elasticsearch-common/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchRestClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-common/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
+++ b/instrumentation/elasticsearch/elasticsearch-common/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/ElasticsearchTransportClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v5_0/Elasticsearch5RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v5_0/Elasticsearch5RestClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v5_0/RestResponseListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v5_0/RestResponseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-5.0/src/test/groovy/Elasticsearch5RestClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/latestDepTest/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v6_4/Elasticsearch6RestClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v6_4/RestResponseListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/rest/v6_4/RestResponseListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/src/test/groovy/Elasticsearch6RestClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Config.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Config.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Doc.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Doc.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/DocRepository.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/DocRepository.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/latestDepTest/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v2_0/Elasticsearch2TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v2_0/Elasticsearch2TransportClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v2_0/TransportActionListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v2_0/TransportActionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2NodeClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/Elasticsearch2TransportClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Config.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Config.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Doc.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Doc.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/DocRepository.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/DocRepository.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringRepositoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-2.0/src/test/groovy/springdata/Elasticsearch2SpringTemplateTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_0/Elasticsearch5TransportClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_0/TransportActionListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_0/TransportActionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5NodeClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/src/test/groovy/Elasticsearch5TransportClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_3/Elasticsearch53TransportClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_3/TransportActionListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v5_3/TransportActionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53NodeClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/Elasticsearch53TransportClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Config.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Config.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Doc.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Doc.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/DocRepository.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/DocRepository.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringRepositoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/src/test/groovy/springdata/Elasticsearch53SpringTemplateTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentation.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v6_0/Elasticsearch6TransportClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v6_0/TransportActionListener.java
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/main/java/io/opentelemetry/auto/instrumentation/elasticsearch/transport/v6_0/TransportActionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6NodeClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/src/test/groovy/Elasticsearch6TransportClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraDecorator.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
+++ b/instrumentation/finatra-2.9/src/main/java/io/opentelemetry/auto/instrumentation/finatra/FinatraInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
+++ b/instrumentation/finatra-2.9/src/test/groovy/FinatraServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/finatra-2.9/src/test/groovy/NettyServerTestInstrumentation.java
+++ b/instrumentation/finatra-2.9/src/test/groovy/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/finatra-2.9/src/test/scala/FinatraController.scala
+++ b/instrumentation/finatra-2.9/src/test/scala/FinatraController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/finatra-2.9/src/test/scala/FinatraServer.scala
+++ b/instrumentation/finatra-2.9/src/test/scala/FinatraServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/finatra-2.9/src/test/scala/ResponseSettingExceptionMapper.scala
+++ b/instrumentation/finatra-2.9/src/test/scala/ResponseSettingExceptionMapper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeDecorator.java
+++ b/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeInstrumentation.java
+++ b/instrumentation/geode-1.4/src/main/java/io/opentelemetry/auto/instrumentation/geode/GeodeInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
+++ b/instrumentation/geode-1.4/src/test/groovy/PutGetTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/GoogleHttpClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/HeadersInjectAdapter.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/HeadersInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/RequestState.java
+++ b/instrumentation/google-http-client-1.19/src/main/java/io/opentelemetry/auto/instrumentation/googlehttpclient/RequestState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/google-http-client-1.19/src/test/groovy/AbstractGoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/src/test/groovy/AbstractGoogleHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientAsyncTest.groovy
+++ b/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientAsyncTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientTest.groovy
+++ b/instrumentation/google-http-client-1.19/src/test/groovy/GoogleHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyDecorator.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyHttpHandlerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyRequestExtractAdapter.java
+++ b/instrumentation/grizzly-2.0/src/main/java/io/opentelemetry/auto/instrumentation/grizzly/GrizzlyRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyAsyncTest.groovy
+++ b/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyAsyncTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyIOStrategyTest.groovy
+++ b/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyIOStrategyTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyTest.groovy
+++ b/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyTestInstrumentation.java
+++ b/instrumentation/grizzly-2.0/src/test/groovy/GrizzlyTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientBuilderInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcInjectAdapter.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/GrpcInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/TracingClientInterceptor.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/client/TracingClientInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/common/GrpcHelper.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/common/GrpcHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcExtractAdapter.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerBuilderInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/GrpcServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/TracingServerInterceptor.java
+++ b/instrumentation/grpc-1.5/src/main/java/io/opentelemetry/auto/instrumentation/grpc/server/TracingServerInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
+++ b/instrumentation/grpc-1.5/src/test/groovy/GrpcStreamingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
+++ b/instrumentation/grpc-1.5/src/test/groovy/GrpcTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/AbstractHibernateInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/AbstractHibernateInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/CriteriaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/CriteriaInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/QueryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/QueryInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/SessionFactoryInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/SessionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v3_3/TransactionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/AbstractHibernateTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/AbstractHibernateTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/CriteriaTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/QueryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/groovy/SessionTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-3.3/src/test/java/Value.java
+++ b/instrumentation/hibernate/hibernate-3.3/src/test/java/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/AbstractHibernateInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/AbstractHibernateInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/CriteriaInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/CriteriaInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/QueryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/QueryInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/SessionFactoryInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/SessionFactoryInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/SessionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/TransactionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_0/TransactionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/AbstractHibernateTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/AbstractHibernateTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/CriteriaTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/QueryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/groovy/SessionTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.0/src/test/java/Value.java
+++ b/instrumentation/hibernate/hibernate-4.0/src/test/java/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/ProcedureCallInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/SessionInstrumentation.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/v4_3/SessionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/ProcedureCallTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/groovy/SpringJpaTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/test/java/Value.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/java/Value.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/test/java/spring/jpa/Customer.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/java/spring/jpa/Customer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/test/java/spring/jpa/CustomerRepository.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/java/spring/jpa/CustomerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-4.3/src/test/java/spring/jpa/PersistenceConfig.java
+++ b/instrumentation/hibernate/hibernate-4.3/src/test/java/spring/jpa/PersistenceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/HibernateDecorator.java
+++ b/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/HibernateDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/SessionMethodUtils.java
+++ b/instrumentation/hibernate/hibernate-common/src/main/java/io/opentelemetry/auto/instrumentation/hibernate/SessionMethodUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HeadersInjectAdapter.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HeadersInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentation.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/HttpUrlConnectionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
+++ b/instrumentation/http-url-connection/src/main/java/io/opentelemetry/auto/instrumentation/httpurlconnection/UrlInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionResponseCodeOnlyTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/HttpUrlConnectionUseCachesFalseTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/SpringRestTemplateTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
+++ b/instrumentation/http-url-connection/src/test/groovy/UrlConnectionTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixInstrumentation.java
+++ b/instrumentation/hystrix-1.4/src/main/java/io/opentelemetry/auto/instrumentation/hystrix/HystrixInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableChainTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixObservableTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
+++ b/instrumentation/hystrix-1.4/src/test/groovy/HystrixTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-class-loader/jboss-testing/src/test/groovy/JBossClassloadingTest.groovy
+++ b/instrumentation/java-class-loader/jboss-testing/src/test/groovy/JBossClassloadingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-class-loader/osgi-testing/src/test/groovy/OSGIClassloadingTest.groovy
+++ b/instrumentation/java-class-loader/osgi-testing/src/test/groovy/OSGIClassloadingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-class-loader/src/main/java/io/opentelemetry/auto/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
+++ b/instrumentation/java-class-loader/src/main/java/io/opentelemetry/auto/instrumentation/javaclassloader/ClassLoaderInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-class-loader/src/test/groovy/ClassLoadingTest.groovy
+++ b/instrumentation/java-class-loader/src/test/groovy/ClassLoadingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-class-loader/tomcat-testing/src/test/groovy/TomcatClassloadingTest.groovy
+++ b/instrumentation/java-class-loader/tomcat-testing/src/test/groovy/TomcatClassloadingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/akka-2.5-testing/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
+++ b/instrumentation/java-concurrent/akka-2.5-testing/src/test/groovy/AkkaExecutorInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/akka-2.5-testing/src/test/scala/AkkaAsyncChild.java
+++ b/instrumentation/java-concurrent/akka-2.5-testing/src/test/scala/AkkaAsyncChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/akka-testing/src/test/groovy/AkkaActorTest.groovy
+++ b/instrumentation/java-concurrent/akka-testing/src/test/groovy/AkkaActorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/akka-testing/src/test/scala/AkkaActors.scala
+++ b/instrumentation/java-concurrent/akka-testing/src/test/scala/AkkaActors.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/kotlin-testing/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
+++ b/instrumentation/java-concurrent/kotlin-testing/src/test/groovy/KotlinCoroutineInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/kotlin-testing/src/test/kotlin/KotlinCoroutineTests.kt
+++ b/instrumentation/java-concurrent/kotlin-testing/src/test/kotlin/KotlinCoroutineTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
+++ b/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaExecutorInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaInstrumentationTest.groovy
+++ b/instrumentation/java-concurrent/scala-testing/src/test/groovy/ScalaInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaAsyncChild.java
+++ b/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaAsyncChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaConcurrentTests.scala
+++ b/instrumentation/java-concurrent/scala-testing/src/test/scala/ScalaConcurrentTests.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AbstractExecutorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaExecutorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaForkJoinTaskInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/AkkaForkJoinTaskInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/CallableInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/CallableInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/JavaExecutorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/JavaForkJoinTaskInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/NonStandardExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/NonStandardExecutorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/RunnableInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/RunnableInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaExecutorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaForkJoinTaskInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ScalaForkJoinTaskInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ThreadPoolExecutorInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/ThreadPoolExecutorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
+++ b/instrumentation/java-concurrent/src/slickTest/groovy/CompletableFutureTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
+++ b/instrumentation/java-concurrent/src/slickTest/groovy/SlickTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/slickTest/scala/SlickUtils.scala
+++ b/instrumentation/java-concurrent/src/slickTest/scala/SlickUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
+++ b/instrumentation/java-concurrent/src/test/groovy/ExecutorInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/test/groovy/ModuleInjectionTest.groovy
+++ b/instrumentation/java-concurrent/src/test/groovy/ModuleInjectionTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-concurrent/src/test/java/JavaAsyncChild.java
+++ b/instrumentation/java-concurrent/src/test/java/JavaAsyncChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-util-logging/src/main/java/io/opentelemetry/auto/instrumentation/jul/JavaUtilLoggingSpans.java
+++ b/instrumentation/java-util-logging/src/main/java/io/opentelemetry/auto/instrumentation/jul/JavaUtilLoggingSpans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-util-logging/src/main/java/io/opentelemetry/auto/instrumentation/jul/JavaUtilLoggingSpansInstrumentation.java
+++ b/instrumentation/java-util-logging/src/main/java/io/opentelemetry/auto/instrumentation/jul/JavaUtilLoggingSpansInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-util-logging/src/test/groovy/JBossJavaUtilLoggingEventTest.groovy
+++ b/instrumentation/java-util-logging/src/test/groovy/JBossJavaUtilLoggingEventTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/java-util-logging/src/test/groovy/JavaUtilLoggingSpansTest.groovy
+++ b/instrumentation/java-util-logging/src/test/groovy/JavaUtilLoggingSpansTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/InjectAdapter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/InjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Decorator.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Decorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Instrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v1_1/JaxRsClientV1Instrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/src/test/groovy/JaxRsClientV1Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JerseyClientConnectionErrorInstrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JerseyClientConnectionErrorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ResteasyClientConnectionErrorInstrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/jaxrs-client-2.0-resteasy-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ResteasyClientConnectionErrorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ClientTracingFeature.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ClientTracingFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ClientTracingFilter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/ClientTracingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/InjectAdapter.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/InjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientDecorator.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientInstrumentation.java
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrsclient/v2_0/JaxRsClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxMultithreadedClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxMultithreadedClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientAsyncTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
+++ b/instrumentation/jaxrs-client/jaxrs-client-2.0/src/test/groovy/JaxRsClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v1_0/JaxRsAnnotationsInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JavaInterfaces.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JavaInterfaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JaxRsAnnotations1InstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JerseyTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JettyTestInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JettyTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/java/Resource.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/java/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JerseyRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-jersey-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JerseyRequestContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy30RequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy30RequestContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy31RequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/jaxrs-2.0-resteasy-3.1/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/Resteasy31RequestContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/AbstractRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/AbstractRequestContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/ContainerRequestFilterInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/DefaultRequestContextInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/DefaultRequestContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsDecorator.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAnnotationsInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/main/java/io/opentelemetry/auto/instrumentation/jaxrs/v2_0/JaxRsAsyncResponseInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JavaInterfaces.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JavaInterfaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsAnnotations2InstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/groovy/JaxRsFilterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jaxrs/jaxrs-2.0/src/test/java/Resource.java
+++ b/instrumentation/jaxrs/jaxrs-2.0/src/test/java/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/ConnectionInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/ConnectionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DataSourceInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DriverInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/DriverInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCMaps.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCMaps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCUtils.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/JDBCUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/PreparedStatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/PreparedStatementInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/StatementInstrumentation.java
+++ b/instrumentation/jdbc/src/main/java/io/opentelemetry/auto/instrumentation/jdbc/StatementInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
+++ b/instrumentation/jdbc/src/test/groovy/JDBCConnectionUrlParserTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
+++ b/instrumentation/jdbc/src/test/groovy/JDBCInstrumentationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/test/groovy/test/TestConnection.groovy
+++ b/instrumentation/jdbc/src/test/groovy/test/TestConnection.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/test/groovy/test/TestDatabaseMetaData.groovy
+++ b/instrumentation/jdbc/src/test/groovy/test/TestDatabaseMetaData.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/test/groovy/test/TestDriver.groovy
+++ b/instrumentation/jdbc/src/test/groovy/test/TestDriver.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jdbc/src/test/groovy/test/TestStatement.groovy
+++ b/instrumentation/jdbc/src/test/groovy/test/TestStatement.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v1_4/JedisClientDecorator.java
+++ b/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v1_4/JedisClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v1_4/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-1.4/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v1_4/JedisInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
+++ b/instrumentation/jedis/jedis-1.4/src/test/groovy/JedisClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v3_0/JedisClientDecorator.java
+++ b/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v3_0/JedisClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v3_0/JedisInstrumentation.java
+++ b/instrumentation/jedis/jedis-3.0/src/main/java/io/opentelemetry/auto/instrumentation/jedis/v3_0/JedisInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
+++ b/instrumentation/jedis/jedis-3.0/src/test/groovy/Jedis30ClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/HttpServletRequestExtractAdapter.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/HttpServletRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyDecorator.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerAdvice.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/JettyHandlerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/TagSettingAsyncListener.java
+++ b/instrumentation/jetty-8.0/src/main/java/io/opentelemetry/auto/instrumentation/jetty/TagSettingAsyncListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyContinuationHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyContinuationHandlerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyHandlerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyTestInstrumentation.java
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/JMS2Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/SpringListenerJMS2Test.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/SpringListenerJMS2Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/SpringTemplateJMS2Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/listener/Config.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/listener/Config.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/latestDepTest/groovy/listener/TestListener.groovy
+++ b/instrumentation/jms-1.1/src/latestDepTest/groovy/listener/TestListener.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSDecorator.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageConsumerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageConsumerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageListenerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageListenerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageProducerInstrumentation.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/JMSMessageProducerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/MessageExtractAdapter.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/MessageExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/MessageInjectAdapter.java
+++ b/instrumentation/jms-1.1/src/main/java/io/opentelemetry/auto/instrumentation/jms/MessageInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/JMS1Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/test/groovy/SpringListenerJMS1Test.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/SpringListenerJMS1Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/test/groovy/SpringTemplateJMS1Test.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/SpringTemplateJMS1Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/test/groovy/listener/Config.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/listener/Config.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jms-1.1/src/test/groovy/listener/TestListener.groovy
+++ b/instrumentation/jms-1.1/src/test/groovy/listener/TestListener.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPDecorator.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JSPInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
+++ b/instrumentation/jsp-2.3/src/main/java/io/opentelemetry/auto/instrumentation/jsp/JasperJSPCompilationContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationBasicTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
+++ b/instrumentation/jsp-2.3/src/test/groovy/JSPInstrumentationForwardTests.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaConsumerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaConsumerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaDecorator.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaProducerInstrumentation.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/KafkaProducerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TextMapExtractAdapter.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TextMapExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TextMapInjectAdapter.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TextMapInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TracingIterable.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TracingIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TracingIterator.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TracingIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TracingList.java
+++ b/instrumentation/kafka-clients-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkaclients/TracingList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
+++ b/instrumentation/kafka-clients-0.11/src/test/groovy/KafkaClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsDecorator.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsProcessorInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsProcessorInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/KafkaStreamsSourceNodeRecordDeserializerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/TextMapExtractAdapter.java
+++ b/instrumentation/kafka-streams-0.11/src/main/java/io/opentelemetry/auto/instrumentation/kafkastreams/TextMapExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
+++ b/instrumentation/kafka-streams-0.11/src/test/groovy/KafkaStreamsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsInstrumentation.java
+++ b/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientInstrumentation.java
+++ b/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceReactiveCommandsInstrumentation.java
+++ b/instrumentation/lettuce-5.0/src/main/java/io/opentelemetry/auto/instrumentation/lettuce/LettuceReactiveCommandsInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/ConnectionFutureAdvice.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/ConnectionFutureAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncBiFunction.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncBiFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceAsyncCommandsAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientDecorator.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceInstrumentationUtil.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/LettuceInstrumentationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceFluxCreationAdvice.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceFluxCreationAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceFluxTerminationRunnable.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceFluxTerminationRunnable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceMonoCreationAdvice.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceMonoCreationAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceMonoDualConsumer.java
+++ b/instrumentation/lettuce-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/lettuce/rx/LettuceMonoDualConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceAsyncClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceReactiveClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
+++ b/instrumentation/lettuce-5.0/src/test/groovy/LettuceSyncClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jMDCInstrumentation.java
+++ b/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jMDCInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jSpans.java
+++ b/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jSpans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jSpansInstrumentation.java
+++ b/instrumentation/log4j/log4j-1.1/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v1_1/Log4jSpansInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-1.1/src/test/groovy/Log4jMDCTest.groovy
+++ b/instrumentation/log4j/log4j-1.1/src/test/groovy/Log4jMDCTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-1.1/src/test/groovy/Log4jSpansTest.groovy
+++ b/instrumentation/log4j/log4j-1.1/src/test/groovy/Log4jSpansTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/Log4jSpans.java
+++ b/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/Log4jSpans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/Log4jSpansInstrumentation.java
+++ b/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/Log4jSpansInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/ThreadContextInstrumentation.java
+++ b/instrumentation/log4j/log4j-2.0/src/main/java/io/opentelemetry/auto/instrumentation/log4j/v2_0/ThreadContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-2.0/src/test/groovy/Log4jSpansTest.groovy
+++ b/instrumentation/log4j/log4j-2.0/src/test/groovy/Log4jSpansTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/log4j/log4j-2.0/src/test/groovy/Log4jThreadContextTest.groovy
+++ b/instrumentation/log4j/log4j-2.0/src/test/groovy/Log4jThreadContextTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/logback-1.0/src/main/java/io/opentelemetry/auto/instrumentation/logback/LogbackSpans.java
+++ b/instrumentation/logback-1.0/src/main/java/io/opentelemetry/auto/instrumentation/logback/LogbackSpans.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/logback-1.0/src/main/java/io/opentelemetry/auto/instrumentation/logback/LogbackSpansInstrumentation.java
+++ b/instrumentation/logback-1.0/src/main/java/io/opentelemetry/auto/instrumentation/logback/LogbackSpansInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/logback-1.0/src/test/groovy/LogbackSpansTest.groovy
+++ b/instrumentation/logback-1.0/src/test/groovy/LogbackSpansTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-3.1/src/main/java/io/opentelemetry/auto/instrumentation/mongo/v3_1/MongoClientInstrumentation.java
+++ b/instrumentation/mongo/mongo-3.1/src/main/java/io/opentelemetry/auto/instrumentation/mongo/v3_1/MongoClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.1/src/test/groovy/MongoClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-3.7/src/main/java/io/opentelemetry/auto/instrumentation/mongo/v3_7/MongoClientInstrumentation.java
+++ b/instrumentation/mongo/mongo-3.7/src/main/java/io/opentelemetry/auto/instrumentation/mongo/v3_7/MongoClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
+++ b/instrumentation/mongo/mongo-3.7/src/test/groovy/MongoClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-async-3.3/src/main/java/io/opentelemetry/auto/instrumentation/mongoasync/v3_3/MongoAsyncClientInstrumentation.java
+++ b/instrumentation/mongo/mongo-async-3.3/src/main/java/io/opentelemetry/auto/instrumentation/mongoasync/v3_3/MongoAsyncClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
+++ b/instrumentation/mongo/mongo-async-3.3/src/test/groovy/MongoAsyncClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/MongoClientDecorator.java
+++ b/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/MongoClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/TracingCommandListener.java
+++ b/instrumentation/mongo/mongo-common/src/main/java/io/opentelemetry/auto/instrumentation/mongo/TracingCommandListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/mongo/mongo-common/src/test/groovy/MongoBaseTest.groovy
+++ b/instrumentation/mongo/mongo-common/src/test/groovy/MongoBaseTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/latestDepTest/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/src/latestDepTest/groovy/Netty38ClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/latestDepTest/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/src/latestDepTest/groovy/Netty38ServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/latestDepTest/groovy/NettyServerTestInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/latestDepTest/groovy/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/AbstractNettyAdvice.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/AbstractNettyAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/ChannelFutureListenerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/ChannelTraceContext.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/ChannelTraceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/NettyChannelPipelineInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/HttpClientRequestTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/HttpClientResponseTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/HttpClientTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/HttpClientTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/NettyHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/NettyResponseInjectAdapter.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/client/NettyResponseInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/HttpServerRequestTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/HttpServerResponseTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/HttpServerTracingHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/HttpServerTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/NettyHttpServerDecorator.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/NettyHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/NettyRequestExtractAdapter.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/server/NettyRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/util/CombinedSimpleChannelHandler.java
+++ b/instrumentation/netty/netty-3.8/src/main/java/io/opentelemetry/auto/instrumentation/netty/v3_8/util/CombinedSimpleChannelHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/test/groovy/Netty38ClientTest.groovy
+++ b/instrumentation/netty/netty-3.8/src/test/groovy/Netty38ClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
+++ b/instrumentation/netty/netty-3.8/src/test/groovy/Netty38ServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-3.8/src/test/groovy/NettyServerTestInstrumentation.java
+++ b/instrumentation/netty/netty-3.8/src/test/groovy/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/AttributeKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/ChannelFutureListenerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/NettyChannelPipelineInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/HttpClientRequestTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/HttpClientResponseTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/HttpClientTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/HttpClientTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/NettyHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/NettyResponseInjectAdapter.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/client/NettyResponseInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/HttpServerRequestTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/HttpServerResponseTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/HttpServerTracingHandler.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/HttpServerTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/NettyHttpServerDecorator.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/NettyHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/NettyRequestExtractAdapter.java
+++ b/instrumentation/netty/netty-4.0/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_0/server/NettyRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
+++ b/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
+++ b/instrumentation/netty/netty-4.0/src/test/groovy/Netty40ServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.0/src/test/groovy/NettyServerTestInstrumentation.java
+++ b/instrumentation/netty/netty-4.0/src/test/groovy/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/AttributeKeys.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/AttributeKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/ChannelFutureListenerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/NettyChannelPipelineInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/HttpClientRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/HttpClientRequestTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/HttpClientResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/HttpClientResponseTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/HttpClientTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/HttpClientTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/NettyHttpClientDecorator.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/NettyHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/NettyResponseInjectAdapter.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/client/NettyResponseInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerRequestTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerResponseTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerResponseTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerTracingHandler.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/HttpServerTracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/NettyHttpServerDecorator.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/NettyHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/NettyRequestExtractAdapter.java
+++ b/instrumentation/netty/netty-4.1/src/main/java/io/opentelemetry/auto/instrumentation/netty/v4_1/server/NettyRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/Netty41ServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/netty/netty-4.1/src/test/groovy/NettyServerTestInstrumentation.java
+++ b/instrumentation/netty/netty-4.1/src/test/groovy/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/OkHttp3Instrumentation.java
+++ b/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/OkHttp3Instrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/OkHttpClientDecorator.java
+++ b/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/OkHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/RequestBuilderInjectAdapter.java
+++ b/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/RequestBuilderInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/TracingInterceptor.java
+++ b/instrumentation/okhttp-3.0/src/main/java/io/opentelemetry/auto/instrumentation/okhttp/TracingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/okhttp-3.0/src/test/groovy/OkHttp3AsyncTest.groovy
+++ b/instrumentation/okhttp-3.0/src/test/groovy/OkHttp3AsyncTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/okhttp-3.0/src/test/groovy/OkHttp3Test.groovy
+++ b/instrumentation/okhttp-3.0/src/test/groovy/OkHttp3Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/AbstractInstrumentation.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/AbstractInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/ContextUtilsInstrumentation.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/ContextUtilsInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/GrpcContextInstrumentation.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/GrpcContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/OpenTelemetryApiInstrumentation.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/OpenTelemetryApiInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/TracingContextUtilsInstrumentation.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/TracingContextUtilsInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/ContextUtils.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/ContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/UnshadedScope.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/UnshadedScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/propagation/UnshadedContextPropagators.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/propagation/UnshadedContextPropagators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/propagation/UnshadedHttpTextFormat.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/context/propagation/UnshadedHttpTextFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedBatchRecorder.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedBatchRecorder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedDoubleCounter.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedDoubleCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedDoubleMeasure.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedDoubleMeasure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedDoubleObserver.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedDoubleObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedLongCounter.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedLongCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedLongMeasure.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedLongMeasure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedLongObserver.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedLongObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedMeter.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedMeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedMeterProvider.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/metrics/UnshadedMeterProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/Bridging.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/Bridging.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/TracingContextUtils.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/TracingContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/UnshadedSpan.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/UnshadedSpan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/UnshadedTracer.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/UnshadedTracer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/UnshadedTracerProvider.java
+++ b/instrumentation/opentelemetry-api-0.3/src/main/java/io/opentelemetry/auto/instrumentation/opentelemetryapi/trace/UnshadedTracerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/test/groovy/MeterTest.groovy
+++ b/instrumentation/opentelemetry-api-0.3/src/test/groovy/MeterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/test/groovy/TracerTest.groovy
+++ b/instrumentation/opentelemetry-api-0.3/src/test/groovy/TracerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/opentelemetry-api-0.3/src/test/groovy/TracingContextUtilsTest.groovy
+++ b/instrumentation/opentelemetry-api-0.3/src/test/groovy/TracingContextUtilsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-1.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v1_0/AsyncHandlerWrapper.java
+++ b/instrumentation/play-ws/play-ws-1.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v1_0/AsyncHandlerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-1.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v1_0/PlayWSClientInstrumentation.java
+++ b/instrumentation/play-ws/play-ws-1.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v1_0/PlayWSClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-1.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v1_0/StreamedAsyncHandlerWrapper.java
+++ b/instrumentation/play-ws/play-ws-1.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v1_0/StreamedAsyncHandlerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-1.0/src/test/groovy/PlayWSClientTest.groovy
+++ b/instrumentation/play-ws/play-ws-1.0/src/test/groovy/PlayWSClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_0/AsyncHandlerWrapper.java
+++ b/instrumentation/play-ws/play-ws-2.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_0/AsyncHandlerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_0/PlayWSClientInstrumentation.java
+++ b/instrumentation/play-ws/play-ws-2.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_0/PlayWSClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_0/StreamedAsyncHandlerWrapper.java
+++ b/instrumentation/play-ws/play-ws-2.0/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_0/StreamedAsyncHandlerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.0/src/test/groovy/PlayWSClientTest.groovy
+++ b/instrumentation/play-ws/play-ws-2.0/src/test/groovy/PlayWSClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_1/AsyncHandlerWrapper.java
+++ b/instrumentation/play-ws/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_1/AsyncHandlerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_1/PlayWSClientInstrumentation.java
+++ b/instrumentation/play-ws/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_1/PlayWSClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_1/StreamedAsyncHandlerWrapper.java
+++ b/instrumentation/play-ws/play-ws-2.1/src/main/java/io/opentelemetry/auto/instrumentation/playws/v2_1/StreamedAsyncHandlerWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-2.1/src/test/groovy/PlayWSClientTest.groovy
+++ b/instrumentation/play-ws/play-ws-2.1/src/test/groovy/PlayWSClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/BasePlayWSClientInstrumentation.java
+++ b/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/BasePlayWSClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/HeadersInjectAdapter.java
+++ b/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/HeadersInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/PlayWSClientDecorator.java
+++ b/instrumentation/play-ws/play-ws-common/src/main/java/io/opentelemetry/auto/instrumentation/playws/PlayWSClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play-ws/play-ws-common/src/test/groovy/PlayWSClientTestBase.groovy
+++ b/instrumentation/play-ws/play-ws-common/src/test/groovy/PlayWSClientTestBase.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/PlayInstrumentation.java
+++ b/instrumentation/play/play-2.3/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_3/PlayInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/PlayAdvice.java
+++ b/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/PlayAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/PlayHeaders.java
+++ b/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/PlayHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/PlayHttpServerDecorator.java
+++ b/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/PlayHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.3/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_3/RequestCompleteCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/groovy/client/PlayWSClientTest.groovy
+++ b/instrumentation/play/play-2.3/src/test/groovy/client/PlayWSClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/groovy/server/NettyServerTestInstrumentation.java
+++ b/instrumentation/play/play-2.3/src/test/groovy/server/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/instrumentation/play/play-2.3/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.3/src/test/groovy/server/PlayServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/scala/server/AsyncServer.scala
+++ b/instrumentation/play/play-2.3/src/test/scala/server/AsyncServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/scala/server/ControllerClosureAdapter.scala
+++ b/instrumentation/play/play-2.3/src/test/scala/server/ControllerClosureAdapter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/scala/server/Settings.scala
+++ b/instrumentation/play/play-2.3/src/test/scala/server/Settings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.3/src/test/scala/server/SyncServer.scala
+++ b/instrumentation/play/play-2.3/src/test/scala/server/SyncServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/PlayInstrumentation.java
+++ b/instrumentation/play/play-2.4/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_4/PlayInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/PlayAdvice.java
+++ b/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/PlayAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/PlayHeaders.java
+++ b/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/PlayHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/PlayHttpServerDecorator.java
+++ b/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/PlayHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.4/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_4/RequestCompleteCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/test/groovy/client/PlayWSClientTest.groovy
+++ b/instrumentation/play/play-2.4/src/test/groovy/client/PlayWSClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/test/groovy/server/NettyServerTestInstrumentation.java
+++ b/instrumentation/play/play-2.4/src/test/groovy/server/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/instrumentation/play/play-2.4/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.4/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.4/src/test/groovy/server/PlayServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/PlayInstrumentation.java
+++ b/instrumentation/play/play-2.6/src/main/java/io/opentelemetry/auto/instrumentation/play/v2_6/PlayInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/PlayAdvice.java
+++ b/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/PlayAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/PlayHeaders.java
+++ b/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/PlayHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/PlayHttpServerDecorator.java
+++ b/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/PlayHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/RequestCompleteCallback.java
+++ b/instrumentation/play/play-2.6/src/main/java8/io/opentelemetry/auto/instrumentation/play/v2_6/RequestCompleteCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/test/groovy/server/AkkaHttpTestInstrumentation.java
+++ b/instrumentation/play/play-2.6/src/test/groovy/server/AkkaHttpTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
+++ b/instrumentation/play/play-2.6/src/test/groovy/server/PlayAsyncServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
+++ b/instrumentation/play/play-2.6/src/test/groovy/server/PlayServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitChannelInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitCommandInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitDecorator.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/RabbitDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TextMapExtractAdapter.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TextMapExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TextMapInjectAdapter.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TextMapInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
+++ b/instrumentation/rabbitmq-amqp-2.7/src/main/java/io/opentelemetry/auto/instrumentation/rabbitmq/amqp/TracedDelegatingConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
+++ b/instrumentation/rabbitmq-amqp-2.7/src/test/groovy/RabbitMQTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/ContinuationInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/ContinuationInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/DefaultExecutionInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/DefaultExecutionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/ServerErrorHandlerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/ServerRegistryInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/main/java/io/opentelemetry/auto/instrumentation/ratpack/ServerRegistryInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/ActionWrapper.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/ActionWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/BlockWrapper.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/BlockWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/ErrorHandlerAdvice.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/ErrorHandlerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/RatpackServerDecorator.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/RatpackServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/ServerRegistryAdvice.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/ServerRegistryAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/TracingHandler.java
+++ b/instrumentation/ratpack-1.4/src/main/java8/io/opentelemetry/auto/instrumentation/ratpack/TracingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/RatpackOtherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/client/RatpackForkedHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/test/groovy/client/RatpackHttpClientTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/client/RatpackHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/NettyServerTestInstrumentation.java
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackAsyncHttpServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackForkedHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackForkedHttpServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
+++ b/instrumentation/ratpack-1.4/src/test/groovy/server/RatpackHttpServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/reactor-3.1/src/main/java/io/opentelemetry/auto/instrumentation/reactor/FluxAndMonoInstrumentation.java
+++ b/instrumentation/reactor-3.1/src/main/java/io/opentelemetry/auto/instrumentation/reactor/FluxAndMonoInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/reactor-3.1/src/main/java8/io/opentelemetry/auto/instrumentation/reactor/FluxAndMonoSubscribeAdvice.java
+++ b/instrumentation/reactor-3.1/src/main/java8/io/opentelemetry/auto/instrumentation/reactor/FluxAndMonoSubscribeAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/reactor-3.1/src/main/java8/io/opentelemetry/auto/instrumentation/reactor/ReactorCoreAdviceUtils.java
+++ b/instrumentation/reactor-3.1/src/main/java8/io/opentelemetry/auto/instrumentation/reactor/ReactorCoreAdviceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/reactor-3.1/src/test/groovy/ReactorCoreTest.groovy
+++ b/instrumentation/reactor-3.1/src/test/groovy/ReactorCoreTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientDecorator.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/client/RmiClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/ContextPayload.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/ContextPayload.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/ContextPropagator.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/ContextPropagator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/client/RmiClientContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/server/ContextDispatcher.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/server/ContextDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/context/server/RmiServerContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerDecorator.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
+++ b/instrumentation/rmi/src/main/java/io/opentelemetry/auto/instrumentation/rmi/server/RmiServerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/test/groovy/RmiTest.groovy
+++ b/instrumentation/rmi/src/test/groovy/RmiTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/test/java/rmi/app/Greeter.java
+++ b/instrumentation/rmi/src/test/java/rmi/app/Greeter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/test/java/rmi/app/Server.java
+++ b/instrumentation/rmi/src/test/java/rmi/app/Server.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rmi/src/test/java/rmi/app/ServerLegacy.java
+++ b/instrumentation/rmi/src/test/java/rmi/app/ServerLegacy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rxjava-1.0/src/main/java/io/opentelemetry/auto/instrumentation/rxjava/SpanFinishingSubscription.java
+++ b/instrumentation/rxjava-1.0/src/main/java/io/opentelemetry/auto/instrumentation/rxjava/SpanFinishingSubscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rxjava-1.0/src/main/java/io/opentelemetry/auto/instrumentation/rxjava/TracedOnSubscribe.java
+++ b/instrumentation/rxjava-1.0/src/main/java/io/opentelemetry/auto/instrumentation/rxjava/TracedOnSubscribe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rxjava-1.0/src/main/java/io/opentelemetry/auto/instrumentation/rxjava/TracedSubscriber.java
+++ b/instrumentation/rxjava-1.0/src/main/java/io/opentelemetry/auto/instrumentation/rxjava/TracedSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/rxjava-1.0/src/main/java/rx/__OpenTelemetryTracingUtil.java
+++ b/instrumentation/rxjava-1.0/src/main/java/rx/__OpenTelemetryTracingUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/GlassFishServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/GrizzlyTestInstrumentation.java
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/GrizzlyTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
+++ b/instrumentation/servlet/glassfish-testing/src/test/groovy/TestServlets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/HttpServletRequestExtractAdapter.java
+++ b/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/HttpServletRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Advice.java
+++ b/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Advice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Decorator.java
+++ b/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Decorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Instrumentation.java
+++ b/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/Servlet2Instrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/StatusSavingHttpServletResponseWrapper.java
+++ b/instrumentation/servlet/request-2.3/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v2_3/StatusSavingHttpServletResponseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/test/groovy/JettyServlet2Test.groovy
+++ b/instrumentation/servlet/request-2.3/src/test/groovy/JettyServlet2Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/test/groovy/ServletTestInstrumentation.java
+++ b/instrumentation/servlet/request-2.3/src/test/groovy/ServletTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-2.3/src/test/groovy/TestServlet2.groovy
+++ b/instrumentation/servlet/request-2.3/src/test/groovy/TestServlet2.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/AsyncContextInstrumentation.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/AsyncContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/HttpServletRequestExtractAdapter.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/HttpServletRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Advice.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Advice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Decorator.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Decorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Instrumentation.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/Servlet3Instrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/TagSettingAsyncListener.java
+++ b/instrumentation/servlet/request-3.0/src/main/java/io/opentelemetry/auto/instrumentation/servlet/v3_0/TagSettingAsyncListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/test/groovy/AbstractServlet3Test.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/AbstractServlet3Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/test/groovy/JettyServlet3Test.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/JettyServlet3Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/test/groovy/RequestDispatcherServlet.java
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/RequestDispatcherServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/test/groovy/ServletTestInstrumentation.java
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/ServletTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/test/groovy/TestServlet3.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/TestServlet3.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/request-3.0/src/test/groovy/TomcatServlet3Test.groovy
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/TomcatServlet3Test.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/RequestDispatcherInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/dispatcher/ServletContextInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/filter/FilterInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseDecorator.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
+++ b/instrumentation/servlet/src/main/java/io/opentelemetry/auto/instrumentation/servlet/http/HttpServletResponseInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/test/groovy/FilterTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/FilterTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/HttpServletResponseTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/HttpServletTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
+++ b/instrumentation/servlet/src/test/groovy/RequestDispatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/servlet/src/test/groovy/RequestDispatcherUtils.java
+++ b/instrumentation/servlet/src/test/groovy/RequestDispatcherUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/sparkjava-2.3/src/main/java/io/opentelemetry/auto/instrumentation/sparkjava/RoutesInstrumentation.java
+++ b/instrumentation/sparkjava-2.3/src/main/java/io/opentelemetry/auto/instrumentation/sparkjava/RoutesInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
+++ b/instrumentation/sparkjava-2.3/src/test/groovy/SparkJavaBasedTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/sparkjava-2.3/src/test/java/TestSparkJavaApplication.java
+++ b/instrumentation/sparkjava-2.3/src/test/java/TestSparkJavaApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringDataDecorator.java
+++ b/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringDataDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringRepositoryInstrumentation.java
+++ b/instrumentation/spring-data-1.8/src/main/java/io/opentelemetry/auto/instrumentation/springdata/SpringRepositoryInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
+++ b/instrumentation/spring-data-1.8/src/test/groovy/SpringJpaTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-data-1.8/src/test/java/spring/jpa/JpaCustomer.java
+++ b/instrumentation/spring-data-1.8/src/test/java/spring/jpa/JpaCustomer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-data-1.8/src/test/java/spring/jpa/JpaCustomerRepository.java
+++ b/instrumentation/spring-data-1.8/src/test/java/spring/jpa/JpaCustomerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-data-1.8/src/test/java/spring/jpa/JpaPersistenceConfig.java
+++ b/instrumentation/spring-data-1.8/src/test/java/spring/jpa/JpaPersistenceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingDecorator.java
+++ b/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
+++ b/instrumentation/spring-scheduling-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springscheduling/SpringSchedulingInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
+++ b/instrumentation/spring-scheduling-3.1/src/test/groovy/SpringSchedulingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-scheduling-3.1/src/test/java/IntervalTask.java
+++ b/instrumentation/spring-scheduling-3.1/src/test/java/IntervalTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-scheduling-3.1/src/test/java/IntervalTaskConfig.java
+++ b/instrumentation/spring-scheduling-3.1/src/test/java/IntervalTaskConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-scheduling-3.1/src/test/java/TriggerTask.java
+++ b/instrumentation/spring-scheduling-3.1/src/test/java/TriggerTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-scheduling-3.1/src/test/java/TriggerTaskConfig.java
+++ b/instrumentation/spring-scheduling-3.1/src/test/java/TriggerTaskConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/client/DefaultWebClientInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/client/DefaultWebClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/AbstractWebfluxInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/AbstractWebfluxInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/HandlerAdapterInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java/io/opentelemetry/auto/instrumentation/springwebflux/server/RouterFunctionInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/DefaultWebClientAdvice.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/DefaultWebClientAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/HttpHeadersInjectAdapter.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/HttpHeadersInjectAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/SpringWebfluxHttpClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/TracingClientResponseMono.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/TracingClientResponseMono.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/TracingClientResponseSubscriber.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/client/TracingClientResponseSubscriber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/AdviceUtils.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/AdviceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/DispatcherHandlerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/HandlerAdapterAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/RouteOnSuccessOrError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/RouterFunctionAdvice.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/RouterFunctionAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/SpringWebfluxHttpServerDecorator.java
+++ b/instrumentation/spring-webflux-5.0/src/main/java8/io/opentelemetry/auto/instrumentation/springwebflux/server/SpringWebfluxHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/SingleThreadedSpringWebfluxTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/SpringWebfluxTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/SpringWebfluxTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/client/SpringWebfluxHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/server/EchoHandler.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/server/EchoHandler.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/server/EchoHandlerFunction.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/server/EchoHandlerFunction.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/server/FooModel.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/server/FooModel.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/server/SpringWebFluxTestApplication.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/server/SpringWebFluxTestApplication.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/groovy/server/TestController.groovy
+++ b/instrumentation/spring-webflux-5.0/src/test/groovy/server/TestController.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webflux-5.0/src/test/java/server/RedirectComponent.java
+++ b/instrumentation/spring-webflux-5.0/src/test/java/server/RedirectComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/DispatcherServletInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/HandlerAdapterInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/SpringWebHttpServerDecorator.java
+++ b/instrumentation/spring-webmvc-3.1/src/main/java/io/opentelemetry/auto/instrumentation/springwebmvc/SpringWebHttpServerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/AppConfig.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/AppConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/ServletTestInstrumentation.java
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/ServletTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/SpringBootBasedTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spring-webmvc-3.1/src/test/groovy/test/TestController.groovy
+++ b/instrumentation/spring-webmvc-3.1/src/test/groovy/test/TestController.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/BulkGetCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/BulkGetCompletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/CompletionListener.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/CompletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/GetCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/GetCompletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcacheClientDecorator.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcacheClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcachedClientInstrumentation.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/MemcachedClientInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/OperationCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/OperationCompletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/SyncCompletionListener.java
+++ b/instrumentation/spymemcached-2.12/src/main/java/io/opentelemetry/auto/instrumentation/spymemcached/SyncCompletionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
+++ b/instrumentation/spymemcached-2.12/src/test/groovy/SpymemcachedTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceAdvice.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceAnnotationsInstrumentation.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceAnnotationsInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceConfigInstrumentation.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceConfigInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceDecorator.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/ConfiguredTraceAnnotationsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceAnnotationsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
+++ b/instrumentation/trace-annotation/src/test/groovy/TraceConfigTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/test/java/OuterClass.java
+++ b/instrumentation/trace-annotation/src/test/java/OuterClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/trace-annotation/src/test/java/io/opentelemetry/test/annotation/SayTracedHello.java
+++ b/instrumentation/trace-annotation/src/test/java/io/opentelemetry/test/annotation/SayTracedHello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioAsyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioAsyncInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioClientDecorator.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioClientDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioSyncInstrumentation.java
+++ b/instrumentation/twilio-6.6/src/main/java/io/opentelemetry/auto/instrumentation/twilio/TwilioSyncInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
+++ b/instrumentation/twilio-6.6/src/test/groovy/test/TwilioClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/vertx-testing/src/test/groovy/client/VertxHttpClientTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/client/VertxHttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/vertx-testing/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/client/VertxRxCircuitBreakerWebClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/vertx-testing/src/test/groovy/client/VertxRxWebClientTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/client/VertxRxWebClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/vertx-testing/src/test/groovy/server/NettyServerTestInstrumentation.java
+++ b/instrumentation/vertx-testing/src/test/groovy/server/NettyServerTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/vertx-testing/src/test/groovy/server/VertxHttpServerTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/server/VertxHttpServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/vertx-testing/src/test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/server/VertxRxCircuitBreakerHttpServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/instrumentation/vertx-testing/src/test/groovy/server/VertxRxHttpServerTest.groovy
+++ b/instrumentation/vertx-testing/src/test/groovy/server/VertxRxHttpServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/main/java/io/opentelemetry/auto/bootstrap/AgentBootstrap.java
+++ b/java-agent/src/main/java/io/opentelemetry/auto/bootstrap/AgentBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/groovy/io/opentelemetry/auto/AgentLoadedIntoBootstrapTest.groovy
+++ b/java-agent/src/test/groovy/io/opentelemetry/auto/AgentLoadedIntoBootstrapTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/groovy/io/opentelemetry/auto/LogLevelTest.groovy
+++ b/java-agent/src/test/groovy/io/opentelemetry/auto/LogLevelTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/groovy/io/opentelemetry/auto/integration/classloading/ClassLoadingTest.groovy
+++ b/java-agent/src/test/groovy/io/opentelemetry/auto/integration/classloading/ClassLoadingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/groovy/io/opentelemetry/auto/integration/classloading/ShadowPackageRenamingTest.groovy
+++ b/java-agent/src/test/groovy/io/opentelemetry/auto/integration/classloading/ShadowPackageRenamingTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/groovy/io/opentelemetry/auto/integration/muzzle/MuzzleBytecodeTransformTest.groovy
+++ b/java-agent/src/test/groovy/io/opentelemetry/auto/integration/muzzle/MuzzleBytecodeTransformTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/java/io/opentelemetry/auto/test/IntegrationTestUtils.java
+++ b/java-agent/src/test/java/io/opentelemetry/auto/test/IntegrationTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/java/io/opentelemetry/test/ClassToInstrument.java
+++ b/java-agent/src/test/java/io/opentelemetry/test/ClassToInstrument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/java/io/opentelemetry/test/ClassToInstrumentChild.java
+++ b/java-agent/src/test/java/io/opentelemetry/test/ClassToInstrumentChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
+++ b/java-agent/src/test/java/jvmbootstraptest/AgentLoadedChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-agent/src/test/java/jvmbootstraptest/LogLevelChecker.java
+++ b/java-agent/src/test/java/jvmbootstraptest/LogLevelChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/load-generator/src/main/java/io/opentelemetry/loadgenerator/LoadGenerator.java
+++ b/load-generator/src/main/java/io/opentelemetry/loadgenerator/LoadGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/cli/src/main/java/io/opentelemetry/smoketest/cli/CliApplication.java
+++ b/smoke-tests/cli/src/main/java/io/opentelemetry/smoketest/cli/CliApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/cli/src/test/groovy/io/opentelemetry/smoketest/CliApplicationSmokeTest.groovy
+++ b/smoke-tests/cli/src/test/groovy/io/opentelemetry/smoketest/CliApplicationSmokeTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/java9-modules/src/main/java9/io/opentelemetry/smoketest/moduleapp/ModuleApplication.java
+++ b/smoke-tests/java9-modules/src/main/java9/io/opentelemetry/smoketest/moduleapp/ModuleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/java9-modules/src/test/groovy/io/opentelemetry/smoketest/Java9ModulesSmokeTest.groovy
+++ b/smoke-tests/java9-modules/src/test/groovy/io/opentelemetry/smoketest/Java9ModulesSmokeTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/play/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
+++ b/smoke-tests/play/src/test/groovy/io/opentelemetry/smoketest/PlaySmokeTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/SpringbootApplication.java
+++ b/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/SpringbootApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/controller/WebController.java
+++ b/smoke-tests/springboot/src/main/java/io/opentelemetry/smoketest/springboot/controller/WebController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/springboot/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
+++ b/smoke-tests/springboot/src/test/groovy/io/opentelemetry/smoketest/SpringBootSmokeTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/src/main/groovy/io/opentelemetry/smoketest/AbstractServerSmokeTest.groovy
+++ b/smoke-tests/src/main/groovy/io/opentelemetry/smoketest/AbstractServerSmokeTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/src/main/groovy/io/opentelemetry/smoketest/AbstractSmokeTest.groovy
+++ b/smoke-tests/src/main/groovy/io/opentelemetry/smoketest/AbstractSmokeTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/src/main/groovy/io/opentelemetry/smoketest/SpanCounter.groovy
+++ b/smoke-tests/src/main/groovy/io/opentelemetry/smoketest/SpanCounter.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/smoke-tests/wildfly/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
+++ b/smoke-tests/wildfly/src/test/groovy/io/opentelemetry/smoketest/WildflySmokeTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/ListWriter.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/ListWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/SpockRunner.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/SpockRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/EventAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/EventAssert.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/ListWriterAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/ListWriterAssert.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/SpanAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/SpanAssert.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/TagsAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/TagsAssert.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/TraceAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/TraceAssert.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpClientTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTestAdvice.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTestAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/log/events/LogEventsTestBase.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/log/events/LogEventsTestBase.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/log/injection/LogContextInjectionTestBase.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/log/injection/LogContextInjectionTestBase.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/server/http/TestHttpServer.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/server/http/TestHttpServer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/utils/ClasspathUtils.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/utils/ClasspathUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/utils/ConfigUtils.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/utils/ConfigUtils.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/utils/OkHttpUtils.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/utils/OkHttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/utils/PortUtils.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/utils/PortUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/utils/TraceUtils.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/main/java/io/opentelemetry/auto/test/server/http/HttpServletRequestExtractAdapter.java
+++ b/testing/src/main/java/io/opentelemetry/auto/test/server/http/HttpServletRequestExtractAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/groovy/AgentTestRunnerTest.groovy
+++ b/testing/src/test/groovy/AgentTestRunnerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/groovy/InstrumentOldBytecode.groovy
+++ b/testing/src/test/groovy/InstrumentOldBytecode.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
+++ b/testing/src/test/groovy/context/FieldBackedProviderTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
+++ b/testing/src/test/groovy/muzzle/ReferenceCreatorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/groovy/muzzle/ReferenceMatcherTest.groovy
+++ b/testing/src/test/groovy/muzzle/ReferenceMatcherTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/groovy/server/ServerTest.groovy
+++ b/testing/src/test/groovy/server/ServerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/java/IBMResourceLevelInstrumentation.java
+++ b/testing/src/test/java/IBMResourceLevelInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/java/config/exclude/SomeClass.java
+++ b/testing/src/test/java/config/exclude/SomeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/java/config/exclude/packagename/SomeClass.java
+++ b/testing/src/test/java/config/exclude/packagename/SomeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/java/context/ContextTestInstrumentation.java
+++ b/testing/src/test/java/context/ContextTestInstrumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/java/muzzle/MuzzleWeakReferenceTest.java
+++ b/testing/src/test/java/muzzle/MuzzleWeakReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testing/src/test/java/muzzle/TestClasses.java
+++ b/testing/src/test/java/muzzle/TestClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/test-utils/src/main/groovy/io/opentelemetry/auto/util/test/AgentSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/io/opentelemetry/auto/util/test/AgentSpecification.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/test-utils/src/main/java/io/opentelemetry/auto/util/gc/GCUtils.java
+++ b/utils/test-utils/src/main/java/io/opentelemetry/auto/util/gc/GCUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/thread-utils/src/main/java/io/opentelemetry/auto/common/exec/CommonTaskExecutor.java
+++ b/utils/thread-utils/src/main/java/io/opentelemetry/auto/common/exec/CommonTaskExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utils/thread-utils/src/main/java/io/opentelemetry/auto/common/exec/DaemonThreadFactory.java
+++ b/utils/thread-utils/src/main/java/io/opentelemetry/auto/common/exec/DaemonThreadFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright The OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Based on guidance from https://github.com/open-telemetry/community/issues/113.