### PR TITLE
Remove inactive maintainer @safris

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @jkwatson @safris @trask @tylerbenson
+* @jkwatson @trask @tylerbenson


### PR DESCRIPTION
Added as a maintainer during bootstrapping of the project, very knowledgeable of the domain, but did not end up fully onboarding to the project (no PRs, few comments on Issues/PRs, not active on gitter channel).