### PR TITLE
Rename ListWriter to InMemoryExporter

### DIFF
--- a/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
@@ -25,7 +25,7 @@ import groovy.lang.DelegatesTo;
 import groovy.transform.stc.ClosureParams;
 import groovy.transform.stc.SimpleType;
 import io.opentelemetry.OpenTelemetry;
-import io.opentelemetry.auto.test.asserts.ListWriterAssert;
+import io.opentelemetry.auto.test.asserts.InMemoryExporterAssert;
 import io.opentelemetry.auto.tooling.AgentInstaller;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import io.opentelemetry.auto.tooling.matcher.AdditionalLibraryIgnoresMatcher;
@@ -80,7 +80,7 @@ public abstract class AgentTestRunner extends AgentSpecification {
    *
    * <p>Before the start of each test the reported traces will be reset.
    */
-  public static final ListWriter TEST_WRITER;
+  public static final InMemoryExporter TEST_WRITER;
 
   protected static final Tracer TEST_TRACER;
 
@@ -102,7 +102,7 @@ public abstract class AgentTestRunner extends AgentSpecification {
     ((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.WARN);
     ((Logger) LoggerFactory.getLogger("io.opentelemetry.auto")).setLevel(Level.DEBUG);
 
-    TEST_WRITER = new ListWriter();
+    TEST_WRITER = new InMemoryExporter();
     OpenTelemetrySdk.getTracerProvider().addSpanProcessor(TEST_WRITER);
     TEST_TRACER = OpenTelemetry.getTracerProvider().get("io.opentelemetry.auto");
   }
@@ -202,9 +202,9 @@ public abstract class AgentTestRunner extends AgentSpecification {
       @ClosureParams(
               value = SimpleType.class,
               options = "io.opentelemetry.auto.test.asserts.ListWriterAssert")
-          @DelegatesTo(value = ListWriterAssert.class, strategy = Closure.DELEGATE_FIRST)
+          @DelegatesTo(value = InMemoryExporterAssert.class, strategy = Closure.DELEGATE_FIRST)
           final Closure spec) {
-    ListWriterAssert.assertTraces(
+    InMemoryExporterAssert.assertTraces(
         TEST_WRITER, size, Predicates.<List<SpanData>>alwaysFalse(), spec);
   }
 
@@ -214,9 +214,9 @@ public abstract class AgentTestRunner extends AgentSpecification {
       @ClosureParams(
               value = SimpleType.class,
               options = "io.opentelemetry.auto.test.asserts.ListWriterAssert")
-          @DelegatesTo(value = ListWriterAssert.class, strategy = Closure.DELEGATE_FIRST)
+          @DelegatesTo(value = InMemoryExporterAssert.class, strategy = Closure.DELEGATE_FIRST)
           final Closure spec) {
-    ListWriterAssert.assertTraces(TEST_WRITER, size, excludes, spec);
+    InMemoryExporterAssert.assertTraces(TEST_WRITER, size, excludes, spec);
   }
 
   public static class TestRunnerListener implements AgentBuilder.Listener {

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/InMemoryExporter.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/InMemoryExporter.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class ListWriter implements SpanProcessor {
+public class InMemoryExporter implements SpanProcessor {
 
   private final List<List<SpanData>> traces = new ArrayList<>(); // guarded by tracesLock
 

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/InMemoryExporterAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/InMemoryExporterAssert.groovy
@@ -18,7 +18,7 @@ package io.opentelemetry.auto.test.asserts
 import com.google.common.base.Predicate
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
-import io.opentelemetry.auto.test.ListWriter
+import io.opentelemetry.auto.test.InMemoryExporter
 import io.opentelemetry.sdk.trace.data.SpanData
 import org.codehaus.groovy.runtime.powerassert.PowerAssertionError
 import org.spockframework.runtime.Condition
@@ -27,25 +27,25 @@ import org.spockframework.runtime.model.TextPosition
 
 import static TraceAssert.assertTrace
 
-class ListWriterAssert {
+class InMemoryExporterAssert {
   private final List<List<SpanData>> traces
-  private final ListWriter writer
+  private final InMemoryExporter writer
 
   private final Set<Integer> assertedIndexes = new HashSet<>()
 
-  private ListWriterAssert(List<List<SpanData>> traces, ListWriter writer) {
+  private InMemoryExporterAssert(List<List<SpanData>> traces, InMemoryExporter writer) {
     this.traces = traces
     this.writer = writer
   }
 
-  static void assertTraces(ListWriter writer, int expectedSize,
+  static void assertTraces(InMemoryExporter writer, int expectedSize,
                            final Predicate<List<SpanData>> excludes,
                            @ClosureParams(value = SimpleType, options = ['io.opentelemetry.auto.test.asserts.ListWriterAssert'])
-                           @DelegatesTo(value = ListWriterAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
+                           @DelegatesTo(value = InMemoryExporterAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     try {
       def traces = writer.waitForTraces(expectedSize, excludes)
       assert traces.size() == expectedSize
-      def asserter = new ListWriterAssert(traces, writer)
+      def asserter = new InMemoryExporterAssert(traces, writer)
       def clone = (Closure) spec.clone()
       clone.delegate = asserter
       clone.resolveStrategy = Closure.DELEGATE_FIRST

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/TraceAssert.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/asserts/TraceAssert.groovy
@@ -18,7 +18,7 @@ package io.opentelemetry.auto.test.asserts
 import com.google.common.base.Stopwatch
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
-import io.opentelemetry.auto.test.ListWriter
+import io.opentelemetry.auto.test.InMemoryExporter
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.TraceId
 
@@ -35,7 +35,7 @@ class TraceAssert {
     this.spans = spans
   }
 
-  static void assertTrace(ListWriter writer, TraceId traceId, int expectedSize,
+  static void assertTrace(InMemoryExporter writer, TraceId traceId, int expectedSize,
                           @ClosureParams(value = SimpleType, options = ['io.opentelemetry.auto.test.asserts.TraceAssert'])
                           @DelegatesTo(value = TraceAssert, strategy = Closure.DELEGATE_FIRST) Closure spec) {
     def spans = getTrace(writer, traceId)
@@ -89,7 +89,7 @@ class TraceAssert {
     assert assertedIndexes.size() == spans.size()
   }
 
-  private static List<SpanData> getTrace(ListWriter writer, TraceId traceId) {
+  private static List<SpanData> getTrace(InMemoryExporter writer, TraceId traceId) {
     for (List<SpanData> trace : writer.getTraces()) {
       if (trace[0].traceId == traceId) {
         return trace

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/server/http/TestHttpServer.groovy
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/server/http/TestHttpServer.groovy
@@ -17,7 +17,7 @@ package io.opentelemetry.auto.test.server.http
 
 import io.opentelemetry.OpenTelemetry
 import io.opentelemetry.auto.bootstrap.instrumentation.decorator.BaseDecorator
-import io.opentelemetry.auto.test.asserts.ListWriterAssert
+import io.opentelemetry.auto.test.asserts.InMemoryExporterAssert
 import io.opentelemetry.auto.test.asserts.TraceAssert
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.trace.Span
@@ -109,7 +109,7 @@ class TestHttpServer implements AutoCloseable {
     clone(handlers)
   }
 
-  static distributedRequestTrace(ListWriterAssert traces, int index, SpanData parentSpan = null) {
+  static distributedRequestTrace(InMemoryExporterAssert traces, int index, SpanData parentSpan = null) {
     traces.trace(index, 1) {
       distributedRequestSpan(it, 0, parentSpan)
     }


### PR DESCRIPTION
Rename to reflect OpenTelemetry terminology.