### PR TITLE
Merge changes from dd-trace-java

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -1,0 +1,42 @@
+name: Add milestone to pull requests
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+jobs:
+  add_milestone_to_merged:
+    if: github.event.pull_request.merged && github.event.pull_request.milestone == null
+    name: Add milestone to merged pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project milestones
+        id: milestones
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const list = await github.issues.listMilestonesForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            })
+            // Need to manually sort because "sort by number" isn't part of the api
+            // highest number first
+            const milestones = list.data.sort((a,b) => (b.number - a.number))
+
+            return milestones.length == 0 ? null : milestones[0].number
+      - name: Update Pull Request
+        if: steps.milestones.outputs.result != null
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Confusingly, the issues api is used because pull requests are issues
+            await github.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ github.event.pull_request.number }},
+              milestone: ${{ steps.milestones.outputs.result }},
+            });

--- a/.github/workflows/create-next-milestone.yml
+++ b/.github/workflows/create-next-milestone.yml
@@ -1,0 +1,20 @@
+name: Create next milestone
+on:
+  milestone:
+    types: [closed]
+
+jobs:
+  create_next_milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get next minor version
+        id: semvers
+        uses: WyriHaximus/github-action-next-semvers@0.1.0
+        with:
+          version: ${{ github.event.milestone.title }}
+      - name: Create next milestone
+        uses: WyriHaximus/github-action-create-milestone@0.1.0
+        with:
+          title: ${{ steps.semvers.outputs.minor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release-notes-on-milestone-close.yaml
+++ b/.github/workflows/draft-release-notes-on-milestone-close.yaml
@@ -1,0 +1,51 @@
+name: Create draft release notes
+on:
+  milestone:
+    types: [closed]
+
+jobs:
+  draft_release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get pull requests for milestone
+        id: pullsA
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const options = github.pulls.list.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+
+            const pullRequests = await github.paginate(options)
+
+            return pullRequests.filter(pullRequest => pullRequest.merged_at
+              && pullRequest.milestone
+              && pullRequest.milestone.number == ${{ github.event.milestone.number }})
+      - name: Generate release notes text
+        id: generate
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var draftText = "# Improvements \n\n# Changes \n\n"
+            for (let pull of ${{ steps.pullsA.outputs.result }}) {
+              draftText += "* " + pull.title + " #" + pull.number + " \n"
+            }
+            draftText += "\n# Fixes \n"
+            return draftText
+      - name: Create release notes draft
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            await github.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: 'v' + '${{ github.event.milestone.title }}',
+              name: '${{ github.event.milestone.title}}',
+              draft: true,
+              body: ${{ steps.generate.outputs.result }}
+            })

--- a/.github/workflows/update-issues-on-release.yaml
+++ b/.github/workflows/update-issues-on-release.yaml
@@ -1,0 +1,62 @@
+name: Update issues on release
+on:
+  release:
+    types: [published]
+
+jobs:
+  update_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get milestone for release
+        id: milestone
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const options = github.issues.listMilestonesForRepo.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all'
+            })
+
+            const milestones = await github.paginate(options)
+
+            return milestones.find( milestone => milestone.title == "${{github.event.release.name}}" ).number
+      - name: Get issues for milestone
+        id: issues
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const options = github.issues.listForRepo.endpoint.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'all',
+              milestone: ${{steps.milestone.outputs.result}}
+            })
+
+            const issues = await github.paginate(options)
+
+            // Pull requests are issues so filter them out
+            return issues.filter( issue => !issue["pull_request"] )
+      - name: Comment and close issues
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            for (let issue of ${{ steps.issues.outputs.result }}) {
+              // This can be parallelized better by moving the await but it might trip rate limits
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: ':robot: This issue has been addressed in the latest release.  See full details in the [Release Notes]( ${{ github.event.release.html_url }}).'
+              })
+
+              await github.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed'
+              })
+            }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -358,8 +358,9 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
   }
 
-  // All tests must complete within 3 minutes.
-  timeout = Duration.ofMinutes(3)
+  // All tests must complete within 15 minutes.
+  // This value is quite big because with lower values (3 mins) we were experiencing large number of false positives
+  timeout = Duration.ofMinutes(15)
 
   // Disable all tests if skipTests property was specified
   onlyIf { !project.rootProject.hasProperty("skipTests") }

