### PR TITLE
Fix some sporadic test failures

### DIFF
--- a/gradle/instrumentation.gradle
+++ b/gradle/instrumentation.gradle
@@ -13,6 +13,10 @@ byteBuddy {
 
 apply from: "${rootDir}/gradle/java.gradle"
 
+tasks.withType(Test) {
+  forkEvery = 1
+}
+
 afterEvaluate {
   byteBuddy {
     transformation {

--- a/instrumentation/dropwizard-testing/src/test/groovy/JettyTestInstrumentation.java
+++ b/instrumentation/dropwizard-testing/src/test/groovy/JettyTestInstrumentation.java
@@ -26,15 +26,7 @@ public class JettyTestInstrumentation implements Instrumenter {
   @Override
   public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
-        // Jetty 8
-        .type(named("org.eclipse.jetty.server.AbstractHttpConnection"))
-        .transform(
-            new AgentBuilder.Transformer.ForAdvice()
-                .advice(
-                    named("headerComplete"),
-                    HttpServerTestAdvice.ServerEntryAdvice.class.getName()))
-        // Jetty 9
-        .type(named("org.eclipse.jetty.server.HttpChannel"))
+        .type(named("org.eclipse.jetty.server.Server"))
         .transform(
             new AgentBuilder.Transformer.ForAdvice()
                 .advice(named("handle"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()));

--- a/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JettyTestInstrumentation.java
+++ b/instrumentation/jaxrs/jaxrs-1.0/src/test/groovy/JettyTestInstrumentation.java
@@ -26,15 +26,7 @@ public class JettyTestInstrumentation implements Instrumenter {
   @Override
   public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
-        // Jetty 8
-        .type(named("org.eclipse.jetty.server.AbstractHttpConnection"))
-        .transform(
-            new AgentBuilder.Transformer.ForAdvice()
-                .advice(
-                    named("headerComplete"),
-                    HttpServerTestAdvice.ServerEntryAdvice.class.getName()))
-        // Jetty 9
-        .type(named("org.eclipse.jetty.server.HttpChannel"))
+        .type(named("org.eclipse.jetty.server.Server"))
         .transform(
             new AgentBuilder.Transformer.ForAdvice()
                 .advice(named("handle"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()));

--- a/instrumentation/jetty-8.0/src/test/groovy/JettyTestInstrumentation.java
+++ b/instrumentation/jetty-8.0/src/test/groovy/JettyTestInstrumentation.java
@@ -26,21 +26,7 @@ public class JettyTestInstrumentation implements Instrumenter {
   @Override
   public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
-        // Jetty 8.0
-        .type(named("org.eclipse.jetty.server.HttpConnection"))
-        .transform(
-            new AgentBuilder.Transformer.ForAdvice()
-                .advice(
-                    named("handleRequest"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()))
-        // Jetty 8.?
-        .type(named("org.eclipse.jetty.server.AbstractHttpConnection"))
-        .transform(
-            new AgentBuilder.Transformer.ForAdvice()
-                .advice(
-                    named("headerComplete"),
-                    HttpServerTestAdvice.ServerEntryAdvice.class.getName()))
-        // Jetty 9
-        .type(named("org.eclipse.jetty.server.HttpChannel"))
+        .type(named("org.eclipse.jetty.server.Server"))
         .transform(
             new AgentBuilder.Transformer.ForAdvice()
                 .advice(named("handle"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()));

--- a/instrumentation/servlet/request-2.3/src/test/groovy/ServletTestInstrumentation.java
+++ b/instrumentation/servlet/request-2.3/src/test/groovy/ServletTestInstrumentation.java
@@ -26,18 +26,9 @@ public class ServletTestInstrumentation implements Instrumenter {
   @Override
   public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
-        // Jetty 7.0
-        .type(named("org.eclipse.jetty.server.HttpConnection"))
+        .type(named("org.eclipse.jetty.server.Server"))
         .transform(
             new AgentBuilder.Transformer.ForAdvice()
-                .advice(
-                    named("handleRequest"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()))
-        // Jetty 7.latest
-        .type(named("org.eclipse.jetty.server.AbstractHttpConnection"))
-        .transform(
-            new AgentBuilder.Transformer.ForAdvice()
-                .advice(
-                    named("headerComplete"),
-                    HttpServerTestAdvice.ServerEntryAdvice.class.getName()));
+                .advice(named("handle"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()));
   }
 }

--- a/instrumentation/servlet/request-3.0/src/test/groovy/ServletTestInstrumentation.java
+++ b/instrumentation/servlet/request-3.0/src/test/groovy/ServletTestInstrumentation.java
@@ -26,15 +26,7 @@ public class ServletTestInstrumentation implements Instrumenter {
   @Override
   public AgentBuilder instrument(final AgentBuilder agentBuilder) {
     return agentBuilder
-        // Jetty 8
-        .type(named("org.eclipse.jetty.server.AbstractHttpConnection"))
-        .transform(
-            new AgentBuilder.Transformer.ForAdvice()
-                .advice(
-                    named("headerComplete"),
-                    HttpServerTestAdvice.ServerEntryAdvice.class.getName()))
-        // Jetty 9
-        .type(named("org.eclipse.jetty.server.HttpChannel"))
+        .type(named("org.eclipse.jetty.server.Server"))
         .transform(
             new AgentBuilder.Transformer.ForAdvice()
                 .advice(named("handle"), HttpServerTestAdvice.ServerEntryAdvice.class.getName()))

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/AgentTestRunner.java
@@ -124,12 +124,6 @@ public abstract class AgentTestRunner extends AgentSpecification {
       final JavaModule module,
       final boolean loaded,
       final Throwable throwable) {
-    if (throwable.getMessage().startsWith("Cannot resolve type description")) {
-      // this can happen on dynamically generated classes
-      // e.g. things like org.mozilla.javascript.gen.map_5 and springdata.Doc_Accessor_yj53u0
-      // because there is no .class file for ByteBuddy to find
-      return false;
-    }
     log.error(
         "Unexpected instrumentation error when instrumenting {} on {}",
         typeName,

--- a/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTestAdvice.java
+++ b/testing/src/main/groovy/io/opentelemetry/auto/test/base/HttpServerTestAdvice.java
@@ -39,12 +39,8 @@ public abstract class HttpServerTestAdvice {
         // Skip if not running the HttpServerTest.
         return null;
       }
-      if (TRACER.getCurrentSpan().getContext().isValid()) {
-        return null;
-      } else {
-        final Span span = TRACER.spanBuilder("TEST_SPAN").startSpan();
-        return new SpanWithScope(span, currentContextWith(span));
-      }
+      final Span span = TRACER.spanBuilder("TEST_SPAN").startSpan();
+      return new SpanWithScope(span, currentContextWith(span));
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)

--- a/utils/test-utils/src/main/groovy/io/opentelemetry/auto/util/test/AgentSpecification.groovy
+++ b/utils/test-utils/src/main/groovy/io/opentelemetry/auto/util/test/AgentSpecification.groovy
@@ -17,6 +17,8 @@ package io.opentelemetry.auto.util.test
 
 import net.bytebuddy.agent.ByteBuddyAgent
 import net.bytebuddy.agent.builder.AgentBuilder
+import net.bytebuddy.description.type.TypeDefinition
+import net.bytebuddy.description.type.TypeDescription
 import net.bytebuddy.dynamic.ClassFileLocator
 import net.bytebuddy.dynamic.Transformer
 import spock.lang.Specification
@@ -31,11 +33,32 @@ abstract class AgentSpecification extends Specification {
   private static final String CONFIG = "io.opentelemetry.auto.config.Config"
 
   static {
+    addByteBuddyRawSetting()
     makeConfigInstanceModifiable()
   }
 
   // Keep track of config instance already made modifiable
   private static isConfigInstanceModifiable = false
+
+  // this is a copy of same method from AgentInstaller
+  // it's needed here, because the test harness loads bytebuddy early
+  // and then it's too late to set the property in AgentInstaller
+  static void addByteBuddyRawSetting() {
+    final String savedPropertyValue = System.getProperty(TypeDefinition.RAW_TYPES_PROPERTY)
+    try {
+      System.setProperty(TypeDefinition.RAW_TYPES_PROPERTY, "true")
+      final boolean rawTypes = TypeDescription.AbstractBase.RAW_TYPES
+      if (!rawTypes) {
+        System.err.println("Too late to enable $TypeDefinition.RAW_TYPES_PROPERTY")
+      }
+    } finally {
+      if (savedPropertyValue == null) {
+        System.clearProperty(TypeDefinition.RAW_TYPES_PROPERTY)
+      } else {
+        System.setProperty(TypeDefinition.RAW_TYPES_PROPERTY, savedPropertyValue)
+      }
+    }
+  }
 
   static void makeConfigInstanceModifiable() {
     if (isConfigInstanceModifiable) {


### PR DESCRIPTION
Reverting #349 in this PR and trying a different approach because still seeing sporadic errors, e.g. now

```
Cannot resolve bounds of unresolved type variable V by class
org.springframework.cglib.core.internal.LoadingCache$2
```

Setting `net.bytebuddy.raw=true` solves the `Cannot resolve bounds of unresolved type variable`. We set this in `AgentInstaller`, but because the tests load bytebuddy early, it's too late during tests to set it in `AgentInstaller`, so setting it now at the beginning of the tests.

After setting `net.bytebuddy.raw=true`, still getting some of the issues that #349 addressed. In general these failures look like they happen during redefinition of classes that were loaded by prior tests, so isolating each test class in it's own JVM seems to be helping.

The instrumentation tests are already so expensive that I'm too concerned about the extra overhead of `forkEvery = 1`.

Lastly in this PR, there is a fix for tests sporadically failing because `TEST_SPAN` was not applied due to existing span (probably left over from propagation to the thread when it was started). Now `TEST_SPAN` is always applied, regardless of existing span, which required some changes to the `JettyTestInstrumentation` to prevent multiple `TEST_SPAN`s from being applied.