### PR TITLE
Add jCenter as a muzzle repository to catch things that are different from Maven Central

### DIFF
--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/apache-httpclient-2.0.gradle
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/apache-httpclient-2.0.gradle
@@ -6,6 +6,7 @@ muzzle {
     group = "commons-httpclient"
     module = "commons-httpclient"
     versions = "[2.0,]"
+    skipVersions += "3.1-jenkins-1" // odd version in jcenter
     assertInverse = true
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/apache-httpclient-4.0.gradle
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/apache-httpclient-4.0.gradle
@@ -6,6 +6,7 @@ muzzle {
     group = "commons-httpclient"
     module = "commons-httpclient"
     versions = "[,4.0)"
+    skipVersions += '3.1-jenkins-1'
   }
   pass {
     group = "org.apache.httpcomponents"

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/elasticsearch-rest-6.4.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/elasticsearch-rest-6.4.gradle
@@ -44,9 +44,8 @@ dependencies {
   testCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.4.0'
 
   // TODO: The tests are incompatible with 7.x.  The instrumentation may be as well.
-  // FIXME: Lock to specific version due to bad deploy rollout.
-  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.8.3'
+  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.+'
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/elasticsearch-transport-5.0.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/elasticsearch-transport-5.0.gradle
@@ -10,8 +10,7 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[5.0.0,5.3.0)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/elasticsearch-transport-5.3.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/elasticsearch-transport-5.3.gradle
@@ -11,8 +11,7 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[5.3.0,6.0.0)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/elasticsearch-transport-6.0.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/elasticsearch-transport-6.0.gradle
@@ -10,14 +10,13 @@ muzzle {
   pass {
     group = "org.elasticsearch.client"
     module = "transport"
-    versions = "[6.0.0,6.8.4)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    versions = "[6.0.0,]"
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
-    versions = "[6.0.0,)"
+    versions = "[6.0.0,]"
     assertInverse = true
   }
 }

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/jaxrs-client-1.1.gradle
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/jaxrs-client-1.1.gradle
@@ -5,7 +5,9 @@ muzzle {
   pass {
     group = "com.sun.jersey"
     module = "jersey-client"
-    versions = "[,]"
+    versions = "[1.1,]"
+    skipVersions += ['1.0.3-atlassian-1-logpatch', '1.8-atlassian-6']
+    assertInverse = true
   }
 }
 

--- a/instrumentation/play-ws/play-ws-2.0/play-ws-2.0.gradle
+++ b/instrumentation/play-ws/play-ws-2.0/play-ws-2.0.gradle
@@ -13,38 +13,20 @@ testSets {
 }
 
 muzzle {
-  // 2.0.5 was a bad release
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[,2.0.0)'
-  }
   pass {
-    group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.0,2.0.4]'
-  }
-  pass {
     group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.6,]'
+    versions = '[2.0.0,]'
+    assertInverse = true
   }
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[,2.0.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.0,2.0.4]'
-  }
-  pass {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.6,2.1.0)'
+    versions = '[2.0.0,2.1.0)'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 
   // No Scala 2.13 versions below 2.0.6 exist

--- a/instrumentation/play-ws/play-ws-2.1/play-ws-2.1.gradle
+++ b/instrumentation/play-ws/play-ws-2.1/play-ws-2.1.gradle
@@ -13,45 +13,27 @@ testSets {
 }
 
 muzzle {
-  // 2.0.5 was a bad release
 
   fail {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.11'
-    versions = '[,2.0.4]'
-  }
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.6,)'
+    versions = '[,]'
   }
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[,2.0.4]'
-  }
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.6,2.1.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.12'
     versions = '[2.1.0,]'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 
-  // No Scala 2.13 versions below 2.0.6 exist
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.13'
-    versions = '[2.0.6,2.1.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.13'
     versions = '[2.1.0,]'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 }
 

--- a/instrumentation/servlet/servlet.gradle
+++ b/instrumentation/servlet/servlet.gradle
@@ -11,6 +11,8 @@ muzzle {
     group = "javax.servlet"
     module = 'servlet-api'
     versions = "[,]"
+    skipVersions += '0'
+    assertInverse = true
   }
 }
 

--- a/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,38 +1,22 @@
 apply from: "${rootDir}/gradle/instrumentation.gradle"
 
 muzzle {
-  fail {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "[,1.2.1)"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
-  // 1.2.1-1.2.4 have broken dependencies.
-  fail {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "(1.2.4,3.1.0.RELEASE)"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
   pass {
     group = 'org.springframework'
     module = 'spring-webmvc'
-    versions = "[3.1.0.RELEASE,3.2.1.RELEASE)"
+    versions = "[3.1.0.RELEASE,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
+    skipVersions += '3.2.1.RELEASE' // missing a required class.  (bad release?)
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
-  // 3.2.1.RELEASE is missing a required class.  (bad release?)
-  pass {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "(3.2.1.RELEASE,]"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
+    assertInverse = true
   }
 
   // FIXME: webmvc depends on web, so we need a separate integration for spring-web specifically.
   fail {
     group = 'org.springframework'
     module = 'spring-web'
-    versions = "(1.2.4,]"
+    versions = "[,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
   }
 }


### PR DESCRIPTION
This is a merge from https://github.com/DataDog/dd-trace-java/pull/1386.

It's needed to fix the current muzzle failure in CI.