--- a/instrumentation/apache-httpclient/apache-httpclient-2.0/apache-httpclient-2.0.gradle
+++ b/instrumentation/apache-httpclient/apache-httpclient-2.0/apache-httpclient-2.0.gradle
@@ -6,6 +6,7 @@ muzzle {
     group = "commons-httpclient"
     module = "commons-httpclient"
     versions = "[2.0,]"
+    skipVersions += "3.1-jenkins-1" // odd version in jcenter
     assertInverse = true
   }
 }

--- a/instrumentation/apache-httpclient/apache-httpclient-4.0/apache-httpclient-4.0.gradle
+++ b/instrumentation/apache-httpclient/apache-httpclient-4.0/apache-httpclient-4.0.gradle
@@ -6,6 +6,7 @@ muzzle {
     group = "commons-httpclient"
     module = "commons-httpclient"
     versions = "[,4.0)"
+    skipVersions += '3.1-jenkins-1'
   }
   pass {
     group = "org.apache.httpcomponents"

--- a/instrumentation/elasticsearch/elasticsearch-rest-6.4/elasticsearch-rest-6.4.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-rest-6.4/elasticsearch-rest-6.4.gradle
@@ -44,9 +44,8 @@ dependencies {
   testCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.4.0'
 
   // TODO: The tests are incompatible with 7.x.  The instrumentation may be as well.
-  // FIXME: Lock to specific version due to bad deploy rollout.
-  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.8.3'
-  latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.8.3'
+  latestDepTestCompile group: 'org.elasticsearch.client', name: 'elasticsearch-rest-client', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch.client', name: 'transport', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch', name: 'elasticsearch', version: '6.+'
+  latestDepTestCompile group: 'org.elasticsearch.plugin', name: 'transport-netty4-client', version: '6.+'
 }

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.0/elasticsearch-transport-5.0.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.0/elasticsearch-transport-5.0.gradle
@@ -10,8 +10,7 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[5.0.0,5.3.0)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-5.3/elasticsearch-transport-5.3.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-5.3/elasticsearch-transport-5.3.gradle
@@ -11,8 +11,7 @@ muzzle {
     group = "org.elasticsearch.client"
     module = "transport"
     versions = "[5.3.0,6.0.0)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"

--- a/instrumentation/elasticsearch/elasticsearch-transport-6.0/elasticsearch-transport-6.0.gradle
+++ b/instrumentation/elasticsearch/elasticsearch-transport-6.0/elasticsearch-transport-6.0.gradle
@@ -10,14 +10,13 @@ muzzle {
   pass {
     group = "org.elasticsearch.client"
     module = "transport"
-    versions = "[6.0.0,6.8.4)"
-    // Work around for a bad release of 6.8.4
-//    assertInverse = true
+    versions = "[6.0.0,]"
+    assertInverse = true
   }
   pass {
     group = "org.elasticsearch"
     module = "elasticsearch"
-    versions = "[6.0.0,)"
+    versions = "[6.0.0,]"
     assertInverse = true
   }
 }

--- a/instrumentation/grizzly-2.0/grizzly-2.0.gradle
+++ b/instrumentation/grizzly-2.0/grizzly-2.0.gradle
@@ -27,6 +27,6 @@ dependencies {
   testCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.0'
 
   latestDepTestCompile group: 'org.glassfish.grizzly', name: 'grizzly-http-server', version: '+'
-  latestDepTestCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '+'
-  latestDepTestCompile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '+'
+  latestDepTestCompile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: '2.+'
+  latestDepTestCompile group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.+'
 }

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/CallableInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/CallableInstrumentation.java
@@ -16,6 +16,7 @@
 package io.opentelemetry.auto.instrumentation.javaconcurrent;
 
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -27,8 +28,6 @@ import io.opentelemetry.auto.bootstrap.instrumentation.java.concurrent.AdviceUti
 import io.opentelemetry.auto.bootstrap.instrumentation.java.concurrent.State;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
@@ -53,18 +52,14 @@ public final class CallableInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<String, String> contextStore() {
-    final Map<String, String> map = new HashMap<>();
-    map.put(Callable.class.getName(), State.class.getName());
-    return Collections.unmodifiableMap(map);
+    return singletonMap(Callable.class.getName(), State.class.getName());
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put(
+    return singletonMap(
         named("call").and(takesArguments(0)).and(isPublic()),
         CallableInstrumentation.class.getName() + "$CallableAdvice");
-    return transformers;
   }
 
   public static class CallableAdvice {

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/FutureInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/FutureInstrumentation.java
@@ -28,7 +28,6 @@ import io.opentelemetry.auto.tooling.Instrumenter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -107,9 +106,7 @@ public final class FutureInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<String, String> contextStore() {
-    final Map<String, String> map = new HashMap<>();
-    map.put(Future.class.getName(), State.class.getName());
-    return Collections.unmodifiableMap(map);
+    return singletonMap(Future.class.getName(), State.class.getName());
   }
 
   @Override

--- a/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/RunnableInstrumentation.java
+++ b/instrumentation/java-concurrent/src/main/java/io/opentelemetry/auto/instrumentation/javaconcurrent/RunnableInstrumentation.java
@@ -16,6 +16,7 @@
 package io.opentelemetry.auto.instrumentation.javaconcurrent;
 
 import static io.opentelemetry.auto.tooling.bytebuddy.matcher.AgentElementMatchers.implementsInterface;
+import static java.util.Collections.singletonMap;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -27,8 +28,6 @@ import io.opentelemetry.auto.bootstrap.instrumentation.java.concurrent.AdviceUti
 import io.opentelemetry.auto.bootstrap.instrumentation.java.concurrent.State;
 import io.opentelemetry.auto.instrumentation.api.SpanWithScope;
 import io.opentelemetry.auto.tooling.Instrumenter;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import net.bytebuddy.asm.Advice;
@@ -52,18 +51,14 @@ public final class RunnableInstrumentation extends Instrumenter.Default {
 
   @Override
   public Map<String, String> contextStore() {
-    final Map<String, String> map = new HashMap<>();
-    map.put(Runnable.class.getName(), State.class.getName());
-    return Collections.unmodifiableMap(map);
+    return singletonMap(Runnable.class.getName(), State.class.getName());
   }
 
   @Override
   public Map<? extends ElementMatcher<? super MethodDescription>, String> transformers() {
-    final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-    transformers.put(
+    return singletonMap(
         named("run").and(takesArguments(0)).and(isPublic()),
         RunnableInstrumentation.class.getName() + "$RunnableAdvice");
-    return transformers;
   }
 
   public static class RunnableAdvice {

--- a/instrumentation/jaxrs-client/jaxrs-client-1.1/jaxrs-client-1.1.gradle
+++ b/instrumentation/jaxrs-client/jaxrs-client-1.1/jaxrs-client-1.1.gradle
@@ -5,7 +5,9 @@ muzzle {
   pass {
     group = "com.sun.jersey"
     module = "jersey-client"
-    versions = "[,]"
+    versions = "[1.1,]"
+    skipVersions += ['1.0.3-atlassian-1-logpatch', '1.8-atlassian-6']
+    assertInverse = true
   }
 }
 

--- a/instrumentation/play-ws/play-ws-2.0/play-ws-2.0.gradle
+++ b/instrumentation/play-ws/play-ws-2.0/play-ws-2.0.gradle
@@ -13,38 +13,20 @@ testSets {
 }
 
 muzzle {
-  // 2.0.5 was a bad release
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[,2.0.0)'
-  }
   pass {
-    group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.0,2.0.4]'
-  }
-  pass {
     group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.6,]'
+    versions = '[2.0.0,]'
+    assertInverse = true
   }
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[,2.0.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.0,2.0.4]'
-  }
-  pass {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.6,2.1.0)'
+    versions = '[2.0.0,2.1.0)'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 
   // No Scala 2.13 versions below 2.0.6 exist

--- a/instrumentation/play-ws/play-ws-2.1/play-ws-2.1.gradle
+++ b/instrumentation/play-ws/play-ws-2.1/play-ws-2.1.gradle
@@ -13,45 +13,27 @@ testSets {
 }
 
 muzzle {
-  // 2.0.5 was a bad release
 
   fail {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.11'
-    versions = '[,2.0.4]'
-  }
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.11'
-    versions = '[2.0.6,)'
+    versions = '[,]'
   }
 
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[,2.0.4]'
-  }
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.12'
-    versions = '[2.0.6,2.1.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.12'
     versions = '[2.1.0,]'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 
-  // No Scala 2.13 versions below 2.0.6 exist
-  fail {
-    group = 'com.typesafe.play'
-    module = 'play-ahc-ws-standalone_2.13'
-    versions = '[2.0.6,2.1.0)'
-  }
   pass {
     group = 'com.typesafe.play'
     module = 'play-ahc-ws-standalone_2.13'
     versions = '[2.1.0,]'
+    skipVersions += '2.0.5' // Bad release
+    assertInverse = true
   }
 }
 

--- a/instrumentation/servlet/servlet.gradle
+++ b/instrumentation/servlet/servlet.gradle
@@ -11,6 +11,8 @@ muzzle {
     group = "javax.servlet"
     module = 'servlet-api'
     versions = "[,]"
+    skipVersions += '0'
+    assertInverse = true
   }
 }
 

--- a/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
+++ b/instrumentation/spring-webmvc-3.1/spring-webmvc-3.1.gradle
@@ -1,38 +1,22 @@
 apply from: "${rootDir}/gradle/instrumentation.gradle"
 
 muzzle {
-  fail {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "[,1.2.1)"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
-  // 1.2.1-1.2.4 have broken dependencies.
-  fail {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "(1.2.4,3.1.0.RELEASE)"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
   pass {
     group = 'org.springframework'
     module = 'spring-webmvc'
-    versions = "[3.1.0.RELEASE,3.2.1.RELEASE)"
+    versions = "[3.1.0.RELEASE,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
+    skipVersions += '3.2.1.RELEASE' // missing a required class.  (bad release?)
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
-  }
-  // 3.2.1.RELEASE is missing a required class.  (bad release?)
-  pass {
-    group = 'org.springframework'
-    module = 'spring-webmvc'
-    versions = "(3.2.1.RELEASE,]"
-    extraDependency "javax.servlet:javax.servlet-api:3.0.1"
+    assertInverse = true
   }
 
   // FIXME: webmvc depends on web, so we need a separate integration for spring-web specifically.
   fail {
     group = 'org.springframework'
     module = 'spring-web'
-    versions = "(1.2.4,]"
+    versions = "[,]"
+    skipVersions += ['1.2.1', '1.2.2', '1.2.3', '1.2.4'] // broken releases... missing dependencies
     extraDependency "javax.servlet:javax.servlet-api:3.0.1"
   }
 }

--- a/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceConfigInstrumentation.java
+++ b/instrumentation/trace-annotation/src/main/java/io/opentelemetry/auto/instrumentation/traceannotation/TraceConfigInstrumentation.java
@@ -25,7 +25,6 @@ import com.google.common.collect.Sets;
 import io.opentelemetry.auto.config.Config;
 import io.opentelemetry.auto.tooling.Instrumenter;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -169,9 +168,8 @@ public class TraceConfigInstrumentation implements Instrumenter {
         }
       }
 
-      final Map<ElementMatcher<? super MethodDescription>, String> transformers = new HashMap<>();
-      transformers.put(methodMatchers, packageName + ".TraceAdvice");
-      return transformers;
+      return Collections.<ElementMatcher<? super MethodDescription>, String>singletonMap(
+          methodMatchers, packageName + ".TraceAdvice");
     }
   }
 }


### PR DESCRIPTION
To fix CI, we need both DataDog/dd-trace-java#1386 and DataDog/dd-trace-java#1392, so decided to just merge master up through those two.

Note: I did not merge the new `exception-profiling` instrumentation because I did not previously merge the JFR profiling work. That all looks super interesting though, and would be cool to bring in at some point.