### PR TITLE
Change aws-sdk span kind to INTERNAL

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/TracingRequestHandler.java
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/main/java/io/opentelemetry/auto/instrumentation/awssdk/v1_11/TracingRequestHandler.java
@@ -16,7 +16,6 @@
 package io.opentelemetry.auto.instrumentation.awssdk.v1_11;
 
 import static io.opentelemetry.auto.instrumentation.awssdk.v1_11.RequestMeta.SPAN_SCOPE_PAIR_CONTEXT_KEY;
-import static io.opentelemetry.trace.Span.Kind.CLIENT;
 import static io.opentelemetry.trace.TracingContextUtils.currentContextWith;
 
 import com.amazonaws.AmazonWebServiceRequest;
@@ -48,8 +47,7 @@ public class TracingRequestHandler extends RequestHandler2 {
 
   @Override
   public void beforeRequest(final Request<?> request) {
-    final Span span =
-        TRACER.spanBuilder(decorate.spanNameForRequest(request)).setSpanKind(CLIENT).startSpan();
+    final Span span = TRACER.spanBuilder(decorate.spanNameForRequest(request)).startSpan();
     decorate.afterStart(span);
     decorate.onRequest(span, request);
     request.addHandlerContext(

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test/groovy/AWSClientTest.groovy
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicReference
 import static io.opentelemetry.auto.test.server.http.TestHttpServer.httpServer
 import static io.opentelemetry.auto.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.trace.Span.Kind.CLIENT
+import static io.opentelemetry.trace.Span.Kind.INTERNAL
 
 class AWSClientTest extends AgentTestRunner {
 
@@ -151,7 +152,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "$service.$operation"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored false
           parent()
           tags {
@@ -238,7 +239,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "$service.$operation"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored true
           parent()
           tags {
@@ -297,7 +298,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           operationName "S3.HeadBucket"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored true
           parent()
           tags {
@@ -339,7 +340,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 5) {
         span(0) {
           operationName "S3.GetObject"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored true
           parent()
           tags {

--- a/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-1.11/src/test_before_1_11_106/groovy/AWSClientTest.groovy
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicReference
 import static io.opentelemetry.auto.test.server.http.TestHttpServer.httpServer
 import static io.opentelemetry.auto.test.utils.PortUtils.UNUSABLE_PORT
 import static io.opentelemetry.trace.Span.Kind.CLIENT
+import static io.opentelemetry.trace.Span.Kind.INTERNAL
 
 class AWSClientTest extends AgentTestRunner {
 
@@ -114,7 +115,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "$service.$operation"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored false
           parent()
           tags {
@@ -183,7 +184,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "$service.$operation"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored true
           parent()
           tags {
@@ -242,7 +243,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           operationName "S3.GetObject"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored true
           parent()
           tags {
@@ -285,7 +286,7 @@ class AWSClientTest extends AgentTestRunner {
       trace(0, 5) {
         span(0) {
           operationName "S3.GetObject"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored true
           parent()
           tags {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/main/java8/io/opentelemetry/auto/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -17,7 +17,6 @@ package io.opentelemetry.auto.instrumentation.awssdk.v2_2;
 
 import static io.opentelemetry.auto.instrumentation.awssdk.v2_2.AwsSdkClientDecorator.DECORATE;
 import static io.opentelemetry.auto.instrumentation.awssdk.v2_2.AwsSdkClientDecorator.TRACER;
-import static io.opentelemetry.trace.Span.Kind.CLIENT;
 import static io.opentelemetry.trace.TracingContextUtils.currentContextWith;
 
 import io.opentelemetry.context.Scope;
@@ -49,8 +48,7 @@ public class TracingExecutionInterceptor implements ExecutionInterceptor {
   @Override
   public void beforeExecution(
       final Context.BeforeExecution context, final ExecutionAttributes executionAttributes) {
-    final Span span =
-        TRACER.spanBuilder(DECORATE.spanName(executionAttributes)).setSpanKind(CLIENT).startSpan();
+    final Span span = TRACER.spanBuilder(DECORATE.spanName(executionAttributes)).startSpan();
     try (final Scope scope = currentContextWith(span)) {
       DECORATE.afterStart(span);
       executionAttributes.putAttribute(SPAN_ATTRIBUTE, span);

--- a/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/src/test/groovy/AwsClientTest.groovy
@@ -51,6 +51,7 @@ import java.util.concurrent.atomic.AtomicReference
 
 import static io.opentelemetry.auto.test.server.http.TestHttpServer.httpServer
 import static io.opentelemetry.trace.Span.Kind.CLIENT
+import static io.opentelemetry.trace.Span.Kind.INTERNAL
 
 class AwsClientTest extends AgentTestRunner {
 
@@ -92,7 +93,7 @@ class AwsClientTest extends AgentTestRunner {
       trace(0, 2) {
         span(0) {
           operationName "$service.$operation"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored false
           parent()
           tags {
@@ -192,7 +193,7 @@ class AwsClientTest extends AgentTestRunner {
       trace(0, 1) {
         span(0) {
           operationName "$service.$operation"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored false
           parent()
           tags {
@@ -303,7 +304,7 @@ class AwsClientTest extends AgentTestRunner {
       trace(0, 5) {
         span(0) {
           operationName "S3.GetObject"
-          spanKind CLIENT
+          spanKind INTERNAL
           errored true
           parent()
           tags {


### PR DESCRIPTION
AWS SDK uses `apache-httpclient` / `netty` to perform the underlying http requests (which we capture as CLIENT spans via the respective `apache-httpclient` / `netty` instrumentation), so the spans that we capture at the AWS SDK layer should be INTERNAL (instead of CLIENT).