### PR TITLE
Jetty-based benchmark for memory usage

### DIFF
--- a/benchmark/benchmark.gradle
+++ b/benchmark/benchmark.gradle
@@ -7,12 +7,17 @@ apply from: "${rootDir}/gradle/java.gradle"
 dependencies {
   jmh group: 'io.opentelemetry', name: 'opentelemetry-api', version: '0.3.0'
   jmh deps.bytebuddyagent
+
+  jmh 'javax.servlet:javax.servlet-api:4.0.1'
+  jmh 'com.google.http-client:google-http-client:1.19.0'
+  jmh 'org.eclipse.jetty:jetty-server:9.4.1.v20170120'
+  jmh 'org.eclipse.jetty:jetty-servlet:9.4.1.v20170120'
 }
 
 jmh {
   timeUnit = 'ms' // Output time unit. Available time units are: [m, s, ms, us, ns].
   benchmarkMode = ['avgt']
-  timeOnIteration = '20s'
+  timeOnIteration = '10s'
   iterations = 1 // Number of measurement iterations to do.
   fork = 1 // How many times to forks a single benchmark. Use 0 to disable forking altogether
 //  jvmArgs += ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:StartFlightRecording=delay=5s,dumponexit=true,name=jmh-benchmark,filename=${rootDir}/benchmark/build/reports/jmh/jmh-benchmark.jfr"]
@@ -25,11 +30,12 @@ jmh {
 
 //  profilers = ['stack:lines=5;detailLine=true;period=5;excludePackages=true']
   // Use profilers to collect additional data. Supported profilers: [cl, comp, gc, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
+  profilers = ['io.opentelemetry.benchmark.UsedMemoryProfiler', 'gc']
 
 //  humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt") // human-readable output file
 //  operationsPerInvocation = 10 // Operations per invocation.
 //  synchronizeIterations = false // Synchronize iterations?
-  timeout = '5s' // Timeout for benchmark iteration.
+  timeout = '3s' // Timeout for benchmark iteration.
 //  includeTests = false
   // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
 

--- a/benchmark/benchmark.gradle
+++ b/benchmark/benchmark.gradle
@@ -17,7 +17,7 @@ dependencies {
 jmh {
   timeUnit = 'ms' // Output time unit. Available time units are: [m, s, ms, us, ns].
   benchmarkMode = ['avgt']
-  timeOnIteration = '10s'
+  timeOnIteration = '20s'
   iterations = 1 // Number of measurement iterations to do.
   fork = 1 // How many times to forks a single benchmark. Use 0 to disable forking altogether
 //  jvmArgs += ["-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "-XX:StartFlightRecording=delay=5s,dumponexit=true,name=jmh-benchmark,filename=${rootDir}/benchmark/build/reports/jmh/jmh-benchmark.jfr"]
@@ -35,7 +35,7 @@ jmh {
 //  humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt") // human-readable output file
 //  operationsPerInvocation = 10 // Operations per invocation.
 //  synchronizeIterations = false // Synchronize iterations?
-  timeout = '3s' // Timeout for benchmark iteration.
+  timeout = '5s' // Timeout for benchmark iteration.
 //  includeTests = false
   // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
 

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -5,7 +5,6 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.openjdk.jmh.annotations.*;
 
-
 public class HttpBenchmark {
 
   @State(Scope.Benchmark)
@@ -45,10 +44,10 @@ public class HttpBenchmark {
   }
 
   @Fork(
-    jvmArgsAppend = {
-      "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
-      "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
-      "-Dota.exporter.jar=/path/to/opentelemetry-auto-instr-java/auto-exporters/logging/build/libs/opentelemetry-auto-exporters-logging-or-other-exporter.jar"
-    })
+      jvmArgsAppend = {
+        "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
+        "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
+        "-Dota.exporter.jar=/path/to/opentelemetry-auto-instr-java/auto-exporters/logging/build/libs/opentelemetry-auto-exporters-logging-or-other-exporter.jar"
+      })
   public static class WithAgent extends ClassRetransformingBenchmark {}
 }

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -1,0 +1,54 @@
+package io.opentelemetry.benchmark;
+
+import io.opentelemetry.benchmark.classes.HttpClass;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.openjdk.jmh.annotations.*;
+
+
+public class HttpBenchmark {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+    @Setup(Level.Trial)
+    public void doSetup() {
+      try {
+        jettyServer = new HttpClass().buildJettyServer();
+        jettyServer.start();
+        // Make sure it's actually running
+        while (!AbstractLifeCycle.STARTED.equals(jettyServer.getState())) {
+          Thread.sleep(500);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @TearDown(Level.Trial)
+    public void doTearDown() {
+      try {
+        jettyServer.stop();
+      } catch (Exception e) {
+        e.printStackTrace();
+      } finally {
+        jettyServer.destroy();
+      }
+    }
+
+    HttpClass http = new HttpClass();
+    Server jettyServer;
+  }
+
+  @Benchmark
+  public void testMakingRequest(BenchmarkState state) {
+    state.http.executeRequest();
+  }
+
+  @Fork(
+    jvmArgsAppend = {
+      "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
+      "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
+      "-Dota.exporter.jar=/path/to/opentelemetry-auto-instr-java/auto-exporters/logging/build/libs/opentelemetry-auto-exporters-logging-or-other-exporter.jar"
+    })
+  public static class WithAgent extends ClassRetransformingBenchmark {}
+}

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -61,7 +61,6 @@ public class HttpBenchmark {
   @Fork(
       jvmArgsAppend = {
         "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
-        "-javaagent:/path/to/opentelemetry-auto-instr-java/java-agent/build/libs/opentelemetry-auto.jar",
         "-Dota.exporter.jar=/path/to/opentelemetry-auto-instr-java/auto-exporters/logging/build/libs/opentelemetry-auto-exporters-logging-or-other-exporter.jar"
       })
   public static class WithAgent extends ClassRetransformingBenchmark {}

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -18,7 +18,15 @@ package io.opentelemetry.benchmark;
 import io.opentelemetry.benchmark.classes.HttpClass;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.io.IOException;
 
 public class HttpBenchmark {
 
@@ -33,7 +41,7 @@ public class HttpBenchmark {
         while (!AbstractLifeCycle.STARTED.equals(jettyServer.getState())) {
           Thread.sleep(500);
         }
-      } catch (Exception e) {
+      } catch (final Exception e) {
         throw new RuntimeException(e);
       }
     }
@@ -42,7 +50,7 @@ public class HttpBenchmark {
     public void doTearDown() {
       try {
         jettyServer.stop();
-      } catch (Exception e) {
+      } catch (final Exception e) {
         e.printStackTrace();
       } finally {
         jettyServer.destroy();
@@ -54,7 +62,7 @@ public class HttpBenchmark {
   }
 
   @Benchmark
-  public void testMakingRequest(BenchmarkState state) {
+  public void testMakingRequest(final BenchmarkState state) throws IOException {
     state.http.executeRequest();
   }
 

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.opentelemetry.benchmark;
 
 import io.opentelemetry.benchmark.classes.HttpClass;

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/HttpBenchmark.java
@@ -16,6 +16,7 @@
 package io.opentelemetry.benchmark;
 
 import io.opentelemetry.benchmark.classes.HttpClass;
+import java.io.IOException;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -25,8 +26,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-
-import java.io.IOException;
 
 public class HttpBenchmark {
 

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.opentelemetry.benchmark;
 
 import java.util.ArrayList;

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
@@ -15,13 +15,16 @@
  */
 package io.opentelemetry.benchmark;
 
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ScalarResult;
+
 import java.util.ArrayList;
 import java.util.Collection;
-import org.openjdk.jmh.*;
-import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.*;
-import org.openjdk.jmh.profile.*;
-import org.openjdk.jmh.results.*;
 
 public class UsedMemoryProfiler implements InternalProfiler {
   private long totalHeapBefore;
@@ -33,7 +36,8 @@ public class UsedMemoryProfiler implements InternalProfiler {
   }
 
   @Override
-  public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
+  public void beforeIteration(
+      final BenchmarkParams benchmarkParams, final IterationParams iterationParams) {
     System.gc();
     System.runFinalization();
 
@@ -43,24 +47,20 @@ public class UsedMemoryProfiler implements InternalProfiler {
 
   @Override
   public Collection<? extends Result> afterIteration(
-      BenchmarkParams benchmarkParams, IterationParams iterationParams, IterationResult result) {
+      final BenchmarkParams benchmarkParams,
+      final IterationParams iterationParams,
+      final IterationResult result) {
 
-    long totalHeap = Runtime.getRuntime().totalMemory();
-    long usedHeap = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+    final long totalHeap = Runtime.getRuntime().totalMemory();
+    final long usedHeap = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 
-    Collection<ScalarResult> results = new ArrayList<>();
+    final Collection<ScalarResult> results = new ArrayList<>();
     results.add(
-        new ScalarResult("·heap.total.before", totalHeapBefore, "bytes", AggregationPolicy.AVG));
+        new ScalarResult("heap.total.before", totalHeapBefore, "bytes", AggregationPolicy.AVG));
     results.add(
-        new ScalarResult("·heap.used.before", usedHeapBefore, "bytes", AggregationPolicy.AVG));
-    results.add(new ScalarResult("·heap.total.after", totalHeap, "bytes", AggregationPolicy.AVG));
-    results.add(new ScalarResult("·heap.used.after", usedHeap, "bytes", AggregationPolicy.AVG));
-    results.add(
-        new ScalarResult(
-            "·heap.total.change", totalHeap - totalHeapBefore, "bytes", AggregationPolicy.AVG));
-    results.add(
-        new ScalarResult(
-            "·heap.used.change", usedHeap - usedHeapBefore, "bytes", AggregationPolicy.AVG));
+        new ScalarResult("heap.used.before", usedHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(new ScalarResult("heap.total.after", totalHeap, "bytes", AggregationPolicy.AVG));
+    results.add(new ScalarResult("heap.used.after", usedHeap, "bytes", AggregationPolicy.AVG));
 
     return results;
   }

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
@@ -3,14 +3,15 @@ package io.opentelemetry.benchmark;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.openjdk.jmh.*;
+import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.*;
 import org.openjdk.jmh.profile.*;
 import org.openjdk.jmh.results.*;
-import org.openjdk.jmh.annotations.*;
 
 public class UsedMemoryProfiler implements InternalProfiler {
   private long totalHeapBefore;
   private long usedHeapBefore;
+
   @Override
   public String getDescription() {
     return "Used memory heap profiler";
@@ -26,19 +27,25 @@ public class UsedMemoryProfiler implements InternalProfiler {
   }
 
   @Override
-  public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams,
-                                                     IterationResult result) {
+  public Collection<? extends Result> afterIteration(
+      BenchmarkParams benchmarkParams, IterationParams iterationParams, IterationResult result) {
 
     long totalHeap = Runtime.getRuntime().totalMemory();
     long usedHeap = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 
     Collection<ScalarResult> results = new ArrayList<>();
-    results.add(new ScalarResult("·heap.total.before", totalHeapBefore, "bytes", AggregationPolicy.AVG));
-    results.add(new ScalarResult("·heap.used.before", usedHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(
+        new ScalarResult("·heap.total.before", totalHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(
+        new ScalarResult("·heap.used.before", usedHeapBefore, "bytes", AggregationPolicy.AVG));
     results.add(new ScalarResult("·heap.total.after", totalHeap, "bytes", AggregationPolicy.AVG));
     results.add(new ScalarResult("·heap.used.after", usedHeap, "bytes", AggregationPolicy.AVG));
-    results.add(new ScalarResult("·heap.total.change", totalHeap-totalHeapBefore, "bytes", AggregationPolicy.AVG));
-    results.add(new ScalarResult("·heap.used.change", usedHeap-usedHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(
+        new ScalarResult(
+            "·heap.total.change", totalHeap - totalHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(
+        new ScalarResult(
+            "·heap.used.change", usedHeap - usedHeapBefore, "bytes", AggregationPolicy.AVG));
 
     return results;
   }

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
@@ -1,0 +1,45 @@
+package io.opentelemetry.benchmark;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import org.openjdk.jmh.*;
+import org.openjdk.jmh.infra.*;
+import org.openjdk.jmh.profile.*;
+import org.openjdk.jmh.results.*;
+import org.openjdk.jmh.annotations.*;
+
+public class UsedMemoryProfiler implements InternalProfiler {
+  private long totalHeapBefore;
+  private long usedHeapBefore;
+  @Override
+  public String getDescription() {
+    return "Used memory heap profiler";
+  }
+
+  @Override
+  public void beforeIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams) {
+    System.gc();
+    System.runFinalization();
+
+    totalHeapBefore = Runtime.getRuntime().totalMemory();
+    usedHeapBefore = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+  }
+
+  @Override
+  public Collection<? extends Result> afterIteration(BenchmarkParams benchmarkParams, IterationParams iterationParams,
+                                                     IterationResult result) {
+
+    long totalHeap = Runtime.getRuntime().totalMemory();
+    long usedHeap = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+
+    Collection<ScalarResult> results = new ArrayList<>();
+    results.add(new ScalarResult("·heap.total.before", totalHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(new ScalarResult("·heap.used.before", usedHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(new ScalarResult("·heap.total.after", totalHeap, "bytes", AggregationPolicy.AVG));
+    results.add(new ScalarResult("·heap.used.after", usedHeap, "bytes", AggregationPolicy.AVG));
+    results.add(new ScalarResult("·heap.total.change", totalHeap-totalHeapBefore, "bytes", AggregationPolicy.AVG));
+    results.add(new ScalarResult("·heap.used.change", usedHeap-usedHeapBefore, "bytes", AggregationPolicy.AVG));
+
+    return results;
+  }
+}

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/UsedMemoryProfiler.java
@@ -15,6 +15,8 @@
  */
 package io.opentelemetry.benchmark;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.IterationParams;
 import org.openjdk.jmh.profile.InternalProfiler;
@@ -22,9 +24,6 @@ import org.openjdk.jmh.results.AggregationPolicy;
 import org.openjdk.jmh.results.IterationResult;
 import org.openjdk.jmh.results.Result;
 import org.openjdk.jmh.results.ScalarResult;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 public class UsedMemoryProfiler implements InternalProfiler {
   private long totalHeapBefore;

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
@@ -19,14 +19,15 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.javanet.NetHttpTransport;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
@@ -50,7 +51,7 @@ public class HttpClass {
   public static class HttpClassServlet extends HttpServlet {
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
-        throws ServletException, IOException {
+      throws ServletException, IOException {
       try {
         Thread.sleep(10);
       } catch (Exception e) {
@@ -63,15 +64,11 @@ public class HttpClass {
 
   private HttpRequestFactory requestFactory = new NetHttpTransport().createRequestFactory();
 
-  public void executeRequest() {
+  public void executeRequest() throws IOException {
     String url = "http://localhost:" + port + contextPath;
 
-    try {
-      HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
-      request.setThrowExceptionOnExecuteError(false);
-      request.execute();
-    } catch (Exception ex) {
-      ex.printStackTrace();
-    }
+    HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
+    request.setThrowExceptionOnExecuteError(false);
+    request.execute();
   }
 }

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.opentelemetry.benchmark.classes;
 
 import com.google.api.client.http.GenericUrl;

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
@@ -64,12 +64,6 @@ public class HttpClass {
       resp.setStatus(HttpServletResponse.SC_OK);
       resp.getWriter().println("{ \"status\": \"ok\"}");
     }
-
-    @Override
-    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
-        throws ServletException, IOException {
-      doGet(req, resp);
-    }
   }
 
   private HttpRequestFactory requestFactory = new NetHttpTransport().createRequestFactory();

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
@@ -19,7 +19,6 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.javanet.NetHttpTransport;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import javax.servlet.ServletException;
@@ -27,7 +26,6 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 
@@ -51,7 +49,7 @@ public class HttpClass {
   public static class HttpClassServlet extends HttpServlet {
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
-      throws ServletException, IOException {
+        throws ServletException, IOException {
       try {
         Thread.sleep(10);
       } catch (Exception e) {

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
@@ -4,24 +4,20 @@ import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.javanet.NetHttpTransport;
-
+import java.io.IOException;
+import java.net.InetSocketAddress;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-
 
 public class HttpClass {
   private String contextPath = "/path";
   private Integer port = 18888;
-
 
   public Server buildJettyServer() {
     System.setProperty("org.eclipse.jetty.util.log.class", "org.eclipse.jetty.util.log.StdErrLog");
@@ -43,17 +39,20 @@ public class HttpClass {
     }
 
     @Override
-    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
+        throws ServletException, IOException {
       try {
         Thread.sleep(10);
-      } catch (Exception e) {}
+      } catch (Exception e) {
+      }
       resp.setContentType("application/json");
       resp.setStatus(HttpServletResponse.SC_OK);
       resp.getWriter().println("{ \"status\": \"ok\"}");
     }
 
     @Override
-    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
+        throws ServletException, IOException {
       doGet(req, resp);
     }
   }
@@ -61,7 +60,7 @@ public class HttpClass {
   private HttpRequestFactory requestFactory = new NetHttpTransport().createRequestFactory();
 
   public void executeRequest() {
-    String url = "http://localhost:"+port+contextPath;
+    String url = "http://localhost:" + port + contextPath;
 
     try {
       HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
@@ -49,11 +49,6 @@ public class HttpClass {
   @WebServlet
   public static class HttpClassServlet extends HttpServlet {
     @Override
-    public void init(final ServletConfig config) throws ServletException {
-      super.init(config);
-    }
-
-    @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
         throws ServletException, IOException {
       try {

--- a/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
+++ b/benchmark/src/jmh/java/io/opentelemetry/benchmark/classes/HttpClass.java
@@ -1,0 +1,74 @@
+package io.opentelemetry.benchmark.classes;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.javanet.NetHttpTransport;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+
+
+public class HttpClass {
+  private String contextPath = "/path";
+  private Integer port = 18888;
+
+
+  public Server buildJettyServer() {
+    System.setProperty("org.eclipse.jetty.util.log.class", "org.eclipse.jetty.util.log.StdErrLog");
+    System.setProperty("org.eclipse.jetty.LEVEL", "WARN");
+
+    Server jettyServer = new Server(new InetSocketAddress("localhost", port));
+    ServletContextHandler servletContext = new ServletContextHandler();
+
+    servletContext.addServlet(HttpClassServlet.class, contextPath);
+    jettyServer.setHandler(servletContext);
+    return jettyServer;
+  }
+
+  @WebServlet
+  public static class HttpClassServlet extends HttpServlet {
+    @Override
+    public void init(final ServletConfig config) throws ServletException {
+      super.init(config);
+    }
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+      try {
+        Thread.sleep(10);
+      } catch (Exception e) {}
+      resp.setContentType("application/json");
+      resp.setStatus(HttpServletResponse.SC_OK);
+      resp.getWriter().println("{ \"status\": \"ok\"}");
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+      doGet(req, resp);
+    }
+  }
+
+  private HttpRequestFactory requestFactory = new NetHttpTransport().createRequestFactory();
+
+  public void executeRequest() {
+    String url = "http://localhost:"+port+contextPath;
+
+    try {
+      HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
+      request.setThrowExceptionOnExecuteError(false);
+      request.execute();
+    } catch (Exception ex) {
+      ex.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
This PR attempts at measuring what is the impact of having the agent on the memory profile of app. Essentially a first part of issue: https://github.com/open-telemetry/opentelemetry-auto-instr-java/issues/312

I added a basic custom memory profiler that measures the amount of memory consumed before and after the series of operations. 

The benchmark runs an embedded Jetty server with a basic servlet and runs a series of GET requests. Both parts should be automatically instrumented and impact memory and cpu usage.

Running this locally on macOS and OpenJDK 11.0.6, I got following results:

|                   | gc.alloc.rate.norm | heap.used.before | 
|-------------------|--------------------|------------------|
| No agent          | 55,927 B/op        | 9,826,125 B      |   
| OT 0.2.3-SNAPSHOT | 88,233 B/op        | 31,947,220 B     |  

Raw benchmark results:

```
HttpBenchmark.WithOT023ExpAgent.testMakingRequest                                   avgt   10         13.186 ±         0.856   ms/op
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.alloc.rate                    avgt   10          6.074 ±         0.364  MB/sec
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.alloc.rate.norm               avgt   10      88233.833 ±       285.569    B/op
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.churn.G1_Eden_Space           avgt   10          5.337 ±         3.140  MB/sec
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.churn.G1_Eden_Space.norm      avgt   10      77916.125 ±     46270.096    B/op
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.churn.G1_Survivor_Space       avgt   10          0.057 ±         0.139  MB/sec
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.churn.G1_Survivor_Space.norm  avgt   10        822.790 ±      2003.598    B/op
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.count                         avgt   10         14.000                  counts
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·gc.time                          avgt   10        111.000                      ms
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·heap.total.after                 avgt   10  229428428.800 ± 133367802.800   bytes
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·heap.total.before                avgt   10  115133644.800 ±  47721866.371   bytes
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·heap.total.change                avgt   10  114294784.000 ± 177573740.280   bytes
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·heap.used.after                  avgt   10   96286686.400 ±  23026009.240   bytes
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·heap.used.before                 avgt   10   31947220.800 ±  11074380.709   bytes
HttpBenchmark.WithOT023ExpAgent.testMakingRequest:·heap.used.change                 avgt   10   64339465.600 ±  27097305.905   bytes
HttpBenchmark.testMakingRequest                                                     avgt   10         12.438 ±         0.567   ms/op
HttpBenchmark.testMakingRequest:·gc.alloc.rate                                      avgt   10          4.082 ±         0.188  MB/sec
HttpBenchmark.testMakingRequest:·gc.alloc.rate.norm                                 avgt   10      55927.110 ±       220.234    B/op
HttpBenchmark.testMakingRequest:·gc.churn.G1_Eden_Space                             avgt   10          4.732 ±         0.392  MB/sec
HttpBenchmark.testMakingRequest:·gc.churn.G1_Eden_Space.norm                        avgt   10      64861.886 ±      5367.398    B/op
HttpBenchmark.testMakingRequest:·gc.churn.G1_Old_Gen                                avgt   10          1.356 ±         0.230  MB/sec
HttpBenchmark.testMakingRequest:·gc.churn.G1_Old_Gen.norm                           avgt   10      18629.961 ±      3734.859    B/op
HttpBenchmark.testMakingRequest:·gc.count                                           avgt   10        119.000                  counts
HttpBenchmark.testMakingRequest:·gc.time                                            avgt   10        191.000                      ms
HttpBenchmark.testMakingRequest:·heap.total.after                                   avgt   10   41313894.400 ±   3007890.117   bytes
HttpBenchmark.testMakingRequest:·heap.total.before                                  avgt   10   41313894.400 ±   3007890.117   bytes
HttpBenchmark.testMakingRequest:·heap.total.change                                  avgt   10            ≈ 0                   bytes
HttpBenchmark.testMakingRequest:·heap.used.after                                    avgt   10   19197616.800 ±   3515717.907   bytes
HttpBenchmark.testMakingRequest:·heap.used.before                                   avgt   10    9826125.600 ±    553095.971   bytes
HttpBenchmark.testMakingRequest:·heap.used.change                                   avgt   10    9371491.200 ±   3630360.420   bytes
